### PR TITLE
fix: use GraphQL API for Copilot coding agent assignment

### DIFF
--- a/.github/workflows/copilot-auto-assign.yml
+++ b/.github/workflows/copilot-auto-assign.yml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 The Linux Foundation
+---
 name: Auto-assign Copilot to labeled issues
 
 on:
@@ -9,19 +10,79 @@ on:
 permissions:
   issues: write
   contents: read
+  pull-requests: write
 
 jobs:
   assign-copilot:
     if: github.event.label.name == 'copilot'
     runs-on: ubuntu-latest
     steps:
-      - name: Assign Copilot coding agent to issue
+      - name: Assign Copilot coding agent via GraphQL
         env:
           GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_REPO: ${{ github.repository }}
+        shell: bash
         run: |
-          gh issue edit "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" \
-            --add-assignee copilot-swe-agent
-          gh issue comment "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" \
+          set -euo pipefail
+
+          # Step 1: Get GraphQL IDs for repo, issue, and bot
+          RESULT=$(gh api graphql -f query="
+            query {
+              repository(owner: \"${OWNER}\", name: \"${REPO_NAME}\") {
+                id
+                issue(number: ${ISSUE_NUMBER}) {
+                  id
+                }
+                suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 10) {
+                  nodes {
+                    login
+                    ... on Bot { id }
+                  }
+                }
+              }
+            }")
+
+          REPO_ID=$(echo "$RESULT" | jq -r '.data.repository.id')
+          ISSUE_ID=$(echo "$RESULT" | jq -r '.data.repository.issue.id')
+          BOT_ID=$(echo "$RESULT" | jq -r '.data.repository.suggestedActors.nodes[] | select(.login == "copilot-swe-agent") | .id')
+
+          if [ -z "$BOT_ID" ]; then
+            echo "::error::Copilot coding agent is not available in this repository"
+            exit 1
+          fi
+
+          echo "Repo ID: $REPO_ID"
+          echo "Issue ID: $ISSUE_ID"
+          echo "Bot ID: $BOT_ID"
+
+          # Step 2: Assign the issue to Copilot using the GraphQL mutation
+          gh api graphql \
+            -H "GraphQL-Features: issues_copilot_assignment_api_support,coding_agent_model_selection" \
+            -f query="
+              mutation {
+                replaceActorsForAssignable(input: {
+                  assignableId: \"${ISSUE_ID}\"
+                  actorIds: [\"${BOT_ID}\"]
+                  agentAssignment: {
+                    targetRepositoryId: \"${REPO_ID}\"
+                    baseRef: \"main\"
+                    customInstructions: \"\"
+                    customAgent: \"\"
+                    model: \"\"
+                  }
+                }) {
+                  assignable {
+                    ... on Issue {
+                      title
+                      assignees(first: 10) { nodes { login } }
+                    }
+                  }
+                }
+              }"
+
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${ISSUE_REPO}" \
             --body "🤖 Copilot coding agent has been assigned and will start working on a PR shortly."


### PR DESCRIPTION
## Summary
The REST API (`gh issue edit --add-assignee copilot-swe-agent`) fails with `'copilot-swe-agent' not found`. Per [GitHub docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-a-pr#assigning-an-issue-to-copilot-via-the-github-api), the correct approach uses the GraphQL `replaceActorsForAssignable` mutation.

## Changes
- Queries `suggestedActors` to get the bot's GraphQL ID dynamically
- Uses `replaceActorsForAssignable` mutation with `agentAssignment`
- Adds `pull-requests: write` permission