### PR TITLE
fix: replace blunt rest-day logic with evidence-based workout modulation

### DIFF
--- a/packages/api/src/router/workout.ts
+++ b/packages/api/src/router/workout.ts
@@ -76,29 +76,32 @@ export const workoutRouter = {
     const goal = (profile.goals as { sport: string; goalType: string }[])?.[0]?.goalType ?? "maintain";
     const availableDays = (profile.weeklyDays as string[])?.length ?? 3;
 
-    // Fetch recovery context for evidence-based workout modulation
-    const [dailyMetric, advancedMetric] = await Promise.all([
-      ctx.db.query.DailyMetric.findFirst({
-        where: and(
-          eq(DailyMetric.userId, userId),
-          eq(DailyMetric.date, today),
-        ),
-      }),
-      ctx.db.query.AdvancedMetric.findFirst({
-        where: and(
-          eq(AdvancedMetric.userId, userId),
-          eq(AdvancedMetric.date, today),
-        ),
-      }),
-    ]);
+    // Only fetch recovery context when the engine actually uses it (poor/low zones)
+    let recovery: RecoveryContext | undefined;
+    if (zone === "poor" || zone === "low") {
+      const [dailyMetric, advancedMetric] = await Promise.all([
+        ctx.db.query.DailyMetric.findFirst({
+          where: and(
+            eq(DailyMetric.userId, userId),
+            eq(DailyMetric.date, today),
+          ),
+        }),
+        ctx.db.query.AdvancedMetric.findFirst({
+          where: and(
+            eq(AdvancedMetric.userId, userId),
+            eq(AdvancedMetric.date, today),
+          ),
+        }),
+      ]);
 
-    const recovery: RecoveryContext = {
-      acwr: advancedMetric?.acwr ?? null,
-      tsb: advancedMetric?.tsb ?? null,
-      bodyBattery: dailyMetric?.bodyBatteryEnd ?? null,
-      sleepDebtMinutes: dailyMetric?.sleepDebtMinutes ?? null,
-      stressScore: dailyMetric?.stressScore ?? null,
-    };
+      recovery = {
+        acwr: advancedMetric?.acwr ?? null,
+        tsb: advancedMetric?.tsb ?? null,
+        bodyBattery: dailyMetric?.bodyBatteryEnd ?? null,
+        sleepDebtMinutes: dailyMetric?.sleepDebtMinutes ?? null,
+        stressScore: dailyMetric?.stressScore ?? null,
+      };
+    }
 
     const recommendation = generateDailyWorkout(
       sport,

--- a/packages/api/src/router/workout.ts
+++ b/packages/api/src/router/workout.ts
@@ -93,11 +93,11 @@ export const workoutRouter = {
     ]);
 
     const recovery: RecoveryContext = {
-      acwr: (advancedMetric?.acwr as number) ?? null,
-      tsb: (advancedMetric?.tsb as number) ?? null,
-      bodyBattery: (dailyMetric?.bodyBatteryEnd as number) ?? null,
-      sleepDebtMinutes: (dailyMetric?.sleepDebtMinutes as number) ?? null,
-      stressScore: (dailyMetric?.stressScore as number) ?? null,
+      acwr: advancedMetric?.acwr ?? null,
+      tsb: advancedMetric?.tsb ?? null,
+      bodyBattery: dailyMetric?.bodyBatteryEnd ?? null,
+      sleepDebtMinutes: dailyMetric?.sleepDebtMinutes ?? null,
+      stressScore: dailyMetric?.stressScore ?? null,
     };
 
     const recommendation = generateDailyWorkout(

--- a/packages/api/src/router/workout.ts
+++ b/packages/api/src/router/workout.ts
@@ -8,13 +8,15 @@ import {
   ReadinessScore,
   Activity,
   Profile,
+  DailyMetric,
+  AdvancedMetric,
 } from "@acme/db/schema";
 import {
   generateDailyWorkout,
   adjustDifficulty,
   countConsecutiveHardDays,
 } from "@acme/engine";
-import type { ReadinessZone } from "@acme/engine";
+import type { ReadinessZone, RecoveryContext } from "@acme/engine";
 
 import { protectedProcedure } from "../trpc";
 
@@ -74,6 +76,30 @@ export const workoutRouter = {
     const goal = (profile.goals as { sport: string; goalType: string }[])?.[0]?.goalType ?? "maintain";
     const availableDays = (profile.weeklyDays as string[])?.length ?? 3;
 
+    // Fetch recovery context for evidence-based workout modulation
+    const [dailyMetric, advancedMetric] = await Promise.all([
+      ctx.db.query.DailyMetric.findFirst({
+        where: and(
+          eq(DailyMetric.userId, userId),
+          eq(DailyMetric.date, today),
+        ),
+      }),
+      ctx.db.query.AdvancedMetric.findFirst({
+        where: and(
+          eq(AdvancedMetric.userId, userId),
+          eq(AdvancedMetric.date, today),
+        ),
+      }),
+    ]);
+
+    const recovery: RecoveryContext = {
+      acwr: (advancedMetric?.acwr as number) ?? null,
+      tsb: (advancedMetric?.tsb as number) ?? null,
+      bodyBattery: (dailyMetric?.bodyBatteryEnd as number) ?? null,
+      sleepDebtMinutes: (dailyMetric?.sleepDebtMinutes as number) ?? null,
+      stressScore: (dailyMetric?.stressScore as number) ?? null,
+    };
+
     const recommendation = generateDailyWorkout(
       sport,
       goal,
@@ -81,6 +107,7 @@ export const workoutRouter = {
       availableDays,
       zone,
       consecutiveHard,
+      recovery,
     );
 
     // Persist

--- a/packages/engine/src/__tests__/coaching.test.ts
+++ b/packages/engine/src/__tests__/coaching.test.ts
@@ -33,7 +33,6 @@ describe("selectWeeklyTemplate", () => {
 
 describe("modulateWorkout", () => {
   const tempoTemplate = allTemplates.find((t) => t.id === "run-tempo")!;
-  const easyTemplate = allTemplates.find((t) => t.id === "run-easy")!;
 
   it("returns active recovery for poor readiness without critical signals", () => {
     const result = modulateWorkout(tempoTemplate, "poor", "running");
@@ -53,6 +52,27 @@ describe("modulateWorkout", () => {
       acwr: null, tsb: -30, bodyBattery: null, sleepDebtMinutes: null, stressScore: null,
     });
     expect(result.workoutType).toBe("rest");
+  });
+
+  it("returns rest for poor readiness with critically low body battery", () => {
+    const result = modulateWorkout(tempoTemplate, "poor", "running", {
+      acwr: null, tsb: null, bodyBattery: 15, sleepDebtMinutes: null, stressScore: null,
+    });
+    expect(result.workoutType).toBe("rest");
+  });
+
+  it("returns rest for poor readiness with high sleep debt", () => {
+    const result = modulateWorkout(tempoTemplate, "poor", "running", {
+      acwr: null, tsb: null, bodyBattery: null, sleepDebtMinutes: 200, stressScore: null,
+    });
+    expect(result.workoutType).toBe("rest");
+  });
+
+  it("returns active recovery for poor readiness with all-null recovery context", () => {
+    const result = modulateWorkout(tempoTemplate, "poor", "running", {
+      acwr: null, tsb: null, bodyBattery: null, sleepDebtMinutes: null, stressScore: null,
+    });
+    expect(result.workoutType).toBe("active_recovery");
   });
 
   it("returns active recovery for poor readiness with moderate signals", () => {

--- a/packages/engine/src/__tests__/coaching.test.ts
+++ b/packages/engine/src/__tests__/coaching.test.ts
@@ -35,9 +35,31 @@ describe("modulateWorkout", () => {
   const tempoTemplate = allTemplates.find((t) => t.id === "run-tempo")!;
   const easyTemplate = allTemplates.find((t) => t.id === "run-easy")!;
 
-  it("returns rest for poor readiness", () => {
+  it("returns active recovery for poor readiness without critical signals", () => {
     const result = modulateWorkout(tempoTemplate, "poor", "running");
+    expect(result.workoutType).toBe("active_recovery");
+    expect(result.targetHrZoneHigh).toBe(1);
+  });
+
+  it("returns rest for poor readiness with critical ACWR", () => {
+    const result = modulateWorkout(tempoTemplate, "poor", "running", {
+      acwr: 1.6, tsb: null, bodyBattery: null, sleepDebtMinutes: null, stressScore: null,
+    });
     expect(result.workoutType).toBe("rest");
+  });
+
+  it("returns rest for poor readiness with deep overreach TSB", () => {
+    const result = modulateWorkout(tempoTemplate, "poor", "running", {
+      acwr: null, tsb: -30, bodyBattery: null, sleepDebtMinutes: null, stressScore: null,
+    });
+    expect(result.workoutType).toBe("rest");
+  });
+
+  it("returns active recovery for poor readiness with moderate signals", () => {
+    const result = modulateWorkout(tempoTemplate, "poor", "running", {
+      acwr: 1.1, tsb: -10, bodyBattery: 35, sleepDebtMinutes: 60, stressScore: 50,
+    });
+    expect(result.workoutType).toBe("active_recovery");
   });
 
   it("substitutes easy on low readiness + hard workout", () => {

--- a/packages/engine/src/coaching/index.ts
+++ b/packages/engine/src/coaching/index.ts
@@ -178,9 +178,12 @@ function recommendForPoorReadiness(
   sport: string,
   recovery: RecoveryContext | undefined,
 ): WorkoutRecommendation {
-  // Without recovery context, default to active recovery (conservative but
-  // not complete rest — active recovery promotes adaptation per Barnett 2006)
-  if (!recovery) {
+  // Without recovery context (or all-null fields), default to active recovery
+  // (conservative but not complete rest — promotes adaptation per Barnett 2006)
+  const hasAnySignal = recovery &&
+    (recovery.acwr !== null || recovery.tsb !== null ||
+     recovery.bodyBattery !== null || recovery.sleepDebtMinutes !== null);
+  if (!hasAnySignal) {
     return getActiveRecoveryRecommendation(
       sport,
       "Readiness is poor — light active recovery to promote blood flow.",

--- a/packages/engine/src/coaching/index.ts
+++ b/packages/engine/src/coaching/index.ts
@@ -1,4 +1,4 @@
-import type { ReadinessZone, WorkoutRecommendation, UserProfile } from "../types";
+import type { ReadinessZone, RecoveryContext, WorkoutRecommendation, UserProfile } from "../types";
 import type { WorkoutTemplate } from "./templates";
 import { allTemplates, runningTemplates, cyclingTemplates, strengthTemplates } from "./templates";
 
@@ -102,9 +102,9 @@ function getEasyTemplate(sport: string): WorkoutTemplate {
 }
 
 /**
- * Get the rest/recovery recommendation.
+ * Get the rest recommendation (complete rest).
  */
-function getRestRecommendation(): WorkoutRecommendation {
+function getRestRecommendation(reason: string): WorkoutRecommendation {
   return {
     sportType: "rest",
     workoutType: "rest",
@@ -119,26 +119,122 @@ function getRestRecommendation(): WorkoutRecommendation {
     structure: [
       { phase: "main", description: "Light walk or complete rest", durationMinutes: 20, hrZone: 1 },
     ],
-    explanation: "Your readiness is very low. Rest today to recover.",
+    explanation: reason,
   };
 }
 
 /**
- * Modulate a workout template based on readiness zone.
+ * Get an active recovery recommendation (light movement, Zone 1).
+ *
+ * Active recovery promotes blood flow and adaptation without adding
+ * significant training stress. Preferred over complete rest when the
+ * athlete is fatigued but not critically depleted.
+ *
+ * Ref: Barnett A. Using recovery modalities between training sessions
+ *      in elite athletes. Sports Med. 2006;36(9):781-796.
+ */
+function getActiveRecoveryRecommendation(sport: string, reason: string): WorkoutRecommendation {
+  const descriptions: Record<string, string> = {
+    running: "Very easy jog or walk — conversational pace only",
+    cycling: "Easy spin — light resistance, high cadence",
+    strength: "Mobility work, foam rolling, and light stretching",
+  };
+  const desc = descriptions[sport] ?? "Light movement — keep it easy and short";
+
+  return {
+    sportType: sport,
+    workoutType: "active_recovery",
+    title: "Active Recovery",
+    description: desc,
+    targetDurationMin: 20,
+    targetDurationMax: 30,
+    targetHrZoneLow: 1,
+    targetHrZoneHigh: 1,
+    targetStrainLow: 0,
+    targetStrainHigh: 3,
+    structure: [
+      { phase: "warmup", description: "Gentle start", durationMinutes: 5, hrZone: 1 },
+      { phase: "main", description: desc, durationMinutes: 20, hrZone: 1 },
+      { phase: "cooldown", description: "Easy stretching", durationMinutes: 5, hrZone: 1 },
+    ],
+    explanation: reason,
+  };
+}
+
+/**
+ * Determine whether "poor" readiness truly requires complete rest, or
+ * whether active recovery is more appropriate.
+ *
+ * Complete rest is reserved for critical states:
+ * - ACWR > 1.5 (high injury risk zone, Hulin 2016)
+ * - TSB < -25 (functional overreaching, Meeusen 2013)
+ * - Body Battery < 20 (critically depleted energy reserves)
+ * - Sleep debt > 3 hours (Mah 2011: impairs reaction time and power)
+ *
+ * Otherwise, active recovery is preferred — it promotes adaptation
+ * without adding significant training stress (Barnett 2006).
+ */
+function recommendForPoorReadiness(
+  sport: string,
+  recovery: RecoveryContext | undefined,
+): WorkoutRecommendation {
+  // Without recovery context, fall back to conservative rest
+  if (!recovery) {
+    return getActiveRecoveryRecommendation(
+      sport,
+      "Readiness is poor — light active recovery to promote blood flow.",
+    );
+  }
+
+  // Critical rest triggers — any one is sufficient for complete rest
+  if (recovery.acwr !== null && recovery.acwr > 1.5) {
+    return getRestRecommendation(
+      `ACWR is ${recovery.acwr.toFixed(2)} — high injury risk zone (>1.5). Complete rest recommended.`,
+    );
+  }
+  if (recovery.tsb !== null && recovery.tsb < -25) {
+    return getRestRecommendation(
+      `TSB is ${recovery.tsb.toFixed(0)} — deep overreach zone. Rest to prevent overtraining.`,
+    );
+  }
+  if (recovery.bodyBattery !== null && recovery.bodyBattery < 20) {
+    return getRestRecommendation(
+      `Body Battery critically low (${recovery.bodyBattery}%). Rest today.`,
+    );
+  }
+  if (recovery.sleepDebtMinutes !== null && recovery.sleepDebtMinutes > 180) {
+    const hours = (recovery.sleepDebtMinutes / 60).toFixed(1);
+    return getRestRecommendation(
+      `Sleep debt is ${hours}h — prioritize rest and catch up on sleep.`,
+    );
+  }
+
+  // Poor readiness but no critical signals → active recovery
+  return getActiveRecoveryRecommendation(
+    sport,
+    "Readiness is poor but no critical risk signals — light active recovery to promote blood flow and adaptation.",
+  );
+}
+
+/**
+ * Modulate a workout template based on readiness zone and recovery signals.
  *
  * Prime   → promote hard session or intensify +5%
  * High    → execute as planned
  * Moderate→ reduce volume -10%
  * Low     → substitute easy/technique
- * Poor    → rest or 20min Zone 1 only
+ * Poor    → evidence-based: rest only if critical signals, else active recovery
+ *
+ * Ref: Hulin 2016 (ACWR), Meeusen 2013 (overreaching), Barnett 2006 (recovery)
  */
 export function modulateWorkout(
   template: WorkoutTemplate,
   readinessZone: ReadinessZone,
   sport: string,
+  recovery?: RecoveryContext,
 ): WorkoutRecommendation {
   if (readinessZone === "poor") {
-    return getRestRecommendation();
+    return recommendForPoorReadiness(sport, recovery);
   }
 
   if (readinessZone === "low" && (template.intensity === "hard" || template.intensity === "very_hard")) {
@@ -207,6 +303,11 @@ function getModulationExplanation(template: WorkoutTemplate, zone: ReadinessZone
 
 /**
  * Generate today's workout recommendation given the day's plan and readiness.
+ *
+ * When recovery context is provided, "poor" readiness uses evidence-based
+ * decision logic instead of unconditionally prescribing rest. This addresses
+ * the Garmin Coach "always rest day" sync bug by providing our own
+ * intelligent recommendations.
  */
 export function generateDailyWorkout(
   sport: string,
@@ -215,6 +316,7 @@ export function generateDailyWorkout(
   availableDays: number,
   readinessZone: ReadinessZone,
   recentHardDays: number, // consecutive hard days
+  recovery?: RecoveryContext,
 ): WorkoutRecommendation {
   // Force easy day after 2+ consecutive hard days
   if (recentHardDays >= 2 && readinessZone !== "prime") {
@@ -231,8 +333,8 @@ export function generateDailyWorkout(
   // Find today's slot
   const todaySlot = weekTemplate.find((s) => s.dayIndex === dayOfWeek);
   if (!todaySlot) {
-    // Rest day in the plan
-    return getRestRecommendation();
+    // Rest day in the weekly plan template
+    return getRestRecommendation("Scheduled rest day in your weekly plan.");
   }
 
   // Find the corresponding workout template
@@ -251,12 +353,12 @@ export function generateDailyWorkout(
     if (harderSlot) {
       const harderTemplate = findTemplate(sport, harderSlot.sessionType);
       if (harderTemplate) {
-        return modulateWorkout(harderTemplate, readinessZone, sport);
+        return modulateWorkout(harderTemplate, readinessZone, sport, recovery);
       }
     }
   }
 
-  return modulateWorkout(template, readinessZone, sport);
+  return modulateWorkout(template, readinessZone, sport, recovery);
 }
 
 /**

--- a/packages/engine/src/coaching/index.ts
+++ b/packages/engine/src/coaching/index.ts
@@ -146,7 +146,7 @@ function getActiveRecoveryRecommendation(sport: string, reason: string): Workout
     workoutType: "active_recovery",
     title: "Active Recovery",
     description: desc,
-    targetDurationMin: 20,
+    targetDurationMin: 30,
     targetDurationMax: 30,
     targetHrZoneLow: 1,
     targetHrZoneHigh: 1,
@@ -178,7 +178,8 @@ function recommendForPoorReadiness(
   sport: string,
   recovery: RecoveryContext | undefined,
 ): WorkoutRecommendation {
-  // Without recovery context, fall back to conservative rest
+  // Without recovery context, default to active recovery (conservative but
+  // not complete rest — active recovery promotes adaptation per Barnett 2006)
   if (!recovery) {
     return getActiveRecoveryRecommendation(
       sport,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,6 +15,7 @@ export type {
   UserProfile,
   WorkoutStructureBlock,
   WorkoutRecommendation,
+  RecoveryContext,
   AnomalyAlert,
   // New types
   TrainingLoadMetrics,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -276,6 +276,18 @@ export interface UserProfile {
 }
 
 // ---------------------------------------------------------------------------
+// Recovery Context — optional signals for smarter workout modulation
+// Ref: Hulin 2016 (ACWR), Meeusen 2013 (TSB overreaching), Kellmann 2010
+// ---------------------------------------------------------------------------
+export interface RecoveryContext {
+  acwr: number | null; // Acute:Chronic Workload Ratio (sweet spot: 0.8-1.3)
+  tsb: number | null; // Training Stress Balance (CTL - ATL)
+  bodyBattery: number | null; // Garmin Body Battery (0-100)
+  sleepDebtMinutes: number | null; // accumulated sleep debt
+  stressScore: number | null; // Garmin daily stress (0-100)
+}
+
+// ---------------------------------------------------------------------------
 // Workout Types
 // ---------------------------------------------------------------------------
 export interface WorkoutStructureBlock {


### PR DESCRIPTION
## Summary
- The "Today's Workout" dashboard unconditionally showed "Rest Day" when readiness zone was "poor" — now uses evidence-based decision logic
- Complete rest only prescribed for critical signals: ACWR >1.5, TSB <-25, Body Battery <20, Sleep debt >3h
- Otherwise shows "Active Recovery" with sport-specific guidance (Barnett 2006)
- Recovery context (ACWR, TSB, body battery, sleep debt, stress) passed from DB to engine

## Problem
The dashboard always showed "😴 Rest Day — Your readiness is very low. Rest today to recover." whenever the readiness score was below 20 (zone="poor"). This was too aggressive — active recovery is often better than complete rest, and the original logic ignored whether there were actual injury risk or overtraining signals.

This also replaces the reliance on Garmin Coach's rest-day suggestion which has a known watch-phone sync desync bug.

## Sport Science References
- Hulin 2016 — ACWR >1.5 = high injury risk
- Meeusen 2013 — TSB <-25 = functional overreaching  
- Mah 2011 — sleep debt >3h impairs performance
- Barnett 2006 — active recovery promotes adaptation

## Test plan
- [ ] Verify "poor" readiness with ACWR >1.5 shows "Rest Day" with ACWR explanation
- [ ] Verify "poor" readiness with no critical signals shows "Active Recovery"
- [ ] Verify "poor" readiness without recovery context shows "Active Recovery" (fallback)
- [ ] Verify other zones (prime/high/moderate/low) unchanged
- [ ] TypeScript compiles, engine tests pass
- [ ] Pre-commit hooks pass

Signed-off-by: Anil Belur <askb23@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)