### PR TITLE
feat: create feature specifications for pending TODOs

### DIFF
--- a/specs/001-insights-refresh/plan.md
+++ b/specs/001-insights-refresh/plan.md
@@ -1,0 +1,26 @@
+# 001: Insights Refresh — Implementation Plan
+
+## Approach
+
+Hook into the sync-completion event and use tRPC's `queryClient.invalidateQueries`
+to automatically re-fetch analytics data on the Insights page. Add a skeleton
+loading state so users see a smooth transition instead of stale-then-fresh data.
+
+## Architecture Decisions
+
+- Use tRPC query invalidation (not full page reload): keeps client state intact
+  and is the idiomatic React Query approach
+- Listen for sync completion via existing tRPC endpoint rather than adding
+  WebSocket infrastructure
+- Use skeleton components for loading state: matches existing UI patterns
+
+## Components Affected
+
+- `apps/nextjs/src/app/insights/` — add invalidation hook and loading skeletons
+- `packages/api/src/router/analytics.ts` — ensure cache headers allow
+  invalidation; may need a sync-status query
+
+## Dependencies
+
+- Existing tRPC query infrastructure (React Query)
+- Sync completion signal (verify how sync status is currently exposed)

--- a/specs/001-insights-refresh/spec.md
+++ b/specs/001-insights-refresh/spec.md
@@ -1,0 +1,37 @@
+# 001: Insights Refresh
+
+## Status: Draft
+
+## Problem Statement
+
+When Garmin data syncs, the Insights page (`/insights`) still shows stale data
+until the user manually reloads the page. This creates a confusing experience
+where a sync completes successfully but the UI doesn't reflect the new data.
+
+## Requirements
+
+- [ ] Auto-invalidate tRPC queries on the Insights page after a sync completes
+- [ ] Show a loading/skeleton state while fresh data is being fetched
+- [ ] Preserve scroll position during refresh
+- [ ] No full-page reload — use client-side query invalidation only
+
+## Acceptance Criteria
+
+- [ ] After a Garmin sync completes, the Insights page updates within 2 seconds
+      without a manual refresh
+- [ ] A loading skeleton is visible during the data re-fetch
+- [ ] No flash of stale data between sync completion and fresh data display
+- [ ] Existing manual refresh (pull-to-refresh / F5) still works
+
+## Out of Scope
+
+- Modifying the Garmin sync process itself
+- Real-time push updates via WebSockets (polling/invalidation is sufficient)
+- Offline caching strategy changes
+
+## Technical Context
+
+- The app uses tRPC for API calls with React Query under the hood
+- Sync status is likely available via a tRPC subscription or polling endpoint
+- Key query routers live in `packages/api/src/router/analytics.ts`
+- The Insights page components are in `apps/nextjs/src/app/insights/`

--- a/specs/001-insights-refresh/tasks.md
+++ b/specs/001-insights-refresh/tasks.md
@@ -1,0 +1,15 @@
+# 001: Insights Refresh — Tasks
+
+## Tasks
+
+- [ ] Task 1: Identify how sync completion is currently signaled to the frontend
+- [ ] Task 2: Create a `useSyncRefresh` hook that listens for sync completion
+      and calls `utils.analytics.invalidate()`
+- [ ] Task 3: Wire the hook into the Insights page layout component
+- [ ] Task 4: Add loading skeleton components for each Insights widget
+- [ ] Task 5: Test end-to-end: trigger sync, verify Insights page auto-updates
+- [ ] Task 6: Verify scroll position is preserved after invalidation
+
+## Done
+
+(none yet)

--- a/specs/002-notable-empty/plan.md
+++ b/specs/002-notable-empty/plan.md
@@ -1,0 +1,29 @@
+# 002: Notable Empty — Implementation Plan
+
+## Approach
+
+Debug the anomaly detection pipeline end-to-end: verify data input, threshold
+logic, and rendering condition. The fix likely involves correcting threshold
+calculations in `anomalies.ts` and/or fixing the conditional rendering in the
+dashboard widget.
+
+## Architecture Decisions
+
+- Fix in place rather than rewrite: the anomaly detection architecture is sound,
+  the bug is in the implementation details
+- Add unit tests for threshold logic to prevent regressions
+- Log anomaly detection results at debug level for future troubleshooting
+
+## Components Affected
+
+- `packages/engine/src/anomalies.ts` — fix threshold calculation and comparison
+  logic
+- `packages/api/src/router/analytics.ts` — verify data query returns sufficient
+  historical data for anomaly detection
+- Dashboard Notable Changes widget — fix rendering condition (may be checking
+  wrong field or mishandling empty results)
+
+## Dependencies
+
+- Sufficient historical data in the database for meaningful comparisons
+- Understanding of current threshold definitions (need to inspect code)

