### PR TITLE
fix(ui): hide bottom tab nav on md+ breakpoints

### DIFF
--- a/apps/nextjs/src/app/_components/bottom-nav.tsx
+++ b/apps/nextjs/src/app/_components/bottom-nav.tsx
@@ -24,7 +24,7 @@ export function BottomNav() {
     : pathname;
 
   return (
-    <nav className="bg-card border-border fixed right-0 bottom-0 left-0 z-50 border-t">
+    <nav className="bg-card border-border fixed right-0 bottom-0 left-0 z-50 border-t md:hidden">
       <div className="mx-auto flex max-w-md items-center justify-around py-2">
         {navItems.map((item) => {
           const isActive =


### PR DESCRIPTION
Spotted via the new screenshot tooling.

## Symptom
On every desktop capture (1440×900), the fixed bottom nav strip renders mid-page and overlaps content. Most visibly on `/training` it covers the ACWR gauge + Risk Zone Legend + Daily Strain bars.

## Cause
`bottom-nav.tsx` is `position: fixed; bottom: 0` with no breakpoint gate. Its inner `<div>` is `max-w-md` so on a 1440-wide screen the strip floats centered and ends up in the middle of the viewport.

## Fix
Add `md:hidden` to the `<nav>`. The sidebar / hamburger top-left already covers desktop navigation.

## Follow-ups (not in this PR)
- 18 page components have `pb-24` to clear the now-hidden nav on desktop — wastes ~96px vertically. Worth a sweep when we revisit page layout.
- Many pages cap at `max-w-lg` (~512px) which looks cramped on desktop. Per-page breakpoint widening is a separate UX pass.