### PR TITLE
fix: aggregate strain by calendar day before ACWR/CTL/ATL compute (#89)

### DIFF
--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -32,6 +32,46 @@ function getDateString(daysAgo: number): string {
   return d.toISOString().split("T")[0]!;
 }
 
+/**
+ * Aggregate per-activity strain scores into a per-day chronological series.
+ *
+ * The engine helpers (`computeACWR`, `computeACWR_EWMA`, `computeTrainingLoads`)
+ * all expect a per-CALENDAR-DAY array. Feeding them a per-activity array — as
+ * we did previously — produces ratios over the wrong domain (e.g., "ratio of
+ * the last 7 activities to the last 28 activities" instead of "ratio of the
+ * last 7 days to the last 28 days"). For an athlete doing doubles or strength
+ * + run the same day, this materially over- or under-estimates ACWR/CTL/ATL.
+ *
+ * Output conventions:
+ *   - `dailyLoadsChrono`  — index 0 = oldest, length = windowDays (zero-padded
+ *     for rest days). Consumed by `computeTrainingLoads` and
+ *     `computeACWR_EWMA`.
+ *   - `dailyLoadsRecent`  — index 0 = today/most recent. Consumed by
+ *     `computeACWR`.
+ */
+function aggregateDailyLoads(
+  activities: { startedAt: Date; strainScore: number | null; trimpScore: number | null }[],
+  windowDays: number,
+): { dailyLoadsChrono: number[]; dailyLoadsRecent: number[] } {
+  const byDay = new Map<string, number>();
+  for (const a of activities) {
+    const day = a.startedAt.toISOString().split("T")[0]!;
+    const s = a.strainScore ?? computeStrainScore(a.trimpScore ?? 0);
+    byDay.set(day, (byDay.get(day) ?? 0) + s);
+  }
+
+  const dailyLoadsRecent: number[] = [];
+  const today = new Date();
+  for (let i = 0; i < windowDays; i++) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    const key = d.toISOString().split("T")[0]!;
+    dailyLoadsRecent.push(byDay.get(key) ?? 0);
+  }
+  const dailyLoadsChrono = [...dailyLoadsRecent].reverse();
+  return { dailyLoadsChrono, dailyLoadsRecent };
+}
+
 export const analyticsRouter = {
   getTrainingLoads: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
@@ -44,13 +84,14 @@ export const analyticsRouter = {
       orderBy: desc(Activity.startedAt),
     });
 
-    const strainScores = recentActivities.map(
-      (a) => a.strainScore ?? computeStrainScore(a.trimpScore ?? 0),
+    const { dailyLoadsChrono, dailyLoadsRecent } = aggregateDailyLoads(
+      recentActivities,
+      42,
     );
 
-    const loadMetrics = computeTrainingLoads(strainScores);
-    const acwr = computeACWR(strainScores);
-    const acwrEwma = computeACWR_EWMA(strainScores);
+    const loadMetrics = computeTrainingLoads(dailyLoadsChrono);
+    const acwr = computeACWR(dailyLoadsRecent);
+    const acwrEwma = computeACWR_EWMA(dailyLoadsChrono);
     const loadFocus = classifyLoadFocus(recentActivities);
 
     return {
@@ -90,12 +131,13 @@ export const analyticsRouter = {
       orderBy: desc(Activity.startedAt),
     });
 
-    const strainScores = recentActivities.map(
-      (a) => a.strainScore ?? computeStrainScore(a.trimpScore ?? 0),
+    const { dailyLoadsChrono, dailyLoadsRecent } = aggregateDailyLoads(
+      recentActivities,
+      42,
     );
 
-    const loadMetrics = computeTrainingLoads(strainScores);
-    const acwr = computeACWR(strainScores);
+    const loadMetrics = computeTrainingLoads(dailyLoadsChrono);
+    const acwr = computeACWR(dailyLoadsRecent);
     const loadFocus = classifyLoadFocus(recentActivities);
 
     return classifyTrainingStatus(vo2maxTrend, {


### PR DESCRIPTION
Refs #89

## Root cause

`computeACWR`, `computeACWR_EWMA`, and `computeTrainingLoads` are documented to take **per-calendar-day load arrays**. The analytics router was feeding them **per-activity strain arrays** — three distinct bugs in one place:

| Engine helper | Expected input | Was receiving | Result |
|---|---|---|---|
| `computeACWR` | daily, recent-first | per-activity, recent-first | wrong domain |
| `computeACWR_EWMA` | daily, oldest-first | per-activity, recent-first | wrong domain **and** reversed |
| `computeTrainingLoads` | daily, oldest-first | per-activity, recent-first | wrong domain **and** reversed |

For an athlete who does doubles or strength+run on the same day, the gauge could read 1.6+ ACWR ("high injury risk") when the actual 7d/28d daily ratio was a healthy 1.1.

## Fix

New `aggregateDailyLoads()` helper that:
- sums strain by calendar day (handles doubles correctly)
- emits a zero-padded 42-day window (rest days count as 0)
- returns both `dailyLoadsChrono` (oldest-first) and `dailyLoadsRecent` (recent-first)

Both `getTrainingLoads` and `getTrainingStatus` now pass each engine helper the array shape its docstring promises.

## Bonus context discovered while fixing this

The dashboard chart reads from `AdvancedMetric` table, which is **only populated by the seed script** — there's no production cron writing to it. So in real installs the chart is stale/empty while the gauge is the only live source. Tracking that in #88 (data layer refactor).

## Verification
- `@acme/api` typecheck: ✅
- All 4 getTrainingLoads / getTrainingStatus tests pass ✅
- 2 pre-existing race-prediction test failures unrelated (same on main)
- Use `/debug` page (PR #93) to spot-check values