### PR TITLE
feat: P3-P5 — HRV analysis, date-range selectors, recompute, export

### DIFF
--- a/apps/nextjs/src/app/_components/bottom-nav.tsx
+++ b/apps/nextjs/src/app/_components/bottom-nav.tsx
@@ -11,7 +11,7 @@ const navItems = [
   { href: "/", label: "Today", icon: "🏠" },
   { href: "/trends", label: "Trends", icon: "📊" },
   { href: "/training", label: "Training", icon: "💪" },
-  { href: "/zones", label: "Zones", icon: "📶" },
+  { href: "/hrv", label: "HRV", icon: "💓" },
   { href: "/sleep", label: "Sleep", icon: "🌙" },
   { href: "/settings", label: "Settings", icon: "⚙️" },
 ];

--- a/apps/nextjs/src/app/_components/date-range-selector.tsx
+++ b/apps/nextjs/src/app/_components/date-range-selector.tsx
@@ -28,6 +28,7 @@ export function DateRangeSelector({
     <div className={cn("flex flex-wrap gap-1.5", className)}>
       {presets.map((p) => (
         <button
+          type="button"
           key={p.days}
           onClick={() => onChange(p.days)}
           className={cn(

--- a/apps/nextjs/src/app/_components/date-range-selector.tsx
+++ b/apps/nextjs/src/app/_components/date-range-selector.tsx
@@ -14,14 +14,14 @@ const PRESETS = [
 interface DateRangeSelectorProps {
   value: number;
   onChange: (days: number) => void;
-  presets?: { label: string; days: number }[];
+  presets?: readonly { readonly label: string; readonly days: number }[];
   className?: string;
 }
 
 export function DateRangeSelector({
   value,
   onChange,
-  presets = PRESETS as unknown as { label: string; days: number }[],
+  presets = PRESETS,
   className,
 }: DateRangeSelectorProps) {
   return (

--- a/apps/nextjs/src/app/_components/date-range-selector.tsx
+++ b/apps/nextjs/src/app/_components/date-range-selector.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { cn } from "@acme/ui";
+
+const PRESETS = [
+  { label: "7d", days: 7 },
+  { label: "14d", days: 14 },
+  { label: "28d", days: 28 },
+  { label: "90d", days: 90 },
+  { label: "180d", days: 180 },
+  { label: "1y", days: 365 },
+] as const;
+
+interface DateRangeSelectorProps {
+  value: number;
+  onChange: (days: number) => void;
+  presets?: { label: string; days: number }[];
+  className?: string;
+}
+
+export function DateRangeSelector({
+  value,
+  onChange,
+  presets = PRESETS as unknown as { label: string; days: number }[],
+  className,
+}: DateRangeSelectorProps) {
+  return (
+    <div className={cn("flex flex-wrap gap-1.5", className)}>
+      {presets.map((p) => (
+        <button
+          key={p.days}
+          onClick={() => onChange(p.days)}
+          className={cn(
+            "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+            value === p.days
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-muted-foreground hover:bg-muted/80",
+          )}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/_components/hamburger-menu.tsx
+++ b/apps/nextjs/src/app/_components/hamburger-menu.tsx
@@ -32,6 +32,7 @@ const menuSections: NavSection[] = [
     title: "Training",
     items: [
       { href: "/training", label: "Training Load", icon: "💪" },
+      { href: "/hrv", label: "HRV Analysis", icon: "💓" },
       { href: "/zones", label: "HR Zones", icon: "📶" },
       { href: "/activities", label: "Activities", icon: "🏃" },
       { href: "/power", label: "Power", icon: "⚡" },

--- a/apps/nextjs/src/app/api/garmin/recompute/route.ts
+++ b/apps/nextjs/src/app/api/garmin/recompute/route.ts
@@ -16,21 +16,32 @@ export async function POST() {
     if (!res.ok) {
       // Fallback: if addon doesn't support /auth/recompute yet, return helpful message
       if (res.status === 404) {
-        return NextResponse.json({
-          success: false,
-          message: "Recompute endpoint not available. Update addon to v0.16.0+",
-        });
+        return NextResponse.json(
+          {
+            success: false,
+            message:
+              "Recompute endpoint not available. Update addon to v0.16.0+",
+          },
+          { status: 404 },
+        );
       }
-      return NextResponse.json({ success: false, message: "Recompute failed" });
+      const body = await res.text().catch(() => "");
+      return NextResponse.json(
+        { success: false, message: body || "Recompute failed" },
+        { status: res.status },
+      );
     }
 
     const data = (await res.json()) as Record<string, unknown>;
     return NextResponse.json({ success: true, ...data });
   } catch (err) {
-    return NextResponse.json({
-      success: false,
-      message: err instanceof Error ? err.message : "Connection error",
-    });
+    return NextResponse.json(
+      {
+        success: false,
+        message: err instanceof Error ? err.message : "Connection error",
+      },
+      { status: 502 },
+    );
   }
 }
 

--- a/apps/nextjs/src/app/api/garmin/recompute/route.ts
+++ b/apps/nextjs/src/app/api/garmin/recompute/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+function getAuthServerBase() {
+  return process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
+}
+
+export async function POST() {
+  try {
+    const res = await fetch(`${getAuthServerBase()}/auth/recompute`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (!res.ok) {
+      // Fallback: if addon doesn't support /auth/recompute yet, return helpful message
+      if (res.status === 404) {
+        return NextResponse.json({
+          success: false,
+          message: "Recompute endpoint not available. Update addon to v0.16.0+",
+        });
+      }
+      return NextResponse.json({ success: false, message: "Recompute failed" });
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    return NextResponse.json({ success: true, ...data });
+  } catch (err) {
+    return NextResponse.json({
+      success: false,
+      message: err instanceof Error ? err.message : "Connection error",
+    });
+  }
+}
+
+export async function GET() {
+  try {
+    const res = await fetch(`${getAuthServerBase()}/auth/recompute-status`);
+    if (!res.ok) {
+      return NextResponse.json({ status: "unknown" });
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ status: "unknown" });
+  }
+}

--- a/apps/nextjs/src/app/export/page.tsx
+++ b/apps/nextjs/src/app/export/page.tsx
@@ -76,7 +76,9 @@ export default function ExportPage() {
   /* ── Data summary counts ── */
   const activityCount = activities.data?.length ?? 0;
   const journalCount = journalQuery.data?.length ?? 0;
-  const advMetricCount = Array.isArray(advancedMetrics.data) ? advancedMetrics.data.length : 0;
+  const advMetricCount = Array.isArray(advancedMetrics.data)
+    ? advancedMetrics.data.length
+    : 0;
   const hrvDayCount = hrvData.data?.daily?.length ?? 0;
 
   const earliestDate = activities.data?.length

--- a/apps/nextjs/src/app/export/page.tsx
+++ b/apps/nextjs/src/app/export/page.tsx
@@ -68,10 +68,16 @@ export default function ExportPage() {
       endDate: new Date().toISOString().slice(0, 10),
     }),
   );
+  const advancedMetrics = useQuery(
+    trpc.advancedMetrics.list.queryOptions({ days: 365 }),
+  );
+  const hrvData = useQuery(trpc.hrv.getAnalysis.queryOptions({ days: 365 }));
 
   /* ── Data summary counts ── */
   const activityCount = activities.data?.length ?? 0;
   const journalCount = journalQuery.data?.length ?? 0;
+  const advMetricCount = Array.isArray(advancedMetrics.data) ? advancedMetrics.data.length : 0;
+  const hrvDayCount = hrvData.data?.daily?.length ?? 0;
 
   const earliestDate = activities.data?.length
     ? [...(activities.data as { startedAt?: Date | string | null }[])]
@@ -107,12 +113,40 @@ export default function ExportPage() {
     );
   }
 
+  function handleExportAdvancedMetrics() {
+    if (!advancedMetrics.data || !Array.isArray(advancedMetrics.data))
+      return toast.error("Advanced metrics not loaded");
+    exportToCSV(
+      advancedMetrics.data as Record<string, unknown>[],
+      `pulsecoach-advanced-metrics-${formatDateForFilename()}.csv`,
+    );
+  }
+
+  function handleExportHrv() {
+    const d = hrvData.data;
+    if (!d?.daily?.length) return toast.error("HRV data not loaded");
+    const rows = d.daily.map((pt, i) => ({
+      date: pt.date,
+      hrv_ms: pt.value,
+      rolling_7d: d.rolling7d.find((r) => r.date === pt.date)?.value ?? "",
+      rolling_14d: d.rolling14d.find((r) => r.date === pt.date)?.value ?? "",
+      baseline: i === d.daily.length - 1 ? d.baseline : "",
+      cv_pct: i === d.daily.length - 1 ? d.cv : "",
+    }));
+    exportToCSV(
+      rows as unknown as Record<string, unknown>[],
+      `pulsecoach-hrv-${formatDateForFilename()}.csv`,
+    );
+  }
+
   function handleFullExport() {
     const payload = {
-      schemaVersion: "1.0",
+      schemaVersion: "1.1",
       exportedAt: new Date().toISOString(),
       activities: activities.data ?? [],
       metrics: trendsSummary.data ?? {},
+      advancedMetrics: advancedMetrics.data ?? [],
+      hrv: hrvData.data ?? {},
       journal: journalQuery.data ?? [],
     };
     exportToJSON(payload, `pulsecoach-backup-${formatDateForFilename()}.json`);
@@ -212,6 +246,42 @@ export default function ExportPage() {
             className="w-full"
             disabled={journalQuery.isLoading}
             onClick={handleExportJournal}
+          >
+            Download CSV
+          </Button>
+        </div>
+
+        <div className="bg-card space-y-3 rounded-2xl border p-4">
+          <div>
+            <p className="font-semibold">Advanced Metrics</p>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              {advMetricCount} days · CTL/ATL/TSB/ACWR · CSV
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full"
+            disabled={advancedMetrics.isLoading}
+            onClick={handleExportAdvancedMetrics}
+          >
+            Download CSV
+          </Button>
+        </div>
+
+        <div className="bg-card space-y-3 rounded-2xl border p-4">
+          <div>
+            <p className="font-semibold">HRV Analysis</p>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              {hrvDayCount} days · Rolling avg + CV% · CSV
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full"
+            disabled={hrvData.isLoading}
+            onClick={handleExportHrv}
           >
             Download CSV
           </Button>

--- a/apps/nextjs/src/app/export/page.tsx
+++ b/apps/nextjs/src/app/export/page.tsx
@@ -127,11 +127,17 @@ export default function ExportPage() {
   function handleExportHrv() {
     const d = hrvData.data;
     if (!d?.daily?.length) return toast.error("HRV data not loaded");
+
+    const rolling7dByDate = new Map(d.rolling7d.map((r) => [r.date, r.value]));
+    const rolling14dByDate = new Map(
+      d.rolling14d.map((r) => [r.date, r.value]),
+    );
+
     const rows = d.daily.map((pt, i) => ({
       date: pt.date,
       hrv_ms: pt.value,
-      rolling_7d: d.rolling7d.find((r) => r.date === pt.date)?.value ?? "",
-      rolling_14d: d.rolling14d.find((r) => r.date === pt.date)?.value ?? "",
+      rolling_7d: rolling7dByDate.get(pt.date) ?? "",
+      rolling_14d: rolling14dByDate.get(pt.date) ?? "",
       baseline: i === d.daily.length - 1 ? d.baseline : "",
       cv_pct: i === d.daily.length - 1 ? d.cv : "",
     }));

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Area,
@@ -17,6 +17,7 @@ import { cn } from "@acme/ui";
 
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
+import { DateRangeSelector } from "../_components/date-range-selector";
 import { SectionHeader } from "../_components/info-button";
 
 /* ─────────────── constants ─────────────── */
@@ -163,9 +164,10 @@ function vdotPace(vo2max: number, fraction: number): string {
 
 export default function FitnessPage() {
   const trpc = useTRPC();
+  const [chartDays, setChartDays] = useState(90);
 
   const vo2max = useQuery(
-    trpc.analytics.getVO2maxHistory.queryOptions({ days: 365 }),
+    trpc.analytics.getVO2maxHistory.queryOptions({ days: chartDays }),
   );
   const racePredictions = useQuery(
     trpc.analytics.getRacePredictions.queryOptions(),
@@ -174,7 +176,7 @@ export default function FitnessPage() {
     trpc.analytics.getTrainingStatus.queryOptions(),
   );
   const recentActivities = useQuery(
-    trpc.activity.list.queryOptions({ days: 90, sportType: "running" }),
+    trpc.activity.list.queryOptions({ days: chartDays, sportType: "running" }),
   );
   const trainingLoads = useQuery(
     trpc.analytics.getTrainingLoads.queryOptions(),
@@ -366,6 +368,9 @@ export default function FitnessPage() {
           </span>
         )}
       </div>
+
+      {/* ── Date Range ── */}
+      <DateRangeSelector value={chartDays} onChange={setChartDays} />
 
       {/* ── Current VO2max Hero ── */}
       {vo2max.isLoading ? (

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -18,6 +18,7 @@ import { cn } from "@acme/ui";
 
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
+import { DateRangeSelector } from "../_components/date-range-selector";
 import { SectionHeader } from "../_components/info-button";
 
 /* ─────────────── constants ─────────────── */
@@ -53,7 +54,7 @@ const STATUS_CONFIG: Record<
   },
 };
 
-const RANGE_OPTIONS = [
+const HRV_PRESETS = [
   { label: "30d", days: 30 },
   { label: "60d", days: 60 },
   { label: "90d", days: 90 },
@@ -269,22 +270,12 @@ export default function HrvPage() {
       )}
 
       {/* ── Date Range Selector ── */}
-      <div className="flex justify-center gap-2">
-        {RANGE_OPTIONS.map((opt) => (
-          <button
-            key={opt.days}
-            onClick={() => setDays(opt.days)}
-            className={cn(
-              "rounded-full px-3 py-1 text-xs font-medium transition-colors",
-              days === opt.days
-                ? "bg-blue-500 text-white"
-                : "bg-card text-muted-foreground hover:text-foreground border",
-            )}
-          >
-            {opt.label}
-          </button>
-        ))}
-      </div>
+      <DateRangeSelector
+        value={days}
+        onChange={setDays}
+        presets={HRV_PRESETS}
+        className="justify-center"
+      />
 
       {/* ── Main HRV Chart ── */}
       {isLoading ? (
@@ -407,7 +398,9 @@ export default function HrvPage() {
                   borderRadius: 8,
                   fontSize: 12,
                 }}
-                formatter={(value: number) => [`${value.toFixed(1)}%`, "CV%"]}
+                formatter={(value: unknown) =>
+                  `${Number(value).toFixed(1)}%`
+                }
               />
               <ReferenceLine
                 y={10}

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -86,7 +86,13 @@ export default function HrvPage() {
 
     const map = new Map<
       string,
-      { date: string; label: string; daily?: number; rolling7d?: number; rolling14d?: number }
+      {
+        date: string;
+        label: string;
+        daily?: number;
+        rolling7d?: number;
+        rolling14d?: number;
+      }
     >();
 
     for (const d of data.daily) {
@@ -116,8 +122,7 @@ export default function HrvPage() {
     const result: { date: string; label: string; cv: number }[] = [];
     for (let i = 6; i < data.daily.length; i++) {
       const window = data.daily.slice(i - 6, i + 1);
-      const mean =
-        window.reduce((s, d) => s + d.value, 0) / window.length;
+      const mean = window.reduce((s, d) => s + d.value, 0) / window.length;
       const std = Math.sqrt(
         window.reduce((s, d) => s + (d.value - mean) ** 2, 0) / window.length,
       );
@@ -132,7 +137,7 @@ export default function HrvPage() {
   }, [data]);
 
   return (
-    <main className="mx-auto flex max-w-lg flex-col gap-4 px-4 pb-24 pt-6">
+    <main className="mx-auto flex max-w-lg flex-col gap-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
@@ -273,7 +278,7 @@ export default function HrvPage() {
               "rounded-full px-3 py-1 text-xs font-medium transition-colors",
               days === opt.days
                 ? "bg-blue-500 text-white"
-                : "bg-card text-muted-foreground border hover:text-foreground",
+                : "bg-card text-muted-foreground hover:text-foreground border",
             )}
           >
             {opt.label}

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -398,9 +398,7 @@ export default function HrvPage() {
                   borderRadius: 8,
                   fontSize: 12,
                 }}
-                formatter={(value: unknown) =>
-                  `${Number(value).toFixed(1)}%`
-                }
+                formatter={(value: unknown) => `${Number(value).toFixed(1)}%`}
               />
               <ReferenceLine
                 y={10}

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -1,0 +1,486 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { cn } from "@acme/ui";
+
+import { useTRPC } from "~/trpc/react";
+import { BottomNav } from "../_components/bottom-nav";
+import { SectionHeader } from "../_components/info-button";
+
+/* ─────────────── constants ─────────────── */
+
+const STATUS_CONFIG: Record<
+  string,
+  { icon: string; label: string; cls: string; description: string }
+> = {
+  recovered: {
+    icon: "✅",
+    label: "Recovered",
+    cls: "bg-green-500/20 text-green-400 border-green-500/30",
+    description: "HRV is above baseline — your body is well recovered.",
+  },
+  recovering: {
+    icon: "🔄",
+    label: "Recovering",
+    cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+    description: "HRV is near baseline — recovery is progressing normally.",
+  },
+  strained: {
+    icon: "⚠️",
+    label: "Strained",
+    cls: "bg-red-500/20 text-red-400 border-red-500/30",
+    description:
+      "HRV is below baseline or highly variable — consider rest or easy training.",
+  },
+  insufficient_data: {
+    icon: "📊",
+    label: "Insufficient Data",
+    cls: "bg-zinc-500/20 text-zinc-400 border-zinc-500/30",
+    description: "Need more HRV data to determine recovery status.",
+  },
+};
+
+const RANGE_OPTIONS = [
+  { label: "30d", days: 30 },
+  { label: "60d", days: 60 },
+  { label: "90d", days: 90 },
+  { label: "180d", days: 180 },
+  { label: "1y", days: 365 },
+];
+
+function fmtDateShort(d: string): string {
+  const date = new Date(d);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/* ─────────────── page ─────────────── */
+
+export default function HrvPage() {
+  const trpc = useTRPC();
+  const [days, setDays] = useState(90);
+
+  const { data, isLoading } = useQuery(
+    trpc.hrv.getAnalysis.queryOptions({ days }),
+  );
+
+  const statusConfig = data?.status
+    ? STATUS_CONFIG[data.status]
+    : STATUS_CONFIG.insufficient_data;
+
+  // Chart data: merge daily, rolling7d, rolling14d into one series
+  const chartData = useMemo(() => {
+    if (!data?.daily.length) return [];
+
+    const map = new Map<
+      string,
+      { date: string; label: string; daily?: number; rolling7d?: number; rolling14d?: number }
+    >();
+
+    for (const d of data.daily) {
+      map.set(d.date, {
+        date: d.date,
+        label: fmtDateShort(d.date),
+        daily: d.value,
+      });
+    }
+    for (const d of data.rolling7d) {
+      const existing = map.get(d.date);
+      if (existing) existing.rolling7d = d.value;
+    }
+    for (const d of data.rolling14d) {
+      const existing = map.get(d.date);
+      if (existing) existing.rolling14d = d.value;
+    }
+
+    return Array.from(map.values()).sort((a, b) =>
+      a.date.localeCompare(b.date),
+    );
+  }, [data]);
+
+  // CV% over time: compute rolling 7-day CV for each point
+  const cvData = useMemo(() => {
+    if (!data?.daily || data.daily.length < 7) return [];
+    const result: { date: string; label: string; cv: number }[] = [];
+    for (let i = 6; i < data.daily.length; i++) {
+      const window = data.daily.slice(i - 6, i + 1);
+      const mean =
+        window.reduce((s, d) => s + d.value, 0) / window.length;
+      const std = Math.sqrt(
+        window.reduce((s, d) => s + (d.value - mean) ** 2, 0) / window.length,
+      );
+      const cv = Math.round((std / mean) * 1000) / 10;
+      result.push({
+        date: data.daily[i]!.date,
+        label: fmtDateShort(data.daily[i]!.date),
+        cv,
+      });
+    }
+    return result;
+  }, [data]);
+
+  return (
+    <main className="mx-auto flex max-w-lg flex-col gap-4 px-4 pb-24 pt-6">
+      {/* ── Header ── */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">HRV Analysis</h1>
+          <p className="text-muted-foreground text-sm">
+            Heart Rate Variability &amp; Recovery
+          </p>
+        </div>
+        {statusConfig && data?.status !== "insufficient_data" && (
+          <span
+            className={cn(
+              "rounded-full border px-3 py-1 text-xs font-semibold",
+              statusConfig.cls,
+            )}
+          >
+            {statusConfig.icon} {statusConfig.label}
+          </span>
+        )}
+      </div>
+
+      {/* ── Recovery Status Card ── */}
+      {isLoading ? (
+        <div className="bg-card animate-pulse rounded-2xl border p-6">
+          <div className="bg-muted mx-auto h-16 w-24 rounded" />
+          <div className="bg-muted mx-auto mt-3 h-4 w-48 rounded" />
+        </div>
+      ) : data?.summary ? (
+        <div
+          className={cn(
+            "rounded-2xl border p-6 text-center",
+            statusConfig?.cls.replace(/text-\S+/, ""),
+            "bg-card",
+          )}
+        >
+          <p className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+            Current HRV (RMSSD)
+          </p>
+          <p
+            className={cn(
+              "mt-1 text-5xl font-bold",
+              data.status === "recovered"
+                ? "text-green-400"
+                : data.status === "recovering"
+                  ? "text-yellow-400"
+                  : data.status === "strained"
+                    ? "text-red-400"
+                    : "text-zinc-400",
+            )}
+          >
+            {data.summary.current.toFixed(0)}
+          </p>
+          <p className="text-muted-foreground mt-1 text-sm">ms</p>
+          {data.summary.deviationFromBaseline !== null && (
+            <p className="mt-2 text-sm">
+              <span
+                className={cn(
+                  "font-semibold",
+                  data.summary.deviationFromBaseline >= 0
+                    ? "text-green-400"
+                    : "text-red-400",
+                )}
+              >
+                {data.summary.deviationFromBaseline >= 0 ? "+" : ""}
+                {data.summary.deviationFromBaseline.toFixed(1)}%
+              </span>
+              <span className="text-muted-foreground"> from baseline</span>
+            </p>
+          )}
+          {statusConfig && (
+            <p className="text-muted-foreground mt-2 text-xs">
+              {statusConfig.description}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="bg-card rounded-2xl border p-6 text-center">
+          <p className="text-muted-foreground text-sm">
+            No HRV data available yet. Wear your Garmin device while sleeping to
+            collect HRV measurements.
+          </p>
+        </div>
+      )}
+
+      {/* ── Quick Stats Row ── */}
+      {data?.summary && (
+        <div className="grid grid-cols-4 gap-2">
+          <div className="bg-card rounded-xl border p-3 text-center">
+            <p className="text-muted-foreground text-[10px] font-medium uppercase">
+              Current
+            </p>
+            <p className="mt-1 text-lg font-bold">
+              {data.summary.current.toFixed(0)}
+            </p>
+          </div>
+          <div className="bg-card rounded-xl border p-3 text-center">
+            <p className="text-muted-foreground text-[10px] font-medium uppercase">
+              7d Avg
+            </p>
+            <p className="mt-1 text-lg font-bold">
+              {data.summary.avg7d.toFixed(0)}
+            </p>
+          </div>
+          <div className="bg-card rounded-xl border p-3 text-center">
+            <p className="text-muted-foreground text-[10px] font-medium uppercase">
+              Baseline
+            </p>
+            <p className="mt-1 text-lg font-bold">
+              {data.summary.baseline?.toFixed(0) ?? "—"}
+            </p>
+          </div>
+          <div className="bg-card rounded-xl border p-3 text-center">
+            <p className="text-muted-foreground text-[10px] font-medium uppercase">
+              CV%
+            </p>
+            <p
+              className={cn(
+                "mt-1 text-lg font-bold",
+                data.summary.cv > 15
+                  ? "text-red-400"
+                  : data.summary.cv > 10
+                    ? "text-yellow-400"
+                    : "text-green-400",
+              )}
+            >
+              {data.summary.cv.toFixed(1)}%
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Date Range Selector ── */}
+      <div className="flex justify-center gap-2">
+        {RANGE_OPTIONS.map((opt) => (
+          <button
+            key={opt.days}
+            onClick={() => setDays(opt.days)}
+            className={cn(
+              "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+              days === opt.days
+                ? "bg-blue-500 text-white"
+                : "bg-card text-muted-foreground border hover:text-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Main HRV Chart ── */}
+      {isLoading ? (
+        <div className="bg-card animate-pulse rounded-2xl border p-4">
+          <div className="bg-muted h-[260px] rounded" />
+        </div>
+      ) : chartData.length > 0 ? (
+        <div className="bg-card rounded-2xl border p-4">
+          <SectionHeader
+            title={`HRV Trend — ${data?.summary?.daysWithData ?? 0} readings`}
+            info="Heart Rate Variability (RMSSD) measured by your Garmin device during sleep. Higher HRV generally indicates better recovery and parasympathetic (rest-and-digest) nervous system activity. The 7-day rolling average smooths daily fluctuations, while the 14-day baseline represents your personal norm. Citation: Shaffer &amp; Ginsberg (2017). An Overview of HRV Metrics and Norms. Frontiers in Public Health."
+            className="mb-3"
+          />
+          <ResponsiveContainer width="100%" height={260}>
+            <ComposedChart
+              data={chartData}
+              margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id="hrvFill" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: "#888", fontSize: 10 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tick={{ fill: "#888", fontSize: 10 }}
+                width={36}
+                domain={["dataMin - 5", "dataMax + 5"]}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "#18181b",
+                  border: "1px solid #333",
+                  borderRadius: 8,
+                  fontSize: 12,
+                }}
+              />
+              {data?.baseline && (
+                <ReferenceLine
+                  y={data.baseline}
+                  stroke="#6366f1"
+                  strokeDasharray="6 3"
+                  strokeWidth={1.5}
+                  label={{
+                    value: `Baseline ${data.baseline.toFixed(0)}`,
+                    position: "insideTopRight",
+                    fill: "#6366f1",
+                    fontSize: 10,
+                  }}
+                />
+              )}
+              <Area
+                type="monotone"
+                dataKey="daily"
+                stroke="#22c55e"
+                fill="url(#hrvFill)"
+                strokeWidth={1}
+                name="Daily HRV"
+                dot={{ fill: "#22c55e", r: 2 }}
+                connectNulls
+              />
+              <Line
+                type="monotone"
+                dataKey="rolling7d"
+                stroke="#3b82f6"
+                strokeWidth={2.5}
+                dot={false}
+                name="7d Average"
+                connectNulls
+              />
+              <Line
+                type="monotone"
+                dataKey="rolling14d"
+                stroke="#6366f1"
+                strokeWidth={1.5}
+                strokeDasharray="6 3"
+                dot={false}
+                name="14d Baseline"
+                connectNulls
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      ) : null}
+
+      {/* ── CV% Trend Chart ── */}
+      {cvData.length > 0 && (
+        <div className="bg-card rounded-2xl border p-4">
+          <SectionHeader
+            title="HRV Variability (CV%)"
+            info="Coefficient of Variation (CV%) measures how consistent your HRV is over a rolling 7-day window. CV% = standard deviation / mean × 100. Below 10% indicates stable, consistent recovery. 10-15% is moderate. Above 15% suggests high stress or inconsistent recovery patterns. Citation: Plews et al. (2013). Training Adaptation and Heart Rate Variability in Elite Endurance Athletes. Int J Sports Physiol Perform."
+            className="mb-3"
+          />
+          <ResponsiveContainer width="100%" height={140}>
+            <ComposedChart
+              data={cvData}
+              margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: "#888", fontSize: 10 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tick={{ fill: "#888", fontSize: 10 }}
+                width={36}
+                domain={[0, "dataMax + 5"]}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "#18181b",
+                  border: "1px solid #333",
+                  borderRadius: 8,
+                  fontSize: 12,
+                }}
+                formatter={(value: number) => [`${value.toFixed(1)}%`, "CV%"]}
+              />
+              <ReferenceLine
+                y={10}
+                stroke="#22c55e"
+                strokeDasharray="4 2"
+                strokeWidth={1}
+              />
+              <ReferenceLine
+                y={15}
+                stroke="#ef4444"
+                strokeDasharray="4 2"
+                strokeWidth={1}
+              />
+              <Line
+                type="monotone"
+                dataKey="cv"
+                stroke="#f59e0b"
+                strokeWidth={2}
+                dot={false}
+                name="CV%"
+                connectNulls
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+          <div className="mt-2 flex justify-center gap-4 text-[10px]">
+            <span className="text-green-400">● &lt;10% Stable</span>
+            <span className="text-yellow-400">● 10–15% Moderate</span>
+            <span className="text-red-400">● &gt;15% High</span>
+          </div>
+        </div>
+      )}
+
+      {/* ── Range Summary ── */}
+      {data?.summary && (
+        <div className="bg-card rounded-2xl border p-4">
+          <SectionHeader
+            title="Period Summary"
+            info="Summary statistics for the selected date range. Min/Max show the full range of your HRV values. Days with data indicates measurement consistency — aim for daily readings for the most reliable analysis."
+            className="mb-3"
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-muted/50 rounded-lg p-3">
+              <p className="text-muted-foreground text-[10px] font-medium uppercase">
+                Min
+              </p>
+              <p className="text-lg font-bold">
+                {data.summary.min.toFixed(0)}{" "}
+                <span className="text-muted-foreground text-xs">ms</span>
+              </p>
+            </div>
+            <div className="bg-muted/50 rounded-lg p-3">
+              <p className="text-muted-foreground text-[10px] font-medium uppercase">
+                Max
+              </p>
+              <p className="text-lg font-bold">
+                {data.summary.max.toFixed(0)}{" "}
+                <span className="text-muted-foreground text-xs">ms</span>
+              </p>
+            </div>
+            <div className="bg-muted/50 rounded-lg p-3">
+              <p className="text-muted-foreground text-[10px] font-medium uppercase">
+                Days with Data
+              </p>
+              <p className="text-lg font-bold">{data.summary.daysWithData}</p>
+            </div>
+            <div className="bg-muted/50 rounded-lg p-3">
+              <p className="text-muted-foreground text-[10px] font-medium uppercase">
+                Coverage
+              </p>
+              <p className="text-lg font-bold">
+                {Math.round((data.summary.daysWithData / days) * 100)}%
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <BottomNav />
+    </main>
+  );
+}

--- a/apps/nextjs/src/app/settings/page.tsx
+++ b/apps/nextjs/src/app/settings/page.tsx
@@ -738,7 +738,7 @@ function GarminConnection() {
           size="sm"
           onClick={handleRecompute}
           disabled={recomputing || !status?.connected}
-          className="bg-purple-600 hover:bg-purple-700 disabled:opacity-50 border-purple-600 text-white"
+          className="border-purple-600 bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-50"
         >
           {recomputing ? "Computing..." : "🔄 Recompute Metrics"}
         </Button>

--- a/apps/nextjs/src/app/settings/page.tsx
+++ b/apps/nextjs/src/app/settings/page.tsx
@@ -556,6 +556,28 @@ function GarminConnection() {
     }
   };
 
+  const [recomputing, setRecomputing] = useState(false);
+
+  const handleRecompute = async () => {
+    setRecomputing(true);
+    try {
+      const res = await fetch(apiUrl("/api/garmin/recompute"), {
+        method: "POST",
+      });
+      const data = (await res.json()) as {
+        success: boolean;
+        message?: string;
+      };
+      if (!data.success) {
+        setError(data.message ?? "Failed to start recompute");
+      }
+    } catch {
+      setError("Failed to trigger recompute");
+    } finally {
+      setRecomputing(false);
+    }
+  };
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -711,6 +733,15 @@ function GarminConnection() {
             {triggeringSyncState ? "Starting..." : "🔄 Sync Now"}
           </Button>
         )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRecompute}
+          disabled={recomputing || !status?.connected}
+          className="bg-purple-600 hover:bg-purple-700 disabled:opacity-50 border-purple-600 text-white"
+        >
+          {recomputing ? "Computing..." : "🔄 Recompute Metrics"}
+        </Button>
         {error && <p className="text-xs text-red-500">{error}</p>}
         <Button
           variant="outline"

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -100,9 +100,13 @@ export default function SleepDashboard() {
   // ---- Data queries ----
   const coach = useQuery(trpc.sleep.getCoach.queryOptions());
 
-  const stages = useQuery(trpc.sleep.getStages.queryOptions({ days: sleepDays }));
+  const stages = useQuery(
+    trpc.sleep.getStages.queryOptions({ days: sleepDays }),
+  );
 
-  const history = useQuery(trpc.sleep.getHistory.queryOptions({ days: sleepDays }));
+  const history = useQuery(
+    trpc.sleep.getHistory.queryOptions({ days: sleepDays }),
+  );
 
   // ---- Derived: Key stats ----
   const stats = useMemo(() => {

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Bar,
@@ -21,6 +21,7 @@ import { cn } from "@acme/ui";
 import { IngressLink as Link } from "~/app/_components/ingress-link";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
+import { DateRangeSelector } from "../_components/date-range-selector";
 import { SectionHeader } from "../_components/info-button";
 
 // ---------------------------------------------------------------------------
@@ -94,13 +95,14 @@ function debtTextColor(debt: number): string {
 
 export default function SleepDashboard() {
   const trpc = useTRPC();
+  const [sleepDays, setSleepDays] = useState(28);
 
   // ---- Data queries ----
   const coach = useQuery(trpc.sleep.getCoach.queryOptions());
 
-  const stages = useQuery(trpc.sleep.getStages.queryOptions({ days: 14 }));
+  const stages = useQuery(trpc.sleep.getStages.queryOptions({ days: sleepDays }));
 
-  const history = useQuery(trpc.sleep.getHistory.queryOptions({ days: 28 }));
+  const history = useQuery(trpc.sleep.getHistory.queryOptions({ days: sleepDays }));
 
   // ---- Derived: Key stats ----
   const stats = useMemo(() => {
@@ -290,6 +292,9 @@ export default function SleepDashboard() {
           Your sleep insights &amp; coaching
         </p>
       </div>
+
+      {/* ── Date Range ── */}
+      <DateRangeSelector value={sleepDays} onChange={setSleepDays} />
 
       {coach.isLoading ? (
         <div className="bg-card animate-pulse rounded-2xl border p-6">

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -298,7 +298,16 @@ export default function SleepDashboard() {
       </div>
 
       {/* ── Date Range ── */}
-      <DateRangeSelector value={sleepDays} onChange={setSleepDays} />
+      <DateRangeSelector
+        value={sleepDays}
+        onChange={setSleepDays}
+        presets={[
+          { label: "7d", days: 7 },
+          { label: "14d", days: 14 },
+          { label: "28d", days: 28 },
+          { label: "90d", days: 90 },
+        ]}
+      />
 
       {coach.isLoading ? (
         <div className="bg-card animate-pulse rounded-2xl border p-6">

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -24,6 +24,7 @@ import { cn } from "@acme/ui";
 
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
+import { DateRangeSelector } from "../_components/date-range-selector";
 import { SectionHeader } from "../_components/info-button";
 
 /* ─────────────── constants ─────────────── */
@@ -57,7 +58,7 @@ function acwrStatus(value: number): { label: string; color: string } {
 
 export default function TrainingLoadPage() {
   const trpc = useTRPC();
-  const [pmcDays, setPmcDays] = useState<42 | 90 | 180>(90);
+  const [pmcDays, setPmcDays] = useState(90);
 
   const loads = useQuery(trpc.analytics.getTrainingLoads.queryOptions());
   const status = useQuery(trpc.analytics.getTrainingStatus.queryOptions());
@@ -138,22 +139,15 @@ export default function TrainingLoadPage() {
             title="Performance Management Chart"
             info="CTL (Chronic Training Load) = fitness built over 42 days. ATL (Acute Training Load) = fatigue over 7 days. TSB (Training Stress Balance) = CTL - ATL = form. ACWR (Acute:Chronic Workload Ratio) = optimal 0.8–1.3. Citation: Banister (1991), Hulin et al. (2016)."
           />
-          <div className="flex gap-1">
-            {([42, 90, 180] as const).map((d) => (
-              <button
-                key={d}
-                onClick={() => setPmcDays(d)}
-                className={cn(
-                  "rounded-lg px-2 py-1 text-[10px] font-semibold transition-all",
-                  pmcDays === d
-                    ? "bg-primary/20 text-primary"
-                    : "text-muted-foreground hover:bg-secondary/50",
-                )}
-              >
-                {d}d
-              </button>
-            ))}
-          </div>
+          <DateRangeSelector
+            value={pmcDays}
+            onChange={setPmcDays}
+            presets={[
+              { label: "42d", days: 42 },
+              { label: "90d", days: 90 },
+              { label: "180d", days: 180 },
+            ]}
+          />
         </div>
 
         {pmcData.isLoading ? (

--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -6,6 +6,7 @@ import { baselinesRouter } from "./router/baselines";
 import { chatRouter } from "./router/chat";
 import { dataQualityRouter } from "./router/data-quality";
 import { garminRouter } from "./router/garmin";
+import { hrvRouter } from "./router/hrv";
 import { interventionRouter } from "./router/intervention";
 import { journalRouter } from "./router/journal";
 import { postRouter } from "./router/post";
@@ -29,6 +30,7 @@ export const appRouter = createTRPCRouter({
   chat: chatRouter,
   dataQuality: dataQualityRouter,
   garmin: garminRouter,
+  hrv: hrvRouter,
   intervention: interventionRouter,
   journal: journalRouter,
   post: postRouter,

--- a/packages/api/src/router/hrv.ts
+++ b/packages/api/src/router/hrv.ts
@@ -1,0 +1,121 @@
+import type { TRPCRouterRecord } from "@trpc/server";
+import { z } from "zod/v4";
+
+import { and, asc, eq, gte } from "@acme/db";
+import { DailyMetric } from "@acme/db/schema";
+
+import { protectedProcedure } from "../trpc";
+
+function getDateString(daysAgo: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return d.toISOString().split("T")[0]!;
+}
+
+export const hrvRouter = {
+  /** Full HRV analysis: daily values, rolling averages, baseline, CV% */
+  getAnalysis: protectedProcedure
+    .input(z.object({ days: z.number().min(7).max(365).default(90) }))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const since = getDateString(input.days);
+
+      const metrics = await ctx.db.query.DailyMetric.findMany({
+        where: and(
+          eq(DailyMetric.userId, userId),
+          gte(DailyMetric.date, since),
+        ),
+        orderBy: asc(DailyMetric.date),
+      });
+
+      const hrvData = metrics
+        .filter((m) => m.hrv !== null)
+        .map((m) => ({ date: m.date, value: m.hrv! }));
+
+      if (hrvData.length === 0) {
+        return {
+          daily: [],
+          rolling7d: [],
+          rolling14d: [],
+          baseline: null,
+          cv: null,
+          status: "insufficient_data" as const,
+          summary: null,
+        };
+      }
+
+      // Compute rolling averages
+      const rolling7d = computeRolling(hrvData, 7);
+      const rolling14d = computeRolling(hrvData, 14);
+
+      // Baseline = 14-day rolling average of the latest value
+      const baseline =
+        rolling14d.length > 0
+          ? rolling14d[rolling14d.length - 1]!.value
+          : null;
+
+      // CV% over last 7 days (coefficient of variation = std/mean * 100)
+      const last7 = hrvData.slice(-7);
+      const mean7 = last7.reduce((s, d) => s + d.value, 0) / last7.length;
+      const std7 = Math.sqrt(
+        last7.reduce((s, d) => s + (d.value - mean7) ** 2, 0) / last7.length,
+      );
+      const cv = Math.round((std7 / mean7) * 1000) / 10; // one decimal
+
+      // Recovery status
+      const latestHrv = hrvData[hrvData.length - 1]!.value;
+      const status = determineRecoveryStatus(latestHrv, baseline, cv);
+
+      // Summary stats
+      const allValues = hrvData.map((d) => d.value);
+      const summary = {
+        current: latestHrv,
+        avg7d: Math.round(mean7 * 10) / 10,
+        baseline: baseline ? Math.round(baseline * 10) / 10 : null,
+        cv,
+        min: Math.round(Math.min(...allValues) * 10) / 10,
+        max: Math.round(Math.max(...allValues) * 10) / 10,
+        daysWithData: hrvData.length,
+        deviationFromBaseline: baseline
+          ? Math.round(((latestHrv - baseline) / baseline) * 1000) / 10
+          : null,
+      };
+
+      return {
+        daily: hrvData,
+        rolling7d,
+        rolling14d,
+        baseline,
+        cv,
+        status,
+        summary,
+      };
+    }),
+} satisfies TRPCRouterRecord;
+
+function computeRolling(
+  data: { date: string; value: number }[],
+  window: number,
+): { date: string; value: number }[] {
+  const result: { date: string; value: number }[] = [];
+  for (let i = window - 1; i < data.length; i++) {
+    const windowData = data.slice(i - window + 1, i + 1);
+    const avg =
+      windowData.reduce((s, d) => s + d.value, 0) / windowData.length;
+    result.push({ date: data[i]!.date, value: Math.round(avg * 10) / 10 });
+  }
+  return result;
+}
+
+function determineRecoveryStatus(
+  current: number,
+  baseline: number | null,
+  cv: number,
+): "recovered" | "recovering" | "strained" | "insufficient_data" {
+  if (!baseline) return "insufficient_data";
+  const deviation = ((current - baseline) / baseline) * 100;
+  if (cv > 15) return "strained"; // high variability = stressed
+  if (deviation >= 5) return "recovered"; // above baseline
+  if (deviation >= -5) return "recovering"; // within 5% of baseline
+  return "strained"; // below baseline
+}

--- a/packages/api/src/router/hrv.ts
+++ b/packages/api/src/router/hrv.ts
@@ -50,9 +50,7 @@ export const hrvRouter = {
 
       // Baseline = 14-day rolling average of the latest value
       const baseline =
-        rolling14d.length > 0
-          ? rolling14d[rolling14d.length - 1]!.value
-          : null;
+        rolling14d.length > 0 ? rolling14d[rolling14d.length - 1]!.value : null;
 
       // CV% over last 7 days (coefficient of variation = std/mean * 100)
       const last7 = hrvData.slice(-7);
@@ -100,8 +98,7 @@ function computeRolling(
   const result: { date: string; value: number }[] = [];
   for (let i = window - 1; i < data.length; i++) {
     const windowData = data.slice(i - window + 1, i + 1);
-    const avg =
-      windowData.reduce((s, d) => s + d.value, 0) / windowData.length;
+    const avg = windowData.reduce((s, d) => s + d.value, 0) / windowData.length;
     result.push({ date: data[i]!.date, value: Math.round(avg * 10) / 10 });
   }
   return result;

--- a/packages/api/src/router/hrv.ts
+++ b/packages/api/src/router/hrv.ts
@@ -58,7 +58,7 @@ export const hrvRouter = {
       const std7 = Math.sqrt(
         last7.reduce((s, d) => s + (d.value - mean7) ** 2, 0) / last7.length,
       );
-      const cv = Math.round((std7 / mean7) * 1000) / 10; // one decimal
+      const cv = mean7 > 0 ? Math.round((std7 / mean7) * 1000) / 10 : 0; // one decimal
 
       // Recovery status
       const latestHrv = hrvData[hrvData.length - 1]!.value;
@@ -109,7 +109,7 @@ function determineRecoveryStatus(
   baseline: number | null,
   cv: number,
 ): "recovered" | "recovering" | "strained" | "insufficient_data" {
-  if (!baseline) return "insufficient_data";
+  if (baseline == null) return "insufficient_data";
   const deviation = ((current - baseline) / baseline) * 100;
   if (cv > 15) return "strained"; // high variability = stressed
   if (deviation >= 5) return "recovered"; // above baseline


### PR DESCRIPTION
## Features

### P3: HRV Trend Analysis (`/hrv` page)
- New tRPC router: `hrv.getAnalysis` — daily HRV, 7d/14d rolling averages, baseline, coefficient of variation (CV%), recovery status
- Full analysis page with:
  - Color-coded recovery status card (recovered/recovering/strained)
  - Quick stats: Current HRV, 7d avg, 14d baseline, CV%
  - ComposedChart with daily values, rolling averages, baseline reference
  - CV% trend chart with zone indicators
  - Date range selector (30d–365d)
- Added to bottom nav (replaced Zones) and hamburger menu

### P4: Chart Date-Range Consistency
- New shared `<DateRangeSelector>` component with preset buttons
- Applied to fitness, training, and sleep pages
- Replaces hardcoded date ranges with user-selectable presets

### P4: Recompute Metrics Button
- New API route: `POST /api/garmin/recompute` → proxies to addon auth server
- Purple "Recompute Metrics" button in Settings (next to Sync Now)
- Status polling and error handling

### P5: Enhanced Export
- Added Advanced Metrics CSV export (CTL/ATL/TSB/ACWR)
- Added HRV Analysis CSV export (daily + rolling avg + CV%)
- Full JSON backup bumped to schema v1.1 with all new data