--- a/specs/002-notable-empty/spec.md
+++ b/specs/002-notable-empty/spec.md
@@ -1,0 +1,40 @@
+# 002: Notable Empty
+
+## Status: Draft
+
+## Problem Statement
+
+The Notable Changes widget on the dashboard shows "No notable changes" even when
+metrics have significant shifts (e.g., a large increase in resting heart rate or
+a sudden drop in sleep score). The anomaly detection logic is either using
+incorrect thresholds or not receiving the right data.
+
+## Requirements
+
+- [ ] Fix anomaly detection logic to correctly identify notable metric changes
+- [ ] Ensure the data pipeline delivers sufficient historical context for
+      comparison
+- [ ] Display detected anomalies in the Notable Changes widget when they exist
+- [ ] Continue showing "No notable changes" only when metrics are genuinely stable
+
+## Acceptance Criteria
+
+- [ ] When a metric changes by more than the defined threshold (e.g., ±1 std
+      deviation), it appears in Notable Changes
+- [ ] Widget correctly renders at least: metric name, direction of change,
+      and magnitude
+- [ ] Widget shows "No notable changes" only when no metrics exceed thresholds
+- [ ] Anomaly detection works for all tracked metrics (HR, HRV, sleep, load)
+
+## Out of Scope
+
+- Adding new anomaly detection algorithms (fix existing logic first)
+- User-configurable thresholds (future enhancement)
+- Push notifications for anomalies
+
+## Technical Context
+
+- Anomaly detection lives in `packages/engine/src/anomalies.ts`
+- Data is served via `packages/api/src/router/analytics.ts`
+- The dashboard widget renders the results; the rendering condition may also
+  have a bug (e.g., checking wrong field or empty-array logic)

--- a/specs/002-notable-empty/tasks.md
+++ b/specs/002-notable-empty/tasks.md
@@ -1,0 +1,19 @@
+# 002: Notable Empty — Tasks
+
+## Tasks
+
+- [ ] Task 1: Add debug logging to `anomalies.ts` and trace a known case where
+      a notable change should appear but doesn't
+- [ ] Task 2: Verify the analytics router query returns enough historical data
+      points for anomaly comparison
+- [ ] Task 3: Fix threshold logic in `anomalies.ts` (inspect standard deviation
+      calculation, comparison operators, edge cases)
+- [ ] Task 4: Fix rendering condition in the dashboard widget (verify it checks
+      the correct field and handles arrays properly)
+- [ ] Task 5: Add unit tests for anomaly detection with known-notable and
+      known-stable datasets
+- [ ] Task 6: Manual end-to-end verification on dashboard
+
+## Done
+
+(none yet)

--- a/specs/003-garmin-weight-sync/plan.md
+++ b/specs/003-garmin-weight-sync/plan.md
@@ -1,0 +1,29 @@
+# 003: Garmin Weight Sync — Implementation Plan
+
+## Approach
+
+Add weight extraction to the addon sync script, extend the database schema to
+store weight history, and update the profile page to display current weight and
+BMI. This is a vertical slice across the sync pipeline.
+
+## Architecture Decisions
+
+- Store weight as a time-series (date + value in kg) rather than a single
+  profile field: enables future trend analysis
+- Use kg as the canonical unit with display-time conversion: avoids rounding
+  errors from repeated conversions
+- BMI recalculation is triggered on weight insert, not on page load: keeps reads
+  fast
+
+## Components Affected
+
+- Addon `garmin-sync.py` — add weight field extraction from daily stats payload
+- `packages/db` schema — add weight history table/column with migration
+- `packages/api/src/router/` — add or extend endpoint to serve weight data
+- Profile page component — display latest weight and calculated BMI
+
+## Dependencies
+
+- Access to Garmin daily stats API response format (verify weight field name)
+- Database migration tooling (Drizzle or Prisma, whichever the project uses)
+- Height value must already exist in user profile for BMI calculation

