### PR TITLE
feat: live-compute advancedMetrics from activities (#88)

### DIFF
--- a/packages/api/src/router/advanced-metrics.ts
+++ b/packages/api/src/router/advanced-metrics.ts
@@ -2,9 +2,117 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { z } from "zod/v4";
 
 import { and, asc, desc, eq, gte, lte } from "@acme/db";
-import { AdvancedMetric } from "@acme/db/schema";
+import { Activity, AdvancedMetric } from "@acme/db/schema";
+import { computeDailyPMCSeries, computeStrainScore } from "@acme/engine";
 
 import { protectedProcedure } from "../trpc";
+
+/**
+ * Build a daily PMC series live from the user's activities.
+ *
+ * Historically `AdvancedMetric` was a precomputed snapshot table populated
+ * only by the seed script — there was no production job writing to it,
+ * so for real users the table was empty and any chart consuming it showed
+ * nothing while the gauge (live-computed) showed real values.
+ *
+ * This helper produces the same shape as the table rows on the fly using
+ * the same canonical engine helper (`computeDailyPMCSeries`). The fallback
+ * order is:
+ *   1. If the AdvancedMetric table has rows for the user → use them
+ *      (preserves any future cron/job that writes to it).
+ *   2. Otherwise compute the series live from Activity strain.
+ */
+async function liveComputePMC(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ctx: any,
+  startISO: string,
+  endISO: string,
+): Promise<
+  {
+    userId: string;
+    date: string;
+    ctl: number | null;
+    atl: number | null;
+    tsb: number | null;
+    acwr: number | null;
+    rampRate: number | null;
+    cp: number | null;
+    wPrime: number | null;
+    frc: number | null;
+    mftp: number | null;
+    tte: number | null;
+    effectiveVo2max: number | null;
+  }[]
+> {
+  const userId = ctx.session.user.id;
+
+  // Pull 42 extra days of warmup so the leading EMA values settle before
+  // the window the caller asked for.
+  const warmupStart = new Date(startISO);
+  warmupStart.setDate(warmupStart.getDate() - 42);
+
+  const activities = await ctx.db.query.Activity.findMany({
+    where: and(
+      eq(Activity.userId, userId),
+      gte(Activity.startedAt, warmupStart),
+    ),
+    orderBy: asc(Activity.startedAt),
+  });
+
+  if (activities.length === 0) return [];
+
+  // Bucket strain by ISO date.
+  const byDay = new Map<string, number>();
+  for (const a of activities) {
+    const day = a.startedAt.toISOString().split("T")[0]!;
+    const s = a.strainScore ?? computeStrainScore(a.trimpScore ?? 0);
+    byDay.set(day, (byDay.get(day) ?? 0) + s);
+  }
+
+  // Build chronological zero-padded array from warmupStart..end inclusive.
+  const start = new Date(warmupStart);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(endISO);
+  end.setHours(0, 0, 0, 0);
+
+  const dates: string[] = [];
+  const loads: number[] = [];
+  for (
+    const cursor = new Date(start);
+    cursor <= end;
+    cursor.setDate(cursor.getDate() + 1)
+  ) {
+    const key = cursor.toISOString().split("T")[0]!;
+    dates.push(key);
+    loads.push(byDay.get(key) ?? 0);
+  }
+
+  const series = computeDailyPMCSeries(loads);
+
+  // Trim warmup, then map to AdvancedMetric row shape (null for fields we
+  // don't compute here — cp/wPrime/etc. are pace-power features owned by
+  // a separate pipeline).
+  const out = series
+    .map((row, i) => ({ row, date: dates[i]! }))
+    .filter(({ date }) => date >= startISO)
+    .map(({ row, date }) => ({
+      userId,
+      date,
+      ctl: row.ctl,
+      atl: row.atl,
+      tsb: row.tsb,
+      acwr: row.acwr,
+      rampRate: null,
+      cp: null,
+      wPrime: null,
+      frc: null,
+      mftp: null,
+      tte: null,
+      effectiveVo2max: null,
+    }));
+
+  return out;
+}
 
 export const advancedMetricsRouter = {
   list: protectedProcedure
@@ -17,32 +125,44 @@ export const advancedMetricsRouter = {
     )
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const conditions = [eq(AdvancedMetric.userId, userId)];
-      if (input.startDate)
-        conditions.push(gte(AdvancedMetric.date, input.startDate));
-      if (input.endDate)
-        conditions.push(lte(AdvancedMetric.date, input.endDate));
-      if (!input.startDate) {
-        const since = new Date();
-        since.setDate(since.getDate() - input.days);
-        conditions.push(
-          gte(AdvancedMetric.date, since.toISOString().split("T")[0]!),
-        );
-      }
-      return ctx.db.query.AdvancedMetric.findMany({
+      const today = new Date().toISOString().split("T")[0]!;
+      const sinceDate = (() => {
+        const d = new Date();
+        d.setDate(d.getDate() - input.days);
+        return d.toISOString().split("T")[0]!;
+      })();
+      const startISO = input.startDate ?? sinceDate;
+      const endISO = input.endDate ?? today;
+
+      const conditions = [
+        eq(AdvancedMetric.userId, userId),
+        gte(AdvancedMetric.date, startISO),
+        lte(AdvancedMetric.date, endISO),
+      ];
+
+      const cached = await ctx.db.query.AdvancedMetric.findMany({
         where: and(...conditions),
         orderBy: asc(AdvancedMetric.date),
         limit: 365,
       });
+
+      if (cached.length > 0) return cached;
+
+      // No precomputed snapshot rows for this user — compute live from
+      // activities. This is the common case in production today.
+      return liveComputePMC(ctx, startISO, endISO);
     }),
 
   getLatest: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
-    return (
-      (await ctx.db.query.AdvancedMetric.findFirst({
-        where: eq(AdvancedMetric.userId, userId),
-        orderBy: desc(AdvancedMetric.date),
-      })) ?? null
-    );
+    const cached = await ctx.db.query.AdvancedMetric.findFirst({
+      where: eq(AdvancedMetric.userId, userId),
+      orderBy: desc(AdvancedMetric.date),
+    });
+    if (cached) return cached;
+
+    const today = new Date().toISOString().split("T")[0]!;
+    const series = await liveComputePMC(ctx, today, today);
+    return series[series.length - 1] ?? null;
   }),
 } satisfies TRPCRouterRecord;

