### PR TITLE
feat(analytics): respect Profile.timezone when bucketing daily loads

### DIFF
--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { dayInTimezone, shiftIsoDay } from "../router/analytics";
+import { dayInTimezone, shiftIsoDay } from "../lib/timezone";
 
 describe("dayInTimezone", () => {
   it("renders YYYY-MM-DD in UTC by default", () => {

--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { dayInTimezone, shiftIsoDay } from "../router/analytics";
+
+describe("dayInTimezone", () => {
+  it("renders YYYY-MM-DD in UTC by default", () => {
+    const d = new Date("2026-04-15T10:00:00Z");
+    expect(dayInTimezone(d, undefined)).toBe("2026-04-15");
+    expect(dayInTimezone(d, null)).toBe("2026-04-15");
+    expect(dayInTimezone(d, "")).toBe("2026-04-15");
+    expect(dayInTimezone(d, "UTC")).toBe("2026-04-15");
+  });
+
+  it("rolls forward to the next day for east-of-UTC zones", () => {
+    // 23:30 UTC on Jan 14 is 10:30 next-day in Sydney (UTC+11 in summer).
+    const lateUtc = new Date("2026-01-14T23:30:00Z");
+    expect(dayInTimezone(lateUtc, "Australia/Sydney")).toBe("2026-01-15");
+  });
+
+  it("stays on the prior day for west-of-UTC zones", () => {
+    // 02:30 UTC on Jan 15 is 18:30 PRIOR day in Los Angeles (UTC-8).
+    const earlyUtc = new Date("2026-01-15T02:30:00Z");
+    expect(dayInTimezone(earlyUtc, "America/Los_Angeles")).toBe("2026-01-14");
+  });
+
+  it("falls back to UTC when given an invalid timezone", () => {
+    const d = new Date("2026-04-15T10:00:00Z");
+    expect(dayInTimezone(d, "Mars/Olympus_Mons")).toBe("2026-04-15");
+  });
+});
+
+describe("shiftIsoDay", () => {
+  it("steps backwards across a month boundary", () => {
+    expect(shiftIsoDay("2026-03-02", -3)).toBe("2026-02-27");
+  });
+
+  it("steps backwards across a year boundary", () => {
+    expect(shiftIsoDay("2026-01-01", -1)).toBe("2025-12-31");
+  });
+
+  it("is a no-op for delta=0", () => {
+    expect(shiftIsoDay("2026-06-15", 0)).toBe("2026-06-15");
+  });
+
+  it("steps forwards", () => {
+    expect(shiftIsoDay("2026-06-15", 7)).toBe("2026-06-22");
+  });
+
+  it("survives DST spring-forward (US, Mar 9 2026)", () => {
+    // Anchoring at noon UTC means the +/- 1h skip never crosses local midnight.
+    expect(shiftIsoDay("2026-03-08", 1)).toBe("2026-03-09");
+    expect(shiftIsoDay("2026-03-09", -1)).toBe("2026-03-08");
+  });
+});

--- a/packages/api/src/lib/timezone.ts
+++ b/packages/api/src/lib/timezone.ts
@@ -1,0 +1,68 @@
+/**
+ * Timezone-aware ISO date helpers used by analytics aggregation.
+ *
+ * Lives in `lib/` so unit tests can import these helpers without pulling in
+ * the full analytics router (and its DB / engine imports).
+ */
+
+// Cache `Intl.DateTimeFormat` per zone — `aggregateDailyLoads` calls
+// `dayInTimezone` once per activity, and constructing a formatter is the
+// expensive part. The formatter itself is thread-safe (V8 builtin) and
+// stateless w.r.t. the input date.
+const FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(zone: string): Intl.DateTimeFormat {
+  let fmt = FORMATTER_CACHE.get(zone);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    FORMATTER_CACHE.set(zone, fmt);
+  }
+  return fmt;
+}
+
+/**
+ * Project a `Date` onto a calendar day in a specific IANA timezone.
+ *
+ * Returns an ISO `YYYY-MM-DD` string. We resolve via `Intl.DateTimeFormat`
+ * (zero-dependency, ships with V8) so a workout finished at 23:30 UTC on
+ * day N appears on day N+1 for an athlete in Sydney and on day N for an
+ * athlete in San Francisco. Falls back to UTC if the zone is invalid.
+ */
+export function dayInTimezone(
+  date: Date,
+  tz: string | null | undefined,
+): string {
+  const zone = tz && tz.length > 0 ? tz : "UTC";
+  try {
+    // `en-CA` renders as YYYY-MM-DD natively, no parsing needed.
+    return getFormatter(zone).format(date);
+  } catch {
+    // Invalid TZ string — degrade to UTC rather than crashing the request.
+    return date.toISOString().split("T")[0]!;
+  }
+}
+
+/**
+ * Compute "today" in the athlete's timezone as a `YYYY-MM-DD` string.
+ * Used as the upper bound when zero-padding the daily-load series.
+ */
+export function todayInTimezone(tz: string | null | undefined): string {
+  return dayInTimezone(new Date(), tz);
+}
+
+/**
+ * Step a `YYYY-MM-DD` string by N days. Operates on the date string
+ * directly so it is timezone-stable (no DST spring-forward bug).
+ */
+export function shiftIsoDay(isoDay: string, deltaDays: number): string {
+  // Anchor at noon UTC to dodge DST midnight ambiguities, then shift in
+  // days. Output is the bare YYYY-MM-DD prefix only.
+  const d = new Date(`${isoDay}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().split("T")[0]!;
+}

--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -33,6 +33,58 @@ function getDateString(daysAgo: number): string {
 }
 
 /**
+ * Project a `Date` onto a calendar day in a specific IANA timezone.
+ *
+ * Returns an ISO `YYYY-MM-DD` string. We resolve via `Intl.DateTimeFormat`
+ * (zero-dependency, ships with V8) so a workout finished at 23:30 UTC on
+ * day N appears on day N+1 for an athlete in Sydney and on day N for an
+ * athlete in San Francisco. Falls back to UTC if the zone is invalid.
+ *
+ * Exported for testability — internal callers go via `aggregateDailyLoads`.
+ */
+export function dayInTimezone(
+  date: Date,
+  tz: string | null | undefined,
+): string {
+  const zone = tz && tz.length > 0 ? tz : "UTC";
+  try {
+    const fmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    // en-CA renders as YYYY-MM-DD natively
+    return fmt.format(date);
+  } catch {
+    // Invalid TZ string — degrade to UTC rather than crashing the request.
+    return date.toISOString().split("T")[0]!;
+  }
+}
+
+/**
+ * Compute "today" in the athlete's timezone as a `YYYY-MM-DD` string.
+ * Used as the upper bound when zero-padding the daily-load series.
+ */
+function todayInTimezone(tz: string | null | undefined): string {
+  return dayInTimezone(new Date(), tz);
+}
+
+/**
+ * Step a `YYYY-MM-DD` string back by N days. Operates on the date string
+ * directly so it is timezone-stable (no DST spring-forward bug).
+ *
+ * Exported for testability.
+ */
+export function shiftIsoDay(isoDay: string, deltaDays: number): string {
+  // Anchor at noon UTC to dodge DST midnight ambiguities, then shift in
+  // milliseconds. Output is the bare YYYY-MM-DD prefix only.
+  const d = new Date(`${isoDay}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().split("T")[0]!;
+}
+
+/**
  * Aggregate per-activity strain scores into a per-day chronological series.
  *
  * The engine helpers (`computeACWR`, `computeACWR_EWMA`, `computeTrainingLoads`)
@@ -56,20 +108,19 @@ function aggregateDailyLoads(
     trimpScore: number | null;
   }[],
   windowDays: number,
+  timezone?: string | null,
 ): { dailyLoadsChrono: number[]; dailyLoadsRecent: number[] } {
   const byDay = new Map<string, number>();
   for (const a of activities) {
-    const day = a.startedAt.toISOString().split("T")[0]!;
+    const day = dayInTimezone(a.startedAt, timezone);
     const s = a.strainScore ?? computeStrainScore(a.trimpScore ?? 0);
     byDay.set(day, (byDay.get(day) ?? 0) + s);
   }
 
   const dailyLoadsRecent: number[] = [];
-  const today = new Date();
+  const todayStr = todayInTimezone(timezone);
   for (let i = 0; i < windowDays; i++) {
-    const d = new Date(today);
-    d.setDate(today.getDate() - i);
-    const key = d.toISOString().split("T")[0]!;
+    const key = shiftIsoDay(todayStr, -i);
     dailyLoadsRecent.push(byDay.get(key) ?? 0);
   }
   const dailyLoadsChrono = [...dailyLoadsRecent].reverse();
@@ -80,17 +131,24 @@ export const analyticsRouter = {
   getTrainingLoads: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    const recentActivities = await ctx.db.query.Activity.findMany({
-      where: and(
-        eq(Activity.userId, userId),
-        gte(Activity.startedAt, new Date(Date.now() - 42 * 86400000)),
-      ),
-      orderBy: desc(Activity.startedAt),
-    });
+    const [profile, recentActivities] = await Promise.all([
+      ctx.db.query.Profile.findFirst({
+        where: eq(Profile.userId, userId),
+        columns: { timezone: true },
+      }),
+      ctx.db.query.Activity.findMany({
+        where: and(
+          eq(Activity.userId, userId),
+          gte(Activity.startedAt, new Date(Date.now() - 42 * 86400000)),
+        ),
+        orderBy: desc(Activity.startedAt),
+      }),
+    ]);
 
     const { dailyLoadsChrono, dailyLoadsRecent } = aggregateDailyLoads(
       recentActivities,
       42,
+      profile?.timezone,
     );
 
     const loadMetrics = computeTrainingLoads(dailyLoadsChrono);
@@ -106,6 +164,7 @@ export const analyticsRouter = {
       acwrEwma,
       loadFocus,
       rampRate: loadMetrics.rampRate,
+      timezone: profile?.timezone ?? "UTC",
       computedAt: new Date(),
     };
   }),
@@ -113,13 +172,26 @@ export const analyticsRouter = {
   getTrainingStatus: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    const vo2maxRecords = await ctx.db.query.VO2maxEstimate.findMany({
-      where: and(
-        eq(VO2maxEstimate.userId, userId),
-        gte(VO2maxEstimate.date, getDateString(28)),
-      ),
-      orderBy: desc(VO2maxEstimate.date),
-    });
+    const [profile, vo2maxRecords, recentActivities] = await Promise.all([
+      ctx.db.query.Profile.findFirst({
+        where: eq(Profile.userId, userId),
+        columns: { timezone: true },
+      }),
+      ctx.db.query.VO2maxEstimate.findMany({
+        where: and(
+          eq(VO2maxEstimate.userId, userId),
+          gte(VO2maxEstimate.date, getDateString(28)),
+        ),
+        orderBy: desc(VO2maxEstimate.date),
+      }),
+      ctx.db.query.Activity.findMany({
+        where: and(
+          eq(Activity.userId, userId),
+          gte(Activity.startedAt, new Date(Date.now() - 42 * 86400000)),
+        ),
+        orderBy: desc(Activity.startedAt),
+      }),
+    ]);
 
     let vo2maxTrend = 0;
     if (vo2maxRecords.length >= 2) {
@@ -128,17 +200,10 @@ export const analyticsRouter = {
       vo2maxTrend = last.value - first.value;
     }
 
-    const recentActivities = await ctx.db.query.Activity.findMany({
-      where: and(
-        eq(Activity.userId, userId),
-        gte(Activity.startedAt, new Date(Date.now() - 42 * 86400000)),
-      ),
-      orderBy: desc(Activity.startedAt),
-    });
-
     const { dailyLoadsChrono, dailyLoadsRecent } = aggregateDailyLoads(
       recentActivities,
       42,
+      profile?.timezone,
     );
 
     const loadMetrics = computeTrainingLoads(dailyLoadsChrono);

--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -24,63 +24,12 @@ import {
   predictRaceTimesFromVO2max,
 } from "@acme/engine";
 
+import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
 import { protectedProcedure } from "../trpc";
 
 function getDateString(daysAgo: number): string {
   const d = new Date();
   d.setDate(d.getDate() - daysAgo);
-  return d.toISOString().split("T")[0]!;
-}
-
-/**
- * Project a `Date` onto a calendar day in a specific IANA timezone.
- *
- * Returns an ISO `YYYY-MM-DD` string. We resolve via `Intl.DateTimeFormat`
- * (zero-dependency, ships with V8) so a workout finished at 23:30 UTC on
- * day N appears on day N+1 for an athlete in Sydney and on day N for an
- * athlete in San Francisco. Falls back to UTC if the zone is invalid.
- *
- * Exported for testability — internal callers go via `aggregateDailyLoads`.
- */
-export function dayInTimezone(
-  date: Date,
-  tz: string | null | undefined,
-): string {
-  const zone = tz && tz.length > 0 ? tz : "UTC";
-  try {
-    const fmt = new Intl.DateTimeFormat("en-CA", {
-      timeZone: zone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-    // en-CA renders as YYYY-MM-DD natively
-    return fmt.format(date);
-  } catch {
-    // Invalid TZ string — degrade to UTC rather than crashing the request.
-    return date.toISOString().split("T")[0]!;
-  }
-}
-
-/**
- * Compute "today" in the athlete's timezone as a `YYYY-MM-DD` string.
- * Used as the upper bound when zero-padding the daily-load series.
- */
-function todayInTimezone(tz: string | null | undefined): string {
-  return dayInTimezone(new Date(), tz);
-}
-
-/**
- * Step a `YYYY-MM-DD` string back by N days. Operates on the date string
- * directly so it is timezone-stable (no DST spring-forward bug).
- *
- * Exported for testability.
- */
-export function shiftIsoDay(isoDay: string, deltaDays: number): string {
-  // Anchor at noon UTC to dodge DST midnight ambiguities, then shift in
-  // milliseconds. Output is the bare YYYY-MM-DD prefix only.
-  const d = new Date(`${isoDay}T12:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + deltaDays);
   return d.toISOString().split("T")[0]!;
 }
 


### PR DESCRIPTION
Closes the `phase1-tz-profile` + `phase1-tz-aggregation` todos from issue ha-garmin-fitness-coach-addon#78 (Phase 1 — timezone unification).

## Problem

`aggregateDailyLoads` bucketed activities by their **UTC** ISO date. For an athlete outside UTC, this systematically misattributes evening / late-night sessions to the wrong calendar day — biasing CTL, ATL, TSB and ACWR by up to one full bucket.

## Fix

- Reads `Profile.timezone` (defaults to `UTC`) in the same `Promise.all` batch as the activities query (no extra round trip).
- Adds two pure helpers — `dayInTimezone` and `shiftIsoDay` — that resolve IANA zones via `Intl.DateTimeFormat` (zero-dep, V8 builtin) and step ISO dates without DST drift.
- Threads the timezone into `aggregateDailyLoads` so **both** the per-day bucket key and the rolling "today minus N days" anchor live in the athlete's local time.
- `getTrainingLoads` returns the resolved `timezone` so the UI can disambiguate the data window.

## Tests

New file `packages/api/src/__tests__/timezone.test.ts` — **9 tests**:

- `dayInTimezone`: UTC default, east-of-UTC (Sydney) roll-forward, west-of-UTC (Los Angeles) roll-back, invalid-TZ fallback.
- `shiftIsoDay`: month boundary, year boundary, zero delta, forward step, DST spring-forward stability.

All 9 pass; `@acme/api` builds and `@acme/nextjs` typechecks clean.

Signed-off-by: Anil Belur <askb23@gmail.com>