--- a/specs/003-garmin-weight-sync/spec.md
+++ b/specs/003-garmin-weight-sync/spec.md
@@ -1,0 +1,41 @@
+# 003: Garmin Weight Sync
+
+## Status: Draft
+
+## Problem Statement
+
+Weight data exists in the Garmin Connect daily stats API response but is not
+being extracted or stored. This means BMI calculations are missing or use stale
+manual entries, and the user profile doesn't reflect current weight from their
+Garmin scale or manual Garmin Connect entries.
+
+## Requirements
+
+- [ ] Extract weight from Garmin daily stats during sync
+- [ ] Store weight history in the database with timestamps
+- [ ] Update the user profile to display current weight
+- [ ] Recalculate BMI when new weight data arrives
+- [ ] Handle missing weight data gracefully (not all daily stats include weight)
+
+## Acceptance Criteria
+
+- [ ] After a sync that includes weight data, the latest weight appears on the
+      profile page
+- [ ] BMI is recalculated using the latest synced weight
+- [ ] Weight history is stored (not just the latest value)
+- [ ] Days without weight data do not overwrite existing weight records
+- [ ] Weight values are stored in a consistent unit (kg) with display conversion
+
+## Out of Scope
+
+- Manual weight entry in the app UI (future enhancement)
+- Weight trend analysis or graphing (future enhancement)
+- Syncing weight to Garmin (read-only)
+
+## Technical Context
+
+- This is cross-repo: the HA addon's `garmin-sync.py` handles extraction from
+  the Garmin API, and the app stores/displays the data
+- The spec lives in the app repo since most implementation work is here
+- The database schema needs a weight column or table
+- BMI calculation depends on height (already in profile) and weight

--- a/specs/003-garmin-weight-sync/tasks.md
+++ b/specs/003-garmin-weight-sync/tasks.md
@@ -1,0 +1,17 @@
+# 003: Garmin Weight Sync — Tasks
+
+## Tasks
+
+- [ ] Task 1: Inspect Garmin daily stats API response to identify the weight
+      field name and format
+- [ ] Task 2: Add weight extraction to `garmin-sync.py` in the addon repo
+- [ ] Task 3: Create database migration to add weight history storage
+- [ ] Task 4: Add API endpoint or extend existing router to serve weight data
+- [ ] Task 5: Update the profile page to display current weight
+- [ ] Task 6: Implement BMI calculation using latest weight and stored height
+- [ ] Task 7: Handle edge cases: missing weight, unit conversion, first-sync
+- [ ] Task 8: Test end-to-end sync with weight data
+
+## Done
+
+(none yet)

--- a/specs/004-strava-oauth/plan.md
+++ b/specs/004-strava-oauth/plan.md
@@ -1,0 +1,32 @@
+# 004: Strava OAuth — Implementation Plan
+
+## Approach
+
+Create a self-contained `packages/strava/` package that handles OAuth2 flow,
+API communication, and data mapping. Integrate with the existing app via a
+settings UI for account management and a sync service for data import.
+
+## Architecture Decisions
+
+- Separate package (`packages/strava/`): isolates Strava-specific logic, makes
+  it testable independently, and follows the monorepo package pattern
+- Use authorization code flow (not implicit): required by Strava API and more
+  secure
+- Store OAuth tokens encrypted in the database: refresh tokens are long-lived
+  and sensitive
+- Map Strava activities to the app's internal activity model: enables unified
+  analysis regardless of data source
+
+## Components Affected
+
+- New `packages/strava/` — OAuth client, API wrapper, activity mapper
+- `packages/db` schema — add OAuth token storage and source tracking on
+  activities
+- `apps/nextjs/src/app/settings/` — add Strava connect/disconnect UI
+- `packages/api/src/router/` — add Strava OAuth callback and sync endpoints
+
+## Dependencies
+
+- Strava API application credentials (client ID and secret)
+- Understanding of Strava API rate limits for sync scheduling
+- Database migration for token storage and activity source field

