### PR TITLE
fix: replace hardcoded LAN IP with dynamic hostname

### DIFF
--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -71,5 +71,5 @@ cd "$APP_DIR"
 
 echo "GarminCoach started (PID $(cat "$PID_FILE"))"
 echo "  Local:   http://localhost:${PORT}"
-echo "  LAN:     http://192.168.1.77:${PORT}"
+echo "  LAN:     http://$(hostname -I | awk '{print $1}'):${PORT}"
 echo "  Logs:    ${LOG_FILE}"


### PR DESCRIPTION
Replaces hardcoded `192.168.1.77` in `scripts/start-prod.sh` with dynamic `hostname -I` detection.