### PR TITLE
fix(ui): consolidate p0 data-consistency and labeling fixes

### DIFF
--- a/apps/nextjs/src/app/_components/garmin-training-summary.tsx
+++ b/apps/nextjs/src/app/_components/garmin-training-summary.tsx
@@ -60,10 +60,15 @@ export function GarminTrainingSummary() {
     <div className="bg-card space-y-3 rounded-2xl border p-4">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold tracking-wide uppercase">
-          Garmin Training Summary
+          Garmin Native (Firstbeat)
         </h2>
         <DataFreshness computedAt={summary.data?.computedAt} />
       </div>
+      <p className="text-muted-foreground -mt-1 text-[11px]">
+        From your watch&apos;s Firstbeat algorithms. Requires Forerunner 245+,
+        Fenix 6+, or similar. See the home page for our computed Readiness
+        score, which uses HRV / RHR / sleep and works on any device.
+      </p>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {/* Training Readiness */}

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -454,8 +454,9 @@ export default function FitnessPage() {
               />
               <YAxis
                 tick={{ fill: "#888", fontSize: 10 }}
-                width={36}
+                width={44}
                 domain={["dataMin - 2", "dataMax + 2"]}
+                tickFormatter={(v: number) => v.toFixed(1)}
               />
               <Tooltip
                 contentStyle={{
@@ -532,8 +533,9 @@ export default function FitnessPage() {
               />
               <YAxis
                 tick={{ fill: "#888", fontSize: 10 }}
-                width={36}
+                width={44}
                 domain={["dataMin - 2", "dataMax + 2"]}
+                tickFormatter={(v: number) => v.toFixed(1)}
               />
               <Tooltip
                 contentStyle={{
@@ -601,8 +603,9 @@ export default function FitnessPage() {
                 />
                 <YAxis
                   tick={{ fill: "#888", fontSize: 10 }}
-                  width={36}
+                  width={44}
                   domain={["dataMin - 2", "dataMax + 2"]}
+                  tickFormatter={(v: number) => v.toFixed(1)}
                 />
                 <Tooltip
                   contentStyle={{
@@ -659,7 +662,15 @@ export default function FitnessPage() {
               {latestVO2max.value.toFixed(1)}
             </span>{" "}
             puts you in the{" "}
-            <span className="font-bold text-green-400">top {topPercent}%</span>{" "}
+            {topPercent <= 50 ? (
+              <span className="font-bold text-green-400">
+                top {topPercent}%
+              </span>
+            ) : (
+              <span className="font-bold text-amber-400">
+                bottom {100 - topPercent}%
+              </span>
+            )}{" "}
             for your age group.
           </p>
           {/* Reference scale */}

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -92,7 +92,11 @@ export default function TrainingLoadPage() {
   }
   const pmcChartData = ((pmcData.data ?? []) as PmcEntry[]).map(
     (d, idx, arr) => {
-      const showLabel = idx % 7 === 0;
+      // Show ~8 labels regardless of window size so 180-day views don't
+      // mash dates together. Recharts respects `interval={0}` so we control
+      // visibility by emitting empty strings on the off-ticks.
+      const step = Math.max(1, Math.ceil(arr.length / 8));
+      const showLabel = idx % step === 0 || idx === arr.length - 1;
       return {
         date: showLabel ? (d.date?.slice(5) ?? "") : "",
         fullDate: d.date ?? "",
@@ -106,7 +110,14 @@ export default function TrainingLoadPage() {
     },
   );
 
-  const currentAcwr = loads.data?.acwr;
+  // ACWR gauge: prefer the dedicated analytics endpoint, but fall back to
+  // the last point on the PMC chart series. This guarantees the gauge and
+  // the chart never disagree by definition. Previously, if
+  // `analytics.getTrainingLoads` returned null (the v0.16.6 invalid-date
+  // bug), the gauge said "No data yet" while the chart happily plotted
+  // ACWR — exact mismatch the screenshot review flagged.
+  const currentAcwr =
+    loads.data?.acwr ?? pmcChartData[pmcChartData.length - 1]?.acwr ?? null;
 
   return (
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
@@ -624,6 +635,7 @@ export default function TrainingLoadPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={28}
                 domain={[0, 21]}
+                tickFormatter={(v: number) => Math.round(v).toString()}
               />
               <Tooltip
                 contentStyle={{

--- a/apps/nextjs/src/app/validation/page.tsx
+++ b/apps/nextjs/src/app/validation/page.tsx
@@ -151,19 +151,19 @@ export default function ValidationPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 pb-20">
+    <div className="min-h-screen bg-background text-foreground pb-20">
       {/* Header */}
-      <div className="sticky top-0 z-10 bg-white px-4 py-4 shadow-sm">
-        <h1 className="text-xl font-bold text-gray-900">Data Validation</h1>
-        <p className="mt-0.5 text-sm text-gray-500">
+      <div className="sticky top-0 z-10 bg-card px-4 py-4 shadow-sm border-b">
+        <h1 className="text-xl font-bold text-foreground">Data Validation</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Compare Garmin estimates against reference measurements
         </p>
       </div>
 
       <div className="mx-auto max-w-2xl space-y-4 px-4 py-4">
         {/* Add Reference Measurement */}
-        <div className="rounded-xl bg-white p-4 shadow-sm">
-          <h2 className="mb-3 font-semibold text-gray-800">
+        <div className="rounded-xl bg-card p-4 shadow-sm border">
+          <h2 className="mb-3 font-semibold text-foreground">
             Add Reference Measurement
           </h2>
           <form onSubmit={handleSubmit} className="space-y-3">
@@ -177,7 +177,7 @@ export default function ValidationPage() {
                   className={`rounded-lg border p-2 text-center text-xs transition-colors ${
                     selectedType === t.key
                       ? "border-blue-500 bg-blue-50 text-blue-700"
-                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300"
+                      : "border-border bg-card text-muted-foreground hover:border-border"
                   }`}
                 >
                   <div className="text-lg">{t.emoji}</div>
@@ -188,7 +188,7 @@ export default function ValidationPage() {
 
             {/* Date */}
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
+              <label className="mb-1 block text-sm font-medium text-foreground">
                 Date
               </label>
               <input
@@ -196,14 +196,14 @@ export default function ValidationPage() {
                 value={date}
                 max={today()}
                 onChange={(e) => setDate(e.target.value)}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
               />
             </div>
 
             {/* Value + unit */}
             <div className="flex gap-2">
               <div className="flex-1">
-                <label className="mb-1 block text-sm font-medium text-gray-700">
+                <label className="mb-1 block text-sm font-medium text-foreground">
                   Reference Value
                 </label>
                 <input
@@ -212,14 +212,14 @@ export default function ValidationPage() {
                   value={value}
                   onChange={(e) => setValue(e.target.value)}
                   placeholder="e.g. 52.4"
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                  className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
                 />
               </div>
               <div className="w-28">
-                <label className="mb-1 block text-sm font-medium text-gray-700">
+                <label className="mb-1 block text-sm font-medium text-foreground">
                   Unit
                 </label>
-                <div className="flex h-[38px] items-center rounded-lg border border-gray-200 bg-gray-50 px-3 text-sm text-gray-500">
+                <div className="flex h-[38px] items-center rounded-lg border border-border bg-muted px-3 text-sm text-muted-foreground">
                   {unit}
                 </div>
               </div>
@@ -227,9 +227,9 @@ export default function ValidationPage() {
 
             {/* Garmin comparable */}
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
+              <label className="mb-1 block text-sm font-medium text-foreground">
                 {GARMIN_LABEL[selectedType]}{" "}
-                <span className="font-normal text-gray-400">(optional)</span>
+                <span className="font-normal text-muted-foreground">(optional)</span>
               </label>
               <input
                 type="number"
@@ -237,22 +237,22 @@ export default function ValidationPage() {
                 value={garminValue}
                 onChange={(e) => setGarminValue(e.target.value)}
                 placeholder={`Garmin's ${unit} estimate`}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
               />
             </div>
 
             {/* Notes */}
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
+              <label className="mb-1 block text-sm font-medium text-foreground">
                 Notes{" "}
-                <span className="font-normal text-gray-400">(optional)</span>
+                <span className="font-normal text-muted-foreground">(optional)</span>
               </label>
               <textarea
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
                 rows={2}
                 placeholder="Lab conditions, protocol, context…"
-                className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                className="w-full resize-none rounded-lg border border-border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
               />
             </div>
 
@@ -268,8 +268,8 @@ export default function ValidationPage() {
 
         {/* Match Quality Summary */}
         {Object.keys(matchQuality).length > 0 && (
-          <div className="rounded-xl bg-white p-4 shadow-sm">
-            <h2 className="mb-3 font-semibold text-gray-800">Match Quality</h2>
+          <div className="rounded-xl bg-card p-4 shadow-sm border">
+            <h2 className="mb-3 font-semibold text-foreground">Match Quality</h2>
             <div className="space-y-2">
               {Object.entries(matchQuality).map(([type, { sum, count }]) => {
                 const avg = sum / count;
@@ -279,9 +279,9 @@ export default function ValidationPage() {
                     key={type}
                     className="flex items-center justify-between text-sm"
                   >
-                    <span className="text-gray-700">
+                    <span className="text-foreground">
                       {typeInfo?.emoji} {typeInfo?.label ?? type}
-                      <span className="ml-1 text-gray-400">
+                      <span className="ml-1 text-muted-foreground">
                         ({count} readings)
                       </span>
                     </span>
@@ -294,14 +294,14 @@ export default function ValidationPage() {
         )}
 
         {/* History */}
-        <div className="rounded-xl bg-white p-4 shadow-sm">
-          <h2 className="mb-3 font-semibold text-gray-800">
+        <div className="rounded-xl bg-card p-4 shadow-sm border">
+          <h2 className="mb-3 font-semibold text-foreground">
             Reference Measurements
           </h2>
           {isLoading ? (
-            <p className="text-sm text-gray-500">Loading…</p>
+            <p className="text-sm text-muted-foreground">Loading…</p>
           ) : measurements.length === 0 ? (
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               No reference measurements yet. Add one above to compare Garmin
               accuracy.
             </p>
@@ -314,29 +314,29 @@ export default function ValidationPage() {
                 return (
                   <div
                     key={m.id}
-                    className="rounded-lg border border-gray-100 p-3"
+                    className="rounded-lg border border-border p-3"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="flex-1">
-                        <div className="flex items-center gap-1.5 text-sm font-medium text-gray-800">
+                        <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
                           <span>{typeInfo?.emoji ?? "📐"}</span>
                           <span>{typeInfo?.label ?? m.measurementType}</span>
-                          <span className="text-gray-400">·</span>
-                          <span className="text-gray-500">{m.date}</span>
+                          <span className="text-muted-foreground">·</span>
+                          <span className="text-muted-foreground">{m.date}</span>
                         </div>
                         <div className="mt-1 flex flex-wrap items-center gap-2">
-                          <span className="text-sm text-gray-700">
+                          <span className="text-sm text-foreground">
                             {m.value} {m.unit}
                           </span>
                           {m.garminComparableValue != null && (
-                            <span className="text-xs text-gray-400">
+                            <span className="text-xs text-muted-foreground">
                               Garmin: {m.garminComparableValue} {m.unit}
                             </span>
                           )}
                           {deviationBadge(m.deviationPercent)}
                         </div>
                         {m.notes && (
-                          <p className="mt-1 text-xs text-gray-500">
+                          <p className="mt-1 text-xs text-muted-foreground">
                             {m.notes}
                           </p>
                         )}
@@ -354,7 +354,7 @@ export default function ValidationPage() {
                             </button>
                             <button
                               onClick={() => setConfirmDelete(null)}
-                              className="rounded px-2 py-1 text-xs text-gray-500 hover:bg-gray-50"
+                              className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
                             >
                               Cancel
                             </button>
@@ -362,7 +362,7 @@ export default function ValidationPage() {
                         ) : (
                           <button
                             onClick={() => setConfirmDelete(m.id)}
-                            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-500"
+                            className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-red-500"
                             aria-label="Delete"
                           >
                             🗑️


### PR DESCRIPTION
Round-1 screenshot review surfaced six independent UI issues. All addressed without touching engine math or schemas.

## Changes

### `apps/nextjs/src/app/training/page.tsx`
- **PMC x-axis**: adaptive ~8-tick step (replaces every-7th slicing that mashed labels on 180-day windows).
- **ACWR gauge**: fall back to last PMC point when `analytics.getTrainingLoads` is null → gauge and chart can no longer disagree.
- **Daily Strain y-axis**: explicit `Math.round` tickFormatter so the [0,21] domain stops rendering as '444'.

### `apps/nextjs/src/app/fitness/page.tsx`
- **Performance Comparison**: when below median, label as 'bottom X%' in amber instead of the misleading 'top 90%' in green.
- **Three VO2max charts**: `tickFormatter={(v) => v.toFixed(1)}` + wider YAxis (44px). Decimals no longer drop.

### `apps/nextjs/src/app/_components/garmin-training-summary.tsx`
- Rename to **Garmin Native (Firstbeat)** with a one-liner clarifying device requirements. Differentiates the card from the home-page computed Readiness score.

### `apps/nextjs/src/app/validation/page.tsx`
- Convert light-mode raw utilities (`bg-gray-50`, `bg-white`, `text-gray-*`) to dark-aware semantic tokens (`bg-background`, `bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`). Was the only screen rendering in light mode.

## Verification
- `pnpm --filter @acme/nextjs typecheck` ✅
- No engine or schema changes.

## Follow-up (not in this PR)
- Long-term ACWR consistency would benefit from a single materialized `daily_aggregates` view both gauge and chart consume from. The fallback here is a tactical patch.