--- a/specs/004-strava-oauth/spec.md
+++ b/specs/004-strava-oauth/spec.md
@@ -1,0 +1,42 @@
+# 004: Strava OAuth
+
+## Status: Draft
+
+## Problem Statement
+
+Users who track activities on Strava (in addition to or instead of Garmin)
+cannot import those activities into the fitness coach. This limits the app to
+Garmin-only users and prevents a unified view of training data.
+
+## Requirements
+
+- [ ] Implement Strava OAuth2 authorization flow (connect/disconnect)
+- [ ] Sync activities from Strava including GPS and heart rate data
+- [ ] Import activity metadata: type, duration, distance, elevation, timestamps
+- [ ] Provide a settings UI for connecting and disconnecting the Strava account
+- [ ] Support incremental sync (only fetch new activities since last sync)
+- [ ] Handle token refresh automatically
+
+## Acceptance Criteria
+
+- [ ] User can connect their Strava account via OAuth2 from the settings page
+- [ ] After connecting, historical activities are imported (configurable lookback)
+- [ ] New activities sync automatically on a schedule
+- [ ] User can disconnect Strava and optionally remove imported data
+- [ ] GPS tracks and heart rate data are available for imported activities
+- [ ] OAuth tokens are securely stored and automatically refreshed
+
+## Out of Scope
+
+- Writing data back to Strava
+- Strava segment analysis
+- Social features (clubs, kudos)
+- Real-time activity streaming
+
+## Technical Context
+
+- Strava API uses OAuth2 with authorization code flow
+- Rate limits: 100 requests per 15 minutes, 1000 per day
+- Activity streams endpoint provides GPS/HR data per activity
+- A new `packages/strava/` package will encapsulate all Strava logic
+- This is an independent feature with no dependency on other pending work

--- a/specs/004-strava-oauth/tasks.md
+++ b/specs/004-strava-oauth/tasks.md
@@ -1,0 +1,20 @@
+# 004: Strava OAuth — Tasks
+
+## Tasks
+
+- [ ] Task 1: Research Strava API — register app, document endpoints, rate
+      limits, and data formats
+- [ ] Task 2: Create `packages/strava/` package scaffold with TypeScript config
+- [ ] Task 3: Implement OAuth2 authorization code flow (authorize, callback,
+      token exchange)
+- [ ] Task 4: Implement token storage and automatic refresh logic
+- [ ] Task 5: Build Strava API client with rate-limit handling
+- [ ] Task 6: Create activity data mapper (Strava format to internal model)
+- [ ] Task 7: Add database migration for OAuth tokens and activity source field
+- [ ] Task 8: Build settings UI for Strava connect/disconnect
+- [ ] Task 9: Implement sync service with incremental fetch
+- [ ] Task 10: Test OAuth flow end-to-end and verify activity import
+
+## Done
+
+(none yet)

--- a/specs/005-fitbit-oauth/plan.md
+++ b/specs/005-fitbit-oauth/plan.md
@@ -1,0 +1,36 @@
+# 005: Fitbit OAuth — Implementation Plan
+
+## Approach
+
+Create a `packages/fitbit/` package following the same pattern established by
+the Strava integration (spec 004). Focus on biometric data (sleep, HRV, HR,
+SpO2) rather than activities, since that's where Fitbit adds the most value
+alongside Garmin activity data.
+
+## Architecture Decisions
+
+- Follow the Strava package pattern: keeps integrations consistent and
+  reduces cognitive overhead
+- Use OAuth2 with PKCE: required by Fitbit's current API and more secure
+  than basic authorization code flow
+- Focus on biometrics first, activities later: Fitbit's biometric data
+  (sleep stages, HRV, SpO2) adds unique value that Garmin may not provide
+  at the same granularity
+- Scope requests to minimum needed: only request sleep, heartrate, oxygen
+  saturation, and profile scopes
+
+## Components Affected
+
+- New `packages/fitbit/` — OAuth client with PKCE, API wrapper, data mappers
+- `packages/db` schema — extend OAuth token storage, add source tracking to
+  biometric tables
+- `apps/nextjs/src/app/settings/` — add Fitbit connect/disconnect UI
+- `packages/api/src/router/` — add Fitbit OAuth callback and sync endpoints
+- `packages/engine/` — ensure readiness engine accepts multi-source biometrics
+
+## Dependencies
+
+- Spec 004 (Strava OAuth) should be implemented first to establish the
+  integration pattern
+- Fitbit API application credentials (client ID)
+- Understanding of Fitbit OAuth scopes and rate limits

