### PR TITLE
feat(api): add daily_athlete_summary matview read path with live-table fallback

### DIFF
--- a/packages/api/src/__tests__/dailySummary.test.ts
+++ b/packages/api/src/__tests__/dailySummary.test.ts
@@ -25,13 +25,13 @@ afterEach(() => {
 function makeDb(opts: {
   matviewRows?: unknown[];
   metrics?: {
-    date: string;
+    date: string | Date;
     hrv: number | null;
     restingHr: number | null;
     totalSleepMinutes: number | null;
     stressScore: number | null;
   }[];
-  scores?: { date: string; score: number }[];
+  scores?: { date: string | Date; score: number }[];
 }) {
   const executeMock = vi.fn(async () => ({ rows: opts.matviewRows ?? [] }));
   const metricsMock = vi.fn(async () => opts.metrics ?? []);
@@ -222,7 +222,7 @@ describe("getDailySummaryRange", () => {
     const { db } = makeDb({
       metrics: [
         {
-          date: new Date("2026-03-15T12:00:00Z") as unknown as string,
+          date: new Date("2026-03-15T12:00:00Z"),
           hrv: 65,
           restingHr: 52,
           totalSleepMinutes: 420,
@@ -235,5 +235,42 @@ describe("getDailySummaryRange", () => {
     const out = await getDailySummaryRange(db, "user-1", "2026-03-15");
 
     expect(out[0]?.date).toBe("2026-03-15");
+  });
+
+  it("dedupes concurrent first-probes (Promise-memoized cache)", async () => {
+    _resetMatviewCacheForTests();
+    // The probe takes a measurable tick — simulate latency so the three
+    // concurrent calls below all hit `matviewProbe === null` simultaneously.
+    const executeMock = vi
+      .fn()
+      // First call: the to_regclass probe (slow, so concurrent callers
+      // queue up against the in-flight Promise).
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ rows: [{ exists: true }] }), 20),
+          ),
+      )
+      // All subsequent calls: matview data reads. Return empty rows so
+      // `isoDate` doesn't choke on an undefined `date` field.
+      .mockResolvedValue({ rows: [] });
+    const db = {
+      execute: executeMock,
+      query: {
+        DailyMetric: { findMany: vi.fn() },
+        ReadinessScore: { findMany: vi.fn() },
+      },
+    } as never;
+
+    // Fire three reads in parallel. Without Promise-memoization, all three
+    // would each issue their own to_regclass probe → 3 probes + 3 reads = 6.
+    // With memoization → 1 probe + 3 reads = 4.
+    await Promise.all([
+      getDailySummaryRange(db, "user-1", "2026-03-15"),
+      getDailySummaryRange(db, "user-1", "2026-03-16"),
+      getDailySummaryRange(db, "user-1", "2026-03-17"),
+    ]);
+
+    expect(executeMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/api/src/__tests__/dailySummary.test.ts
+++ b/packages/api/src/__tests__/dailySummary.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for `getDailySummaryRange` — verifies the matview / live-table
+ * fallback contract.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetMatviewCacheForTests,
+  _setMatviewAvailableForTests,
+  getDailySummaryRange,
+} from "../lib/dailySummary";
+
+afterEach(() => {
+  _resetMatviewCacheForTests();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Minimal db stub. We only need the surface used by `getDailySummaryRange`:
+ *   - `db.execute(sql)` → matview path
+ *   - `db.query.DailyMetric.findMany` / `db.query.ReadinessScore.findMany`
+ *     → fallback path
+ */
+function makeDb(opts: {
+  matviewRows?: unknown[];
+  metrics?: {
+    date: string;
+    hrv: number | null;
+    restingHr: number | null;
+    totalSleepMinutes: number | null;
+    stressScore: number | null;
+  }[];
+  scores?: { date: string; score: number }[];
+}) {
+  const executeMock = vi.fn(async () => ({ rows: opts.matviewRows ?? [] }));
+  const metricsMock = vi.fn(async () => opts.metrics ?? []);
+  const scoresMock = vi.fn(async () => opts.scores ?? []);
+  return {
+    db: {
+      execute: executeMock,
+      query: {
+        DailyMetric: { findMany: metricsMock },
+        ReadinessScore: { findMany: scoresMock },
+      },
+    } as never,
+    executeMock,
+    metricsMock,
+    scoresMock,
+  };
+}
+
+describe("getDailySummaryRange", () => {
+  it("reads from the matview when present", async () => {
+    _setMatviewAvailableForTests(true);
+    const { db, executeMock, metricsMock } = makeDb({
+      matviewRows: [
+        {
+          date: "2026-03-15",
+          hrv: 65,
+          resting_hr: 52,
+          total_sleep_minutes: 420,
+          stress_score: 30,
+          readiness_score: 78,
+        },
+        {
+          date: "2026-03-16",
+          hrv: 70,
+          resting_hr: 50,
+          total_sleep_minutes: 440,
+          stress_score: 25,
+          readiness_score: 82,
+        },
+      ],
+    });
+
+    const out = await getDailySummaryRange(db, "user-1", "2026-03-15");
+
+    expect(out).toEqual([
+      {
+        date: "2026-03-15",
+        hrv: 65,
+        restingHr: 52,
+        totalSleepMinutes: 420,
+        stressScore: 30,
+        readinessScore: 78,
+      },
+      {
+        date: "2026-03-16",
+        hrv: 70,
+        restingHr: 50,
+        totalSleepMinutes: 440,
+        stressScore: 25,
+        readinessScore: 82,
+      },
+    ]);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(metricsMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to live tables when matview is absent", async () => {
+    _setMatviewAvailableForTests(false);
+    const { db, executeMock, metricsMock, scoresMock } = makeDb({
+      metrics: [
+        {
+          date: "2026-03-15",
+          hrv: 65,
+          restingHr: 52,
+          totalSleepMinutes: 420,
+          stressScore: 30,
+        },
+        {
+          date: "2026-03-16",
+          hrv: 70,
+          restingHr: 50,
+          totalSleepMinutes: 440,
+          stressScore: 25,
+        },
+      ],
+      scores: [{ date: "2026-03-16", score: 82 }],
+    });
+
+    const out = await getDailySummaryRange(db, "user-1", "2026-03-15");
+
+    expect(out).toEqual([
+      {
+        date: "2026-03-15",
+        hrv: 65,
+        restingHr: 52,
+        totalSleepMinutes: 420,
+        stressScore: 30,
+        readinessScore: null,
+      },
+      {
+        date: "2026-03-16",
+        hrv: 70,
+        restingHr: 50,
+        totalSleepMinutes: 440,
+        stressScore: 25,
+        readinessScore: 82,
+      },
+    ]);
+    // No matview read — `execute` was never called because the cache was seeded.
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(metricsMock).toHaveBeenCalledTimes(1);
+    expect(scoresMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges fallback DailyMetric + ReadinessScore by date", async () => {
+    _setMatviewAvailableForTests(false);
+    const { db } = makeDb({
+      metrics: [
+        {
+          date: "2026-03-15",
+          hrv: 65,
+          restingHr: 52,
+          totalSleepMinutes: 420,
+          stressScore: 30,
+        },
+      ],
+      // Score on a date that doesn't appear in metrics → should be dropped
+      // (we return one row per DailyMetric, not the cross-join).
+      scores: [
+        { date: "2026-03-15", score: 78 },
+        { date: "2026-03-99", score: 99 },
+      ],
+    });
+
+    const out = await getDailySummaryRange(db, "user-1", "2026-03-15");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ date: "2026-03-15", readinessScore: 78 });
+  });
+
+  it("probes matview presence exactly once across calls (cached)", async () => {
+    _resetMatviewCacheForTests();
+    const executeMock = vi
+      .fn()
+      // First call is the to_regclass probe.
+      .mockResolvedValueOnce({ rows: [{ exists: true }] })
+      // Subsequent calls return matview data.
+      .mockResolvedValue({ rows: [] });
+    const db = {
+      execute: executeMock,
+      query: {
+        DailyMetric: { findMany: vi.fn() },
+        ReadinessScore: { findMany: vi.fn() },
+      },
+    } as never;
+
+    await getDailySummaryRange(db, "user-1", "2026-03-15");
+    await getDailySummaryRange(db, "user-1", "2026-03-16");
+    await getDailySummaryRange(db, "user-1", "2026-03-17");
+
+    // 1 probe + 3 data reads, NOT 3 probes + 3 reads.
+    expect(executeMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("falls back gracefully when the probe itself throws", async () => {
+    _resetMatviewCacheForTests();
+    const executeMock = vi.fn().mockRejectedValueOnce(new Error("DB down"));
+    const metricsMock = vi.fn().mockResolvedValue([]);
+    const scoresMock = vi.fn().mockResolvedValue([]);
+    const db = {
+      execute: executeMock,
+      query: {
+        DailyMetric: { findMany: metricsMock },
+        ReadinessScore: { findMany: scoresMock },
+      },
+    } as never;
+
+    const out = await getDailySummaryRange(db, "user-1", "2026-03-15");
+
+    expect(out).toEqual([]);
+    // Probe failed → treated as "not available" → live-table path was used.
+    expect(metricsMock).toHaveBeenCalledTimes(1);
+    expect(scoresMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles Date objects in the date column (live-table path)", async () => {
+    _setMatviewAvailableForTests(false);
+    const { db } = makeDb({
+      metrics: [
+        {
+          date: new Date("2026-03-15T12:00:00Z") as unknown as string,
+          hrv: 65,
+          restingHr: 52,
+          totalSleepMinutes: 420,
+          stressScore: 30,
+        },
+      ],
+      scores: [],
+    });
+
+    const out = await getDailySummaryRange(db, "user-1", "2026-03-15");
+
+    expect(out[0]?.date).toBe("2026-03-15");
+  });
+});

--- a/packages/api/src/lib/dailySummary.ts
+++ b/packages/api/src/lib/dailySummary.ts
@@ -28,35 +28,42 @@ export interface DailySummaryRow {
   readinessScore: number | null;
 }
 
-let matviewAvailable: boolean | null = null;
+let matviewProbe: Promise<boolean> | null = null;
 
 /**
  * Probe (once) whether `daily_athlete_summary` exists in the current DB.
  * Uses `to_regclass`, which returns NULL for missing relations without
  * raising — so this is safe even on a brand-new install.
+ *
+ * The probe is memoized as a **Promise**, not a resolved boolean, so that
+ * concurrent first-callers all `await` the same in-flight query instead
+ * of each racing their own `to_regclass` round-trip.
  */
 async function isMatviewAvailable(db: DB): Promise<boolean> {
-  if (matviewAvailable !== null) return matviewAvailable;
-  try {
-    const result = await db.execute<{ exists: boolean }>(
-      sql`SELECT to_regclass('public.daily_athlete_summary') IS NOT NULL AS exists`,
-    );
-    const row = (result as unknown as { rows: { exists: boolean }[] }).rows[0];
-    matviewAvailable = row?.exists === true;
-  } catch {
-    matviewAvailable = false;
-  }
-  return matviewAvailable;
+  if (matviewProbe !== null) return matviewProbe;
+  matviewProbe = (async () => {
+    try {
+      const result = await db.execute<{ exists: boolean }>(
+        sql`SELECT to_regclass('public.daily_athlete_summary') IS NOT NULL AS exists`,
+      );
+      const row = (result as unknown as { rows: { exists: boolean }[] })
+        .rows[0];
+      return row?.exists === true;
+    } catch {
+      return false;
+    }
+  })();
+  return matviewProbe;
 }
 
 /** Test-only: reset the cached detection so a unit test can flip availability. */
 export function _resetMatviewCacheForTests(): void {
-  matviewAvailable = null;
+  matviewProbe = null;
 }
 
 /** Test-only: explicitly seed the detection cache. */
 export function _setMatviewAvailableForTests(value: boolean): void {
-  matviewAvailable = value;
+  matviewProbe = Promise.resolve(value);
 }
 
 function isoDate(value: string | Date): string {

--- a/packages/api/src/lib/dailySummary.ts
+++ b/packages/api/src/lib/dailySummary.ts
@@ -1,0 +1,154 @@
+/**
+ * Read helper for the `daily_athlete_summary` materialized view.
+ *
+ * The view is created and refreshed by the **addon** side (see
+ * `pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql` and
+ * `refresh_daily_athlete_summary()` in the sync pipeline). The app treats it
+ * as a *read-only optimization*: when present we issue one indexed scan
+ * instead of three separate table queries; when absent (e.g. fresh install,
+ * or matview SQL has not yet run) we fall back to the live tables.
+ *
+ * Detection is cached for the lifetime of the Node process — the matview
+ * lifecycle is install-time, not request-time, so re-probing on every call
+ * would be wasted work.
+ */
+
+import type { db as drizzleDb } from "@acme/db/client";
+import { and, asc, eq, gte, sql } from "@acme/db";
+import { DailyMetric, ReadinessScore } from "@acme/db/schema";
+
+type DB = typeof drizzleDb;
+
+export interface DailySummaryRow {
+  date: string;
+  hrv: number | null;
+  restingHr: number | null;
+  totalSleepMinutes: number | null;
+  stressScore: number | null;
+  readinessScore: number | null;
+}
+
+let matviewAvailable: boolean | null = null;
+
+/**
+ * Probe (once) whether `daily_athlete_summary` exists in the current DB.
+ * Uses `to_regclass`, which returns NULL for missing relations without
+ * raising — so this is safe even on a brand-new install.
+ */
+async function isMatviewAvailable(db: DB): Promise<boolean> {
+  if (matviewAvailable !== null) return matviewAvailable;
+  try {
+    const result = await db.execute<{ exists: boolean }>(
+      sql`SELECT to_regclass('public.daily_athlete_summary') IS NOT NULL AS exists`,
+    );
+    const row = (result as unknown as { rows: { exists: boolean }[] }).rows[0];
+    matviewAvailable = row?.exists === true;
+  } catch {
+    matviewAvailable = false;
+  }
+  return matviewAvailable;
+}
+
+/** Test-only: reset the cached detection so a unit test can flip availability. */
+export function _resetMatviewCacheForTests(): void {
+  matviewAvailable = null;
+}
+
+/** Test-only: explicitly seed the detection cache. */
+export function _setMatviewAvailableForTests(value: boolean): void {
+  matviewAvailable = value;
+}
+
+function isoDate(value: string | Date): string {
+  if (typeof value === "string")
+    return value.length >= 10 ? value.slice(0, 10) : value;
+  return value.toISOString().slice(0, 10);
+}
+
+/**
+ * Fetch a per-day series of {date, hrv, restingHr, totalSleepMinutes,
+ * stressScore, readinessScore} for `userId` from `since` (inclusive,
+ * `YYYY-MM-DD`) onward, sorted ascending.
+ *
+ * Single source of truth: prefers the matview when present; otherwise
+ * issues the equivalent two-table query (DailyMetric LEFT JOIN
+ * ReadinessScore) so callers get identical shape either way.
+ */
+export async function getDailySummaryRange(
+  db: DB,
+  userId: string,
+  since: string,
+): Promise<DailySummaryRow[]> {
+  if (await isMatviewAvailable(db)) {
+    const result = await db.execute<{
+      date: string | Date;
+      hrv: number | null;
+      resting_hr: number | null;
+      total_sleep_minutes: number | null;
+      stress_score: number | null;
+      readiness_score: number | null;
+    }>(sql`
+      SELECT
+        date,
+        hrv,
+        resting_hr,
+        total_sleep_minutes,
+        stress_score,
+        readiness_score
+      FROM daily_athlete_summary
+      WHERE user_id = ${userId} AND date >= ${since}
+      ORDER BY date ASC
+    `);
+    const rows = (
+      result as unknown as {
+        rows: Array<{
+          date: string | Date;
+          hrv: number | null;
+          resting_hr: number | null;
+          total_sleep_minutes: number | null;
+          stress_score: number | null;
+          readiness_score: number | null;
+        }>;
+      }
+    ).rows;
+    return rows.map((r) => ({
+      date: isoDate(r.date),
+      hrv: r.hrv,
+      restingHr: r.resting_hr,
+      totalSleepMinutes: r.total_sleep_minutes,
+      stressScore: r.stress_score,
+      readinessScore: r.readiness_score,
+    }));
+  }
+
+  // Fallback: live tables. Two queries since DailyMetric and ReadinessScore
+  // are independent — merge in memory by date.
+  const [metrics, scores] = await Promise.all([
+    db.query.DailyMetric.findMany({
+      where: and(eq(DailyMetric.userId, userId), gte(DailyMetric.date, since)),
+      orderBy: asc(DailyMetric.date),
+    }),
+    db.query.ReadinessScore.findMany({
+      where: and(
+        eq(ReadinessScore.userId, userId),
+        gte(ReadinessScore.date, since),
+      ),
+      orderBy: asc(ReadinessScore.date),
+    }),
+  ]);
+
+  const scoreByDate = new Map<string, number>();
+  for (const s of scores) scoreByDate.set(isoDate(s.date), s.score);
+
+  return metrics.map((m) => {
+    const date = isoDate(m.date);
+    return {
+      date,
+      hrv: m.hrv,
+      restingHr: m.restingHr,
+      totalSleepMinutes: m.totalSleepMinutes,
+      stressScore: m.stressScore,
+      readinessScore: scoreByDate.get(date) ?? null,
+    };
+  });
+}

--- a/packages/api/src/router/trends.ts
+++ b/packages/api/src/router/trends.ts
@@ -11,6 +11,7 @@ import {
   findNotableChanges,
 } from "@acme/engine";
 
+import { getDailySummaryRange } from "../lib/dailySummary";
 import { protectedProcedure } from "../trpc";
 
 type DB = typeof _dependencies_db;
@@ -62,41 +63,32 @@ async function fetchMetricData(
   metric: z.infer<typeof trendMetricEnum>,
   since: string,
 ): Promise<{ date: string; value: number }[]> {
-  if (metric === "readiness") {
-    const scores = await db.query.ReadinessScore.findMany({
-      where: and(
-        eq(ReadinessScore.userId, userId),
-        gte(ReadinessScore.date, since),
-      ),
-      orderBy: ReadinessScore.date,
-    });
-    return scores.map((s) => ({ date: s.date, value: s.score }));
-  }
-
-  // Strain = activity-based TRIMP load (0-21), NOT daily HRV stress
+  // Strain stays activity-derived — daily_athlete_summary doesn't capture
+  // per-activity TRIMP, so we still group from the Activity table.
   if (metric === "strain") {
     return fetchStrainByDate(db, userId, since);
   }
 
-  const metrics = await db.query.DailyMetric.findMany({
-    where: and(eq(DailyMetric.userId, userId), gte(DailyMetric.date, since)),
-    orderBy: DailyMetric.date,
-  });
+  // Everything else lives on `daily_athlete_summary` (or its live-table
+  // fallback). Single read path means readiness/HRV/sleep/etc. all stay
+  // consistent with whatever the matview last refreshed to.
+  const summary = await getDailySummaryRange(db, userId, since);
 
   const fieldMap: Record<
-    Exclude<z.infer<typeof trendMetricEnum>, "readiness" | "strain">,
-    (m: (typeof metrics)[number]) => number | null
+    Exclude<z.infer<typeof trendMetricEnum>, "strain">,
+    (row: (typeof summary)[number]) => number | null
   > = {
-    sleep: (m) => m.totalSleepMinutes,
-    hrv: (m) => m.hrv,
-    restingHr: (m) => m.restingHr,
-    stress: (m) => m.stressScore,
+    readiness: (r) => r.readinessScore,
+    sleep: (r) => r.totalSleepMinutes,
+    hrv: (r) => r.hrv,
+    restingHr: (r) => r.restingHr,
+    stress: (r) => r.stressScore,
   };
 
   const extractor = fieldMap[metric];
-  return metrics
-    .filter((m) => extractor(m) !== null)
-    .map((m) => ({ date: m.date, value: extractor(m)! }));
+  return summary
+    .filter((r) => extractor(r) !== null)
+    .map((r) => ({ date: r.date, value: extractor(r)! }));
 }
 
 function getDateString(daysAgo: number): string {


### PR DESCRIPTION
Closes the `phase1-matview-design` + `phase1-matview-implement` todos from issue ha-garmin-fitness-coach-addon#78 (Phase 1 — materialized view integration).

Per checkpoint review: **reuse the addon-owned matview rather than designing a separate app-side one** — no schema duplication, no risk of Drizzle migrations fighting the addon's REFRESH cycle.

## What this does

Adds `packages/api/src/lib/dailySummary.ts` with `getDailySummaryRange()`:

- **Runtime detection** — probes `to_regclass('public.daily_athlete_summary')` once per Node process. Cached.
- **Matview fast path** — single indexed scan via the `(user_id, date)` unique index the addon already creates.
- **Live-table fallback** — when the matview is absent (fresh install, DDL not yet run), parallel `DailyMetric` + `ReadinessScore` reads merged by date. Output shape is identical to the matview path so callers don't branch.
- **Failure-safe** — if the `to_regclass` probe itself throws, we treat the matview as unavailable and fall back rather than 500'ing the request.

## Migration

`trends.fetchMetricData()` now uses the helper for `readiness` / `sleep` / `hrv` / `restingHr` / `stress`. `strain` stays activity-derived (TRIMP is per-activity, not in the daily summary). Remaining DailyMetric / ReadinessScore call sites are intentionally left alone — they do fresh computation that depends on data newer than the matview's last refresh.

## Why no Drizzle binding?

The matview's DDL stays owned by the addon (`pulsecoach/rootfs/app/sql/create_daily_athlete_summary.sql`). The app consumes it via a raw `sql` template, so Drizzle migrations cannot accidentally drop or alter it.

## Tests

`packages/api/src/__tests__/dailySummary.test.ts` — **6 new tests**:

- Matview path returns rows in canonical shape
- Fallback path joins DailyMetric + ReadinessScore by date
- Fallback drops orphan readiness rows (no matching DailyMetric date)
- Probe is cached — 3 calls = 1 `to_regclass` query, not 3
- Probe error → graceful fallback (not a 500)
- Date-typed `date` columns are coerced to ISO YYYY-MM-DD

All 6 pass. `@acme/api` builds and `@acme/nextjs` typechecks clean. Pre-existing DB-required integration tests (profile, readiness, trends) fail on `main` too without a running Postgres on :5432 — not introduced here.

Signed-off-by: Anil Belur <askb23@gmail.com>