### PR TITLE
fix(analytics): handle invalid Activity.startedAt without 500

### DIFF
--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -27,6 +27,16 @@ describe("dayInTimezone", () => {
     const d = new Date("2026-04-15T10:00:00Z");
     expect(dayInTimezone(d, "Mars/Olympus_Mons")).toBe("2026-04-15");
   });
+
+  it("returns sentinel epoch day for an invalid Date instead of throwing", () => {
+    // Guards against `RangeError: Invalid time value` propagating out of
+    // `analytics.getTrainingLoads` / `getTrainingStatus` when an Activity
+    // row has a malformed `startedAt` (seen in production logs).
+    expect(dayInTimezone(new Date("not-a-date"), "UTC")).toBe("1970-01-01");
+    expect(dayInTimezone(new Date(NaN), "Australia/Sydney")).toBe(
+      "1970-01-01",
+    );
+  });
 });
 
 describe("shiftIsoDay", () => {

--- a/packages/api/src/lib/timezone.ts
+++ b/packages/api/src/lib/timezone.ts
@@ -37,6 +37,14 @@ export function dayInTimezone(
   date: Date,
   tz: string | null | undefined,
 ): string {
+  // Guard against invalid Dates (e.g., an Activity row with a malformed
+  // `startedAt`). `Intl.DateTimeFormat.format()` and `.toISOString()` both
+  // throw `RangeError: Invalid time value` for these, which would 500 the
+  // whole tRPC call. Sentinel epoch-day is sortable and obviously bogus,
+  // so downstream aggregations bucket bad rows together rather than crash.
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return "1970-01-01";
+  }
   const zone = tz && tz.length > 0 ? tz : "UTC";
   try {
     // `en-CA` renders as YYYY-MM-DD natively, no parsing needed.

--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -61,6 +61,15 @@ function aggregateDailyLoads(
 ): { dailyLoadsChrono: number[]; dailyLoadsRecent: number[] } {
   const byDay = new Map<string, number>();
   for (const a of activities) {
+    // Skip rows with a malformed `startedAt`. These exist in the wild for
+    // partial Garmin syncs and would otherwise propagate `RangeError:
+    // Invalid time value` out of the tRPC handler.
+    if (
+      !(a.startedAt instanceof Date) ||
+      Number.isNaN(a.startedAt.getTime())
+    ) {
+      continue;
+    }
     const day = dayInTimezone(a.startedAt, timezone);
     const s = a.strainScore ?? computeStrainScore(a.trimpScore ?? 0);
     byDay.set(day, (byDay.get(day) ?? 0) + s);
@@ -304,6 +313,12 @@ export const analyticsRouter = {
       // Max strain per day from activities
       const strainMap = new Map<string, number>();
       for (const a of activities) {
+        if (
+          !(a.startedAt instanceof Date) ||
+          Number.isNaN(a.startedAt.getTime())
+        ) {
+          continue;
+        }
         const date = a.startedAt.toISOString().split("T")[0]!;
         const strain = a.strainScore ?? computeStrainScore(a.trimpScore ?? 0);
         const existing = strainMap.get(date) ?? 0;


### PR DESCRIPTION
## Symptom

From the user's HAOS logs after enabling port 3000:

```
>>> tRPC Error on 'analytics.getTrainingStatus' Error [TRPCError]: Invalid time value
    at Date1.toISOString (<anonymous>)
    at i (.next/server/chunks/_76067180._.js:8:17623)   ← dayInTimezone
    at f (.next/server/chunks/_76067180._.js:8:18293)   ← aggregateDailyLoads
```

Both `analytics.getTrainingLoads` and `analytics.getTrainingStatus` return 500. Every other endpoint in the same batch (`trends.getChart`, `garmin.getTrainingSummary`, `analytics.getRecoveryTime`, `advancedMetrics.list`) succeeds.

## Cause

Both failing endpoints funnel through `aggregateDailyLoads` → `dayInTimezone(a.startedAt, tz)`. If any `Activity` row in the 42-day window has a malformed `startedAt` (NaN time), `Intl.DateTimeFormat.format()` throws `RangeError: Invalid time value`. The existing catch falls back to `date.toISOString()` — which throws the same error — so it propagates out as a 500.

## Fix

1. `dayInTimezone` short-circuits to a sentinel `1970-01-01` for invalid Dates instead of trying to format them. Protects every caller.
2. `aggregateDailyLoads` and `getCorrelations` skip rows with NaN `startedAt` so they don't pollute ACWR/CTL/ATL.

## Tests

`packages/api/src/__tests__/timezone.test.ts` — 10/10 pass (1 new for invalid Date).