--- a/specs/005-fitbit-oauth/spec.md
+++ b/specs/005-fitbit-oauth/spec.md
@@ -1,0 +1,44 @@
+# 005: Fitbit OAuth
+
+## Status: Draft
+
+## Problem Statement
+
+Fitbit users cannot import their health data (sleep, HRV, heart rate zones,
+SpO2) into the fitness coach. Fitbit provides rich biometric data that would
+enhance training readiness and recovery analysis.
+
+## Requirements
+
+- [ ] Implement Fitbit OAuth2 authorization flow (connect/disconnect)
+- [ ] Sync sleep data including sleep stages and duration
+- [ ] Sync HRV data (daily and intraday where available)
+- [ ] Sync heart rate zones and resting heart rate
+- [ ] Sync SpO2 (blood oxygen) data
+- [ ] Provide settings UI for connecting and disconnecting Fitbit
+- [ ] Support incremental sync
+- [ ] Handle token refresh automatically
+
+## Acceptance Criteria
+
+- [ ] User can connect their Fitbit account via OAuth2 from settings
+- [ ] Sleep, HRV, HR zones, and SpO2 data import after connecting
+- [ ] New data syncs automatically on a schedule
+- [ ] User can disconnect Fitbit and optionally remove imported data
+- [ ] Imported biometric data is available to the readiness engine
+- [ ] OAuth tokens are securely stored and refreshed
+
+## Out of Scope
+
+- Fitbit activity/exercise import (focus on biometrics first)
+- Fitbit food logging or water intake
+- Writing data back to Fitbit
+- Fitbit Premium features
+
+## Technical Context
+
+- Fitbit API uses OAuth2 with PKCE (Authorization Code Grant with PKCE)
+- Rate limit: 150 requests per hour per user
+- Sleep, HRV, and SpO2 endpoints require specific OAuth scopes
+- Implementation pattern should mirror `packages/strava/` (do Strava first)
+- A new `packages/fitbit/` package will encapsulate all Fitbit logic

--- a/specs/005-fitbit-oauth/tasks.md
+++ b/specs/005-fitbit-oauth/tasks.md
@@ -1,0 +1,21 @@
+# 005: Fitbit OAuth — Tasks
+
+## Tasks
+
+- [ ] Task 1: Research Fitbit API — register app, document endpoints, scopes,
+      rate limits, and PKCE requirements
+- [ ] Task 2: Create `packages/fitbit/` package scaffold with TypeScript config
+- [ ] Task 3: Implement OAuth2 with PKCE flow (authorize, callback, token
+      exchange)
+- [ ] Task 4: Implement token storage and automatic refresh logic
+- [ ] Task 5: Build Fitbit API client with rate-limit handling
+- [ ] Task 6: Create sleep data mapper (stages, duration, quality score)
+- [ ] Task 7: Create HRV and heart rate data mapper
+- [ ] Task 8: Create SpO2 data mapper
+- [ ] Task 9: Build settings UI for Fitbit connect/disconnect
+- [ ] Task 10: Implement sync service with incremental fetch
+- [ ] Task 11: Verify readiness engine works with Fitbit-sourced biometrics
+
+## Done
+
+(none yet)

--- a/specs/006-multi-source-dedup/plan.md
+++ b/specs/006-multi-source-dedup/plan.md
@@ -1,0 +1,33 @@
+# 006: Multi-Source Dedup — Implementation Plan
+
+## Approach
+
+Build a deduplication engine that runs after each sync to identify and resolve
+duplicate activities. The engine uses fuzzy matching on time, sport, and duration
+to find candidates, then applies a richness score to select the preferred source.
+
+## Architecture Decisions
+
+- Fuzzy matching over exact matching: different platforms record slightly
+  different start times and durations for the same activity
+- Richness-based preference: automatically pick the source with more data
+  fields rather than always preferring one platform
+- Soft delete for discarded duplicates: keep the data but mark it as
+  superseded, enabling undo and audit
+- Run dedup post-sync: simpler than real-time and ensures all data is
+  available for comparison
+
+## Components Affected
+
+- New `packages/engine/src/dedup.ts` — matching algorithm and richness scoring
+- `packages/db` schema — add dedup status and source-link fields to activities
+- `packages/api/src/router/` — add dedup resolution endpoints and activity
+  source metadata
+- Activity list UI — show dedup badges and manual override controls
+
+## Dependencies
+
+- Spec 004 (Strava OAuth) must be implemented first — dedup requires at least
+  two data sources
+- Activity model must include a `source` field to identify origin platform
+- Understanding of data completeness per platform to calibrate richness scoring

