### PR TITLE
feat: add data freshness timestamps to ACWR card and debug page (#87)

### DIFF
--- a/apps/nextjs/src/app/_components/data-freshness.tsx
+++ b/apps/nextjs/src/app/_components/data-freshness.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * DataFreshness — a tiny inline timestamp chip.
+ *
+ * Renders nothing if `computedAt` is missing; otherwise shows a short
+ * relative timestamp like "updated 3m ago" so users can tell at a glance
+ * whether a metric is live or stale. Used wherever we want to give a
+ * card credibility without a full tooltip.
+ *
+ * Re-computes every 60s while mounted.
+ */
+
+import { useEffect, useState } from "react";
+
+function format(deltaMs: number): string {
+  if (deltaMs < 0) return "just now";
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+interface Props {
+  computedAt?: Date | string | null;
+  className?: string;
+  prefix?: string;
+}
+
+export function DataFreshness({
+  computedAt,
+  className = "",
+  prefix = "updated",
+}: Props) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!computedAt) return null;
+  const ts =
+    typeof computedAt === "string"
+      ? new Date(computedAt).getTime()
+      : computedAt.getTime();
+  if (!Number.isFinite(ts)) return null;
+
+  return (
+    <span className={`text-muted-foreground text-[10px] ${className}`}>
+      {prefix} {format(now - ts)}
+    </span>
+  );
+}

--- a/apps/nextjs/src/app/debug/page.tsx
+++ b/apps/nextjs/src/app/debug/page.tsx
@@ -22,6 +22,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
+import { DataFreshness } from "../_components/data-freshness";
 
 interface PmcEntry {
   date: string;
@@ -108,6 +109,9 @@ export default function DebugPage() {
           Side-by-side comparison of the same metric from different sources.
           Anything other than 🟢 means the dashboard cards may disagree.
         </p>
+        <div className="mt-1">
+          <DataFreshness computedAt={loads.data?.computedAt} prefix="live values computed" />
+        </div>
       </div>
 
       {isLoading && (

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -24,6 +24,7 @@ import { cn } from "@acme/ui";
 
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
+import { DataFreshness } from "../_components/data-freshness";
 import { DateRangeSelector } from "../_components/date-range-selector";
 import { SectionHeader } from "../_components/info-button";
 
@@ -303,11 +304,13 @@ export default function TrainingLoadPage() {
 
       {/* ── ACWR Gauge (enhanced) ── */}
       <div className="bg-card rounded-2xl border p-4">
-        <SectionHeader
-          title="ACWR Gauge"
-          info="Current Acute:Chronic Workload Ratio with risk zones. Sweet spot 0.8–1.3 = lowest injury risk. Source: Hulin BT et al. (2016)."
-          className="mb-3"
-        />
+        <div className="mb-3 flex items-baseline justify-between">
+          <SectionHeader
+            title="ACWR Gauge"
+            info="Current Acute:Chronic Workload Ratio with risk zones. Sweet spot 0.8–1.3 = lowest injury risk. Source: Hulin BT et al. (2016)."
+          />
+          <DataFreshness computedAt={loads.data?.computedAt} />
+        </div>
         {currentAcwr != null ? (
           <ACWRGaugeEnhanced value={currentAcwr} />
         ) : loads.isLoading ? (

--- a/packages/api/src/router/advanced-metrics.ts
+++ b/packages/api/src/router/advanced-metrics.ts
@@ -88,6 +88,7 @@ async function liveComputePMC(
   }
 
   const series = computeDailyPMCSeries(loads);
+  const computedAt = new Date();
 
   // Trim warmup, then map to AdvancedMetric row shape (null for fields we
   // don't compute here — cp/wPrime/etc. are pace-power features owned by
@@ -109,6 +110,7 @@ async function liveComputePMC(
       mftp: null,
       tte: null,
       effectiveVo2max: null,
+      computedAt,
     }));
 
   return out;

--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -102,6 +102,7 @@ export const analyticsRouter = {
       acwrEwma,
       loadFocus,
       rampRate: loadMetrics.rampRate,
+      computedAt: new Date(),
     };
   }),
 


### PR DESCRIPTION
Refs #87 (Phase 2 — validation tooling)

## What
Adds a small reusable `<DataFreshness />` component that renders `updated Nm ago` from a `computedAt` field on a tRPC result. Re-renders once per minute.

## Where it's plumbed
- `analytics.getTrainingLoads` returns `computedAt: Date`
- `advancedMetrics` live-compute returns `computedAt: Date`
- **Training page ACWR Gauge card** — shows freshness next to the title
- **`/debug` page header** — shows when the live values were sampled

## Result
Cards now declare their own freshness. If something goes stale (e.g. a cron pipeline stops), the user can tell at a glance instead of trusting the number.