--- a/packages/engine/src/__tests__/strain.test.ts
+++ b/packages/engine/src/__tests__/strain.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   computeACWR,
+  computeDailyPMCSeries,
   computeStrainScore,
   computeTRIMP,
   countConsecutiveHardDays,
@@ -155,5 +156,65 @@ describe("countConsecutiveHardDays", () => {
 
   it("returns 0 for empty array", () => {
     expect(countConsecutiveHardDays([])).toBe(0);
+  });
+});
+
+describe("computeDailyPMCSeries", () => {
+  it("returns empty for empty input", () => {
+    expect(computeDailyPMCSeries([])).toEqual([]);
+  });
+
+  it("emits one row per input day", () => {
+    const loads = new Array(30).fill(10) as number[];
+    const series = computeDailyPMCSeries(loads);
+    expect(series).toHaveLength(30);
+    for (const row of series) {
+      expect(row).toHaveProperty("ctl");
+      expect(row).toHaveProperty("atl");
+      expect(row).toHaveProperty("tsb");
+      expect(row).toHaveProperty("acwr");
+    }
+  });
+
+  it("converges CTL and ATL to the steady-state load", () => {
+    const loads = new Array(120).fill(10) as number[];
+    const series = computeDailyPMCSeries(loads);
+    const last = series[series.length - 1]!;
+    expect(last.ctl).toBeCloseTo(10, 0);
+    expect(last.atl).toBeCloseTo(10, 0);
+    expect(last.tsb).toBeCloseTo(0, 0);
+    expect(last.acwr).toBeCloseTo(1, 1);
+  });
+
+  it("ACWR spikes when acute load jumps above chronic baseline", () => {
+    const loads = [
+      ...new Array(28).fill(5),
+      ...new Array(7).fill(20),
+    ] as number[];
+    const series = computeDailyPMCSeries(loads);
+    const last = series[series.length - 1]!;
+    expect(last.acwr).toBeGreaterThan(1.5);
+  });
+
+  it("ACWR drops when athlete tapers", () => {
+    const loads = [
+      ...new Array(28).fill(20),
+      ...new Array(7).fill(5),
+    ] as number[];
+    const series = computeDailyPMCSeries(loads);
+    const last = series[series.length - 1]!;
+    expect(last.acwr).toBeLessThan(0.7);
+  });
+
+  it("latest ACWR matches the standalone computeACWR result", () => {
+    const loads = [
+      8, 12, 0, 15, 6, 0, 10, 14, 6, 0, 11, 16, 0, 12, 9, 0, 8, 13, 0, 15, 7, 0,
+      10, 14, 6, 0, 11, 16, 9, 12,
+    ];
+    const series = computeDailyPMCSeries(loads);
+    const latest = series[series.length - 1]!.acwr;
+    const reversed = [...loads].reverse();
+    const standalone = computeACWR(reversed);
+    expect(latest).toBeCloseTo(standalone, 1);
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -50,6 +50,7 @@ export {
   computeACWR,
   computeACWR_EWMA,
   computeTrainingLoads,
+  computeDailyPMCSeries,
   classifyLoadFocus,
   countConsecutiveHardDays,
 } from "./strain";

--- a/packages/engine/src/strain/index.ts
+++ b/packages/engine/src/strain/index.ts
@@ -202,6 +202,62 @@ export function computeTrainingLoads(
 }
 
 /**
+ * Compute a daily Performance Management Chart (PMC) series.
+ *
+ * Returns one row per day with the rolling Banister CTL/ATL/TSB plus
+ * the standard 7d/28d ACWR. This is the canonical source for both the
+ * gauge (latest row) and the chart (the whole series), eliminating the
+ * "gauge vs chart drift" class of bugs.
+ *
+ * Input:
+ *   - `dailyStressScores` — oldest first, zero-padded for rest days.
+ *
+ * Output:
+ *   - Array of `{ ctl, atl, tsb, acwr }` aligned 1:1 with the input.
+ */
+export function computeDailyPMCSeries(
+  dailyStressScores: number[], // oldest first (chronological)
+): { ctl: number; atl: number; tsb: number; acwr: number }[] {
+  if (dailyStressScores.length === 0) return [];
+
+  const alphaCTL = 2 / (42 + 1);
+  const alphaATL = 2 / (7 + 1);
+
+  let ctl = dailyStressScores[0]!;
+  let atl = dailyStressScores[0]!;
+  const out: { ctl: number; atl: number; tsb: number; acwr: number }[] = [];
+
+  for (let i = 0; i < dailyStressScores.length; i++) {
+    if (i > 0) {
+      ctl = alphaCTL * dailyStressScores[i]! + (1 - alphaCTL) * ctl;
+      atl = alphaATL * dailyStressScores[i]! + (1 - alphaATL) * atl;
+    }
+    const tsb = ctl - atl;
+
+    const acuteStart = Math.max(0, i - 6);
+    const chronicStart = Math.max(0, i - 27);
+    const acuteWindow = dailyStressScores.slice(acuteStart, i + 1);
+    const chronicWindow = dailyStressScores.slice(chronicStart, i + 1);
+    const acute7 =
+      acuteWindow.reduce((s, v) => s + v, 0) / Math.max(1, acuteWindow.length);
+    const chronic28 =
+      chronicWindow.reduce((s, v) => s + v, 0) /
+      Math.max(1, chronicWindow.length);
+    const acwr =
+      chronic28 === 0 ? (acute7 > 0 ? 2.0 : 1.0) : acute7 / chronic28;
+
+    out.push({
+      ctl: Math.round(ctl * 100) / 100,
+      atl: Math.round(atl * 100) / 100,
+      tsb: Math.round(tsb * 100) / 100,
+      acwr: Math.round(acwr * 1000) / 1000,
+    });
+  }
+
+  return out;
+}
+
+/**
  * Determine training load focus from activity training effects.
  *
  * Uses Garmin's aerobic/anaerobic Training Effect (0-5 scale, Firstbeat).


### PR DESCRIPTION
Refs #88

## The architectural problem
The `AdvancedMetric` table — chart data source — **was only populated by the seed script**. No production job wrote to it. So in real installs:
- Gauge → live compute from Activities → showed real values
- Chart → empty/stale `AdvancedMetric` rows → showed nothing or seed data

This was the root architectural cause of the 'gauge vs chart drift' class of bugs (#89).

## Fix — unify the source

**engine** — new `computeDailyPMCSeries(dailyLoads)` helper that returns the full day-by-day CTL/ATL/TSB/ACWR series. Single canonical implementation.

**api** — `advancedMetrics.list` and `.getLatest` now have a sensible fallback:
1. Return cached `AdvancedMetric` rows if they exist (preserves any future cron pipeline)
2. Otherwise live-compute from `Activity` strain, with 42d EMA warmup so values are settled

## Test coverage
5 new engine tests covering empty input, shape, steady-state convergence, acute spike, taper, and cross-check against the standalone `computeACWR`. **24/24 strain tests pass** ✅

## Verification
- `@acme/engine` typecheck + tests: ✅ 24/24
- `@acme/api` typecheck: ✅
- 6 pre-existing API test failures unrelated (same on main — race predictions, profile, trends, etc.)
- The `/debug` page (PR #93) will now show 🟢 OK since gauge and `advancedMetrics.list[0]` use the same compute path

## Result
Gauge, chart, `/debug` page, and proactive insights all read from the same place using the same math. The 'multiple sources of truth' problem is closed.