--- a/specs/006-multi-source-dedup/spec.md
+++ b/specs/006-multi-source-dedup/spec.md
@@ -1,0 +1,49 @@
+# 006: Multi-Source Dedup
+
+## Status: Draft
+
+## Problem Statement
+
+Users who connect multiple platforms (e.g., Garmin + Strava) will get duplicate
+activities because the same workout is recorded on both services. Without
+deduplication, training load, volume, and analytics will be inflated and
+inaccurate.
+
+## Requirements
+
+- [ ] Detect duplicate activities across platforms using fuzzy matching
+- [ ] Match criteria: start time within ±5 minutes AND same sport type AND
+      duration within ±10%
+- [ ] When duplicates are found, prefer the source with richer data (more
+      data fields, higher resolution GPS/HR)
+- [ ] Allow manual override of automatic dedup decisions
+- [ ] Show dedup status on activity list (merged, kept, discarded)
+
+## Acceptance Criteria
+
+- [ ] Two activities from different sources that match the criteria are
+      automatically merged into one
+- [ ] The richer data source is preferred by default
+- [ ] Users can see which activities were deduped and from which sources
+- [ ] Users can manually split or re-merge incorrectly deduped activities
+- [ ] Training load calculations use deduplicated data (no double-counting)
+- [ ] Dedup runs automatically on each sync without user intervention
+
+## Out of Scope
+
+- Deduplication within a single source (assume each source has unique
+  activities)
+- Merging partial data from multiple sources into one enriched activity
+  (future enhancement)
+- Historical re-dedup of all existing data on first enable (process going
+  forward only)
+
+## Technical Context
+
+- Matching algorithm uses: `|start_time_a - start_time_b| ≤ 5min` AND
+  `sport_type_a == sport_type_b` AND `|duration_a - duration_b| / max(a,b) ≤ 0.10`
+- Source richness scoring: count of non-null fields (GPS points, HR samples,
+  elevation, power, cadence)
+- Dedup engine lives in `packages/engine/src/dedup.ts`
+- Merge logic in `packages/api/` handles the database operations
+- Requires at least one additional platform integration (Strava) to be useful

--- a/specs/006-multi-source-dedup/tasks.md
+++ b/specs/006-multi-source-dedup/tasks.md
@@ -1,0 +1,20 @@
+# 006: Multi-Source Dedup — Tasks
+
+## Tasks
+
+- [ ] Task 1: Design the matching algorithm with configurable thresholds
+      (time window, duration tolerance)
+- [ ] Task 2: Implement source richness scoring function (count non-null
+      fields, weight by importance)
+- [ ] Task 3: Build the dedup engine in `packages/engine/src/dedup.ts`
+- [ ] Task 4: Add database migration for dedup status and source-link fields
+- [ ] Task 5: Integrate dedup engine into the post-sync pipeline
+- [ ] Task 6: Add API endpoints for dedup status and manual resolution
+- [ ] Task 7: Build UI for dedup status badges on activity list
+- [ ] Task 8: Build UI for manual split/merge override
+- [ ] Task 9: Add unit tests with known duplicate and non-duplicate pairs
+- [ ] Task 10: End-to-end test with Garmin + Strava dual-source activities
+
+## Done
+
+(none yet)


### PR DESCRIPTION
## Summary

Adds Spec Kit feature specifications for 6 pending TODO items, each with `spec.md`, `plan.md`, and `tasks.md`:

| Spec | Type | Description |
|------|------|-------------|
| 001-insights-refresh | Bug | Auto-refresh Insights page after data sync |
| 002-notable-empty | Bug | Fix Notable Changes empty state |
| 003-garmin-weight-sync | Feature | Auto-sync weight from Garmin daily stats |
| 004-strava-oauth | Feature | Strava OAuth2 activity import |
| 005-fitbit-oauth | Feature | Fitbit OAuth2 biometric data integration |
| 006-multi-source-dedup | Feature | Cross-platform activity deduplication |

## File Structure
```
specs/
├── 001-insights-refresh/{spec,plan,tasks}.md
├── 002-notable-empty/{spec,plan,tasks}.md
├── 003-garmin-weight-sync/{spec,plan,tasks}.md
├── 004-strava-oauth/{spec,plan,tasks}.md
├── 005-fitbit-oauth/{spec,plan,tasks}.md
└── 006-multi-source-dedup/{spec,plan,tasks}.md
```

Pre-commit hooks pass cleanly.