### PR TITLE
fix: ui and data consistency pass 2

### DIFF
--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -139,7 +139,7 @@ export function DashboardHome() {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold">Good morning 👋</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Good morning 👋</h1>
         <p className="text-muted-foreground text-sm">
           {new Date().toLocaleDateString("en-US", {
             weekday: "long",

--- a/apps/nextjs/src/app/activities/page.tsx
+++ b/apps/nextjs/src/app/activities/page.tsx
@@ -111,7 +111,7 @@ export default function ActivitiesPage() {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold">Activities</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Activities</h1>
         <p className="text-muted-foreground text-sm">Your recent workouts</p>
       </div>
 
@@ -166,7 +166,7 @@ export default function ActivitiesPage() {
                   <span className="truncate font-medium">
                     {sportLabel(a.sportType)}
                   </span>
-                  {a.subType && (
+                  {a.subType && !/^\d+$/.test(a.subType) && (
                     <span className="text-muted-foreground truncate text-xs">
                       {sportLabel(a.subType)}
                     </span>

--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -341,7 +341,7 @@ export default function CoachPage() {
   return (
     <div className="flex h-dvh flex-col bg-zinc-950">
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-zinc-800 bg-zinc-900 px-4 py-3">
+      <header className="flex items-center justify-between border-b border-zinc-800 bg-zinc-900 px-4 py-3 pl-16 sm:pl-4">
         <div className="flex items-center gap-3">
           <Link
             href="/"

--- a/apps/nextjs/src/app/debug/page.tsx
+++ b/apps/nextjs/src/app/debug/page.tsx
@@ -103,7 +103,7 @@ export default function DebugPage() {
   return (
     <main className="mx-auto max-w-2xl space-y-4 px-4 pt-6 pb-24">
       <div>
-        <h1 className="text-2xl font-bold">🔧 Debug — Data Consistency</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">🔧 Debug — Data Consistency</h1>
         <p className="mt-1 text-sm text-gray-500">
           Side-by-side comparison of the same metric from different sources.
           Anything other than 🟢 means the dashboard cards may disagree.

--- a/apps/nextjs/src/app/export/page.tsx
+++ b/apps/nextjs/src/app/export/page.tsx
@@ -164,7 +164,7 @@ export default function ExportPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold">Data Export</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Data Export</h1>
         <p className="text-muted-foreground text-sm">
           Download your training data · Import backups
         </p>

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -182,10 +182,23 @@ export default function FitnessPage() {
     trpc.analytics.getTrainingLoads.queryOptions(),
   );
 
-  // Latest VO2max value
+  // Latest VO2max value (prefer Garmin Firstbeat → running pace HR → Cooper → UTH)
   const latestVO2max = useMemo(() => {
     if (!vo2max.data?.estimates?.length) return null;
-    return vo2max.data.estimates[0]!;
+    const SOURCE_PRIORITY: Record<string, number> = {
+      garmin_official: 0,
+      running_pace_hr: 1,
+      cooper: 2,
+      uth_method: 4,
+      uth_ratio: 4,
+    };
+    return vo2max.data.estimates.reduce((best, e) => {
+      const bp = SOURCE_PRIORITY[best.source] ?? 3;
+      const ep = SOURCE_PRIORITY[e.source] ?? 3;
+      if (ep < bp) return e;
+      if (ep === bp && new Date(e.date) > new Date(best.date)) return e;
+      return best;
+    }, vo2max.data.estimates[0]!);
   }, [vo2max.data]);
 
   const trend = vo2max.data?.trend;
@@ -352,7 +365,7 @@ export default function FitnessPage() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Fitness &amp; Performance</h1>
+          <h1 className="text-2xl font-bold pl-12 sm:pl-0">Fitness &amp; Performance</h1>
           <p className="text-muted-foreground text-sm">
             VO2max &amp; race predictions
           </p>
@@ -387,6 +400,18 @@ export default function FitnessPage() {
             {latestVO2max.value.toFixed(1)}
           </p>
           <p className="text-muted-foreground mt-1 text-sm">ml/kg/min</p>
+          <p className="text-muted-foreground mt-1 text-[10px] tracking-wider uppercase">
+            via {latestVO2max.source === "garmin_official"
+              ? "Garmin Firstbeat"
+              : latestVO2max.source === "running_pace_hr"
+                ? "Pace+HR model"
+                : latestVO2max.source === "cooper"
+                  ? "Cooper test"
+                  : latestVO2max.source === "uth_method" ||
+                      latestVO2max.source === "uth_ratio"
+                    ? "UTH ratio"
+                    : latestVO2max.source}
+          </p>
           {classification && (
             <p className="mt-2 text-sm">
               <span

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -142,7 +142,7 @@ export default function HrvPage() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">HRV Analysis</h1>
+          <h1 className="text-2xl font-bold pl-12 sm:pl-0">HRV Analysis</h1>
           <p className="text-muted-foreground text-sm">
             Heart Rate Variability &amp; Recovery
           </p>

--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -49,6 +49,37 @@ interface ProactiveInsight {
   isRead: boolean | null;
 }
 
+/** Friendly labels for metric keys cited by AI insights. */
+const METRIC_LABELS: Record<string, string> = {
+  hrv: "HRV",
+  rhr: "Resting HR",
+  resting_hr: "Resting HR",
+  restingHr: "Resting HR",
+  acwr: "ACWR",
+  tsb: "Form (TSB)",
+  ctl: "Fitness (CTL)",
+  atl: "Fatigue (ATL)",
+  spo2: "SpO₂",
+  zone: "Zone",
+  readiness: "Readiness",
+  sleephours: "Sleep",
+  sleep_hours: "Sleep",
+  sleepHours: "Sleep",
+  sleep_duration: "Sleep Duration",
+  sleep_quality: "Sleep Quality",
+  next_day_hrv: "Next-day HRV",
+  stress: "Stress",
+  rr: "Resp. Rate",
+};
+
+function prettyMetricKey(k: string): string {
+  return k
+    .replace(/_/g, " ")
+    .replace(/([A-Z])/g, " $1")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function ProactiveInsightCard({
   insight,
   onMarkRead,
@@ -95,15 +126,28 @@ function ProactiveInsightCard({
 
       {/* Cited metrics */}
       {metricEntries.length > 0 && (
-        <p className="text-muted-foreground mt-2 font-mono text-[11px]">
-          {metricEntries
-            .map(([k, v]) => {
-              const num = typeof v === "number" ? v : parseFloat(String(v));
-              const display = isNaN(num) ? String(v) : num.toFixed(2);
-              return `${k.toUpperCase()}: ${display}`;
-            })
-            .join(" | ")}
-        </p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {metricEntries.map(([k, v]) => {
+            const num = typeof v === "number" ? v : parseFloat(String(v));
+            const display = isNaN(num)
+              ? String(v)
+              : Number.isInteger(num)
+                ? String(num)
+                : num.toFixed(1);
+            const label = METRIC_LABELS[k] ?? prettyMetricKey(k);
+            return (
+              <span
+                key={k}
+                className={cn(
+                  "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                  style.badge,
+                )}
+              >
+                {label}: {display}
+              </span>
+            );
+          })}
+        </div>
       )}
 
       {/* Action suggestion */}
@@ -457,12 +501,16 @@ export default function InsightsPage() {
     trpc.trends.getSummary.queryOptions({ period: "7d" }),
   );
 
+  // Show the skeleton only during the *initial* fetch of every query. Once
+  // any of them errors or returns, we drop out so the page is never stuck on
+  // a perpetual placeholder. Previously a single hanging query (e.g. when
+  // the analytics endpoint timed out) left four skeletons spinning forever.
   const isLoading =
-    readiness.isLoading ||
-    loads.isLoading ||
-    sleepCoach.isLoading ||
-    recovery.isLoading ||
-    trainingStatus.isLoading;
+    readiness.isPending &&
+    loads.isPending &&
+    sleepCoach.isPending &&
+    recovery.isPending &&
+    trainingStatus.isPending;
 
   const insights = useMemo(() => {
     return generateInsights({
@@ -502,7 +550,7 @@ export default function InsightsPage() {
       <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
         {/* ── Header ── */}
         <div>
-          <h1 className="text-2xl font-bold">Insights</h1>
+          <h1 className="text-2xl font-bold pl-12 sm:pl-0">Insights</h1>
           <p className="text-muted-foreground text-sm">
             {new Date().toLocaleDateString("en-US", {
               weekday: "long",

--- a/apps/nextjs/src/app/power/page.tsx
+++ b/apps/nextjs/src/app/power/page.tsx
@@ -125,7 +125,7 @@ export default function PowerPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold">Power &amp; CP Analytics</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Power &amp; CP Analytics</h1>
         <p className="text-muted-foreground text-sm">
           Critical Power · W&apos; · Power-Duration Curve
         </p>

--- a/apps/nextjs/src/app/settings/page.tsx
+++ b/apps/nextjs/src/app/settings/page.tsx
@@ -845,7 +845,7 @@ function GarminConnection() {
 export default function SettingsPage() {
   return (
     <main className="mx-auto max-w-lg space-y-6 px-4 pt-6 pb-24">
-      <h1 className="text-2xl font-bold">Settings</h1>
+      <h1 className="text-2xl font-bold pl-12 sm:pl-0">Settings</h1>
 
       {/* Athlete Profile */}
       <ProfileEditor />

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -148,8 +148,8 @@ export default function SleepDashboard() {
       scores.length > 0
         ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
         : null;
-    const currentDebt =
-      debts.length > 0 ? (debts[debts.length - 1] ?? null) : null;
+    // `history.data` is ordered DESC (newest first), so [0] is the most recent
+    const currentDebt = debts.length > 0 ? (debts[0] ?? null) : null;
 
     // Efficiency: (total - awake) / total * 100
     let avgEfficiency: number | null = null;
@@ -166,7 +166,7 @@ export default function SleepDashboard() {
 
   // ---- Derived: Sleep stages chart data ----
   const stagesChartData = useMemo(() => {
-    const data = stages.data as
+    const raw = stages.data as
       | {
           date: string;
           deepMinutes: number;
@@ -176,7 +176,8 @@ export default function SleepDashboard() {
           sleepNeedMinutes?: number;
         }[]
       | undefined;
-    if (!data) return [];
+    if (!raw) return [];
+    const data = [...raw].reverse();
     return data.map((d) => ({
       date: fmtDateShort(d.date, data.length),
       deep: minToHours(d.deepMinutes),
@@ -200,10 +201,11 @@ export default function SleepDashboard() {
 
   // ---- Derived: Sleep score trend with moving average ----
   const scoreChartData = useMemo(() => {
-    const data = history.data as
+    const raw = history.data as
       | { date: string; sleepScore: number | null }[]
       | undefined;
-    if (!data) return [];
+    if (!raw) return [];
+    const data = [...raw].reverse();
     const scores = data.map((d) => d.sleepScore);
     const ma = data.length > 14 ? movingAvg(scores, 7) : null;
     return data.map((d, i) => ({
@@ -215,14 +217,15 @@ export default function SleepDashboard() {
 
   // ---- Derived: Sleep vs Need chart ----
   const vsNeedChartData = useMemo(() => {
-    const data = history.data as
+    const raw = history.data as
       | {
           date: string;
           totalSleepMinutes: number | null;
           sleepNeedMinutes: number | null;
         }[]
       | undefined;
-    if (!data) return [];
+    if (!raw) return [];
+    const data = [...raw].reverse();
     // Show last 14 days for readability
     const slice = data.slice(-14);
     return slice.map((d) => ({
@@ -234,10 +237,11 @@ export default function SleepDashboard() {
 
   // ---- Derived: Sleep debt tracker (last 7 days) ----
   const debtChartData = useMemo(() => {
-    const data = history.data as
+    const raw = history.data as
       | { date: string; sleepDebt: number | null }[]
       | undefined;
-    if (!data) return [];
+    if (!raw) return [];
+    const data = [...raw].reverse();
     const slice = data.slice(-7);
     return slice.map((d) => ({
       date: fmtDateShort(d.date, slice.length),
@@ -248,14 +252,15 @@ export default function SleepDashboard() {
 
   // ---- Derived: Sleep timing range chart ----
   const timingChartData = useMemo(() => {
-    const data = history.data as
+    const raw = history.data as
       | {
           date: string;
           sleepStartTime: number | null;
           sleepEndTime: number | null;
         }[]
       | undefined;
-    if (!data) return [];
+    if (!raw) return [];
+    const data = [...raw].reverse();
     const slice = data.slice(-14);
     return slice.map((d) => {
       // Normalize bedtime: if after noon treat as same day, otherwise add 24h
@@ -291,7 +296,7 @@ export default function SleepDashboard() {
       {/* Header: Sleep Coach Recommendation                                 */}
       {/* ================================================================== */}
       <div>
-        <h1 className="text-2xl font-bold">Sleep Dashboard</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Sleep Dashboard</h1>
         <p className="text-muted-foreground text-sm">
           Your sleep insights &amp; coaching
         </p>
@@ -384,12 +389,23 @@ export default function SleepDashboard() {
           />
           <StatCard
             label="Sleep Debt"
-            value={fmtDuration(stats.currentDebt)}
+            value={
+              // Prefer the live coach value (used for the "+14h 47m debt"
+              // badge); fall back to last entry in history. Previously the
+              // badge and stat card could disagree because the StatCard
+              // pulled only from history.sleepDebt, which is often null on
+              // today's row before Garmin syncs.
+              coachData != null
+                ? `${coachData.sleepDebtMinutes > 0 ? "+" : ""}${fmtDuration(coachData.sleepDebtMinutes)}`
+                : fmtDuration(stats.currentDebt)
+            }
             icon="📉"
             color={
-              stats.currentDebt != null
-                ? debtTextColor(stats.currentDebt)
-                : "text-zinc-400"
+              coachData != null
+                ? debtTextColor(coachData.sleepDebtMinutes)
+                : stats.currentDebt != null
+                  ? debtTextColor(stats.currentDebt)
+                  : "text-zinc-400"
             }
           />
           <StatCard
@@ -560,7 +576,7 @@ export default function SleepDashboard() {
                 tick={{ fill: "#a1a1aa", fontSize: 11 }}
                 tickLine={false}
                 axisLine={false}
-                width={35}
+                width={40}
               />
               <Tooltip
                 contentStyle={{

--- a/apps/nextjs/src/app/team/page.tsx
+++ b/apps/nextjs/src/app/team/page.tsx
@@ -103,7 +103,7 @@ export default function TeamPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold">Team</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Team</h1>
         <p className="text-muted-foreground text-sm">Multi-athlete dashboard</p>
       </div>
 

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -123,7 +123,7 @@ export default function TrainingLoadPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Training Load</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Training Load</h1>
         {status.data ? (
           <span
             className={cn(
@@ -395,6 +395,7 @@ export default function TrainingLoadPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={32}
                 domain={[0, 21]}
+                ticks={[0, 5, 10, 15, 20]}
               />
               <Tooltip
                 contentStyle={{
@@ -635,6 +636,7 @@ export default function TrainingLoadPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={28}
                 domain={[0, 21]}
+                ticks={[0, 5, 10, 15, 20]}
                 tickFormatter={(v: number) => Math.round(v).toString()}
               />
               <Tooltip

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -46,11 +46,32 @@ const METRIC_COLORS: Record<string, string> = {
 const METRIC_LABELS: Record<string, string> = {
   readiness: "Readiness",
   sleep: "Sleep",
+  sleep_duration: "Sleep Duration",
+  sleep_score: "Sleep Score",
   hrv: "HRV",
+  next_day_hrv: "Next-Day HRV",
   strain: "Strain",
   restingHr: "Resting HR",
+  resting_hr: "Resting HR",
   stress: "Stress",
+  avg_stress: "Avg Stress",
+  steps: "Steps",
+  body_battery: "Body Battery",
+  spo2: "SpO₂",
+  respiration_rate: "Respiration",
+  training_load: "Training Load",
+  tsb: "Form (TSB)",
+  ctl: "Fitness (CTL)",
+  atl: "Fatigue (ATL)",
+  acwr: "ACWR",
 };
+
+function prettyMetric(key: string): string {
+  if (METRIC_LABELS[key]) return METRIC_LABELS[key];
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 type TrendMetric =
   | "readiness"
@@ -295,7 +316,7 @@ export default function TrendsPage() {
     <main className="mx-auto max-w-4xl space-y-6 px-4 pt-6 pb-24">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold">Trends &amp; Analytics</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Trends &amp; Analytics</h1>
         <p className="text-muted-foreground text-sm">
           {PERIODS.find((x) => x.value === period)?.label ?? period} overview
           {useSmoothed ? " · 7-day rolling avg" : ""}
@@ -356,7 +377,7 @@ export default function TrendsPage() {
           />
           <SummaryCard
             label="Avg Stress"
-            value="—"
+            value={s.avgStress != null ? String(s.avgStress) : "—"}
             trend={trendStrain.data}
             color={METRIC_COLORS.strain!}
           />
@@ -419,7 +440,7 @@ export default function TrendsPage() {
                 tick={{ fill: "#a1a1aa", fontSize: 11 }}
                 tickLine={false}
                 axisLine={false}
-                width={35}
+                width={40}
               />
               <YAxis
                 yAxisId="sleep"
@@ -658,8 +679,8 @@ export default function TrendsPage() {
                 >
                   <div className="flex items-center justify-between">
                     <p className="text-sm font-medium">
-                      {METRIC_LABELS[c.metricA] ?? c.metricA} →{" "}
-                      {METRIC_LABELS[c.metricB] ?? c.metricB}
+                      {prettyMetric(c.metricA)} →{" "}
+                      {prettyMetric(c.metricB)}
                     </p>
                     <span
                       className={cn(

--- a/apps/nextjs/src/app/vitals/page.tsx
+++ b/apps/nextjs/src/app/vitals/page.tsx
@@ -297,6 +297,7 @@ export default function VitalsPage() {
                             value: "baseline",
                             fill: "#666",
                             fontSize: 10,
+                            position: "insideTopRight",
                           }}
                         />
                       )}
@@ -441,6 +442,7 @@ export default function VitalsPage() {
                             value: "baseline",
                             fill: "#666",
                             fontSize: 10,
+                            position: "insideTopRight",
                           }}
                         />
                       )}
@@ -582,6 +584,7 @@ export default function VitalsPage() {
                             value: "baseline",
                             fill: "#666",
                             fontSize: 10,
+                            position: "insideTopRight",
                           }}
                         />
                       )}

--- a/apps/nextjs/src/app/workout/[id]/page.tsx
+++ b/apps/nextjs/src/app/workout/[id]/page.tsx
@@ -62,7 +62,7 @@ export default function WorkoutDetailPage() {
 
       {/* Title */}
       <div>
-        <h1 className="text-2xl font-bold">{w.title}</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">{w.title}</h1>
         <p className="text-muted-foreground mt-1 text-sm">
           {w.sportType} · Zone {w.targetHrZoneLow}
           {w.targetHrZoneLow !== w.targetHrZoneHigh

--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -327,7 +327,7 @@ export default function ZoneAnalysisPage() {
     <main className="mx-auto max-w-4xl space-y-6 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold">Zone Analysis</h1>
+        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Zone Analysis</h1>
         <p className="text-muted-foreground mt-1 text-sm">
           HR zone distribution, polarization tracking, and efficiency trends
         </p>
@@ -487,7 +487,7 @@ export default function ZoneAnalysisPage() {
               <YAxis
                 yAxisId="pct"
                 tick={{ fill: "#888", fontSize: 10 }}
-                width={36}
+                width={48}
                 domain={[0, 100]}
                 label={{
                   value: "%",
@@ -628,7 +628,7 @@ export default function ZoneAnalysisPage() {
               />
               <YAxis
                 tick={{ fill: "#888", fontSize: 10 }}
-                width={36}
+                width={48}
                 domain={[0, 100]}
                 label={{
                   value: "%",

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -1,7 +1,7 @@
 import type { TRPCRouterRecord } from "@trpc/server";
 import { z } from "zod/v4";
 
-import { and, desc, eq, gte } from "@acme/db";
+import { and, desc, eq, gte, lte } from "@acme/db";
 import { Activity, Profile } from "@acme/db/schema";
 import { analyzeRunningForm } from "@acme/engine";
 
@@ -28,6 +28,8 @@ export const activityRouter = {
       const conditions = [
         eq(Activity.userId, userId),
         gte(Activity.startedAt, since),
+        // Hide future-dated rows (clock skew / TZ artefacts).
+        lte(Activity.startedAt, new Date()),
       ];
 
       if (input.sportType) {
@@ -96,8 +98,15 @@ export const activityRouter = {
   getRecent: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
+    // Hide future-dated activities. Garmin sync or seed data occasionally
+    // produces records with startedAt past `now()` (clock skew, TZ ambiguity).
+    // The home page renders the most-recent row, so a future row would show
+    // a Friday activity even though today is Thursday.
     const activities = await ctx.db.query.Activity.findMany({
-      where: eq(Activity.userId, userId),
+      where: and(
+        eq(Activity.userId, userId),
+        lte(Activity.startedAt, new Date()),
+      ),
       orderBy: desc(Activity.startedAt),
       limit: 5,
       columns: {

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -143,6 +143,36 @@ function getDateString(daysAgo: number): string {
   return d.toISOString().split("T")[0]!;
 }
 
+// Legacy debug-style explanations look like:
+//   "Buchheit composite: 67/100 (hrv=74, sleep=52, load=36, ...)"
+// Detect them so we can replace with a clean message at read-time.
+function isLegacyDebugExplanation(text: string): boolean {
+  if (!text) return false;
+  const t = text.toLowerCase();
+  return (
+    t.includes("composite:") ||
+    /hrv=\d/.test(t) ||
+    /(load|stress|rhr|spo2|rr)=\d/.test(t)
+  );
+}
+
+function defaultZoneExplanation(zone: string | null): string {
+  switch (zone) {
+    case "prime":
+      return "Prime readiness — great day for intensity.";
+    case "high":
+      return "High readiness — normal training day.";
+    case "moderate":
+      return "Moderate readiness — stick to planned training but listen to your body.";
+    case "low":
+      return "Low readiness — take it easy today.";
+    case "poor":
+      return "Poor readiness — rest or light recovery only.";
+    default:
+      return "Metrics are close to your baseline — normal training day.";
+  }
+}
+
 export const readinessRouter = {
   getToday: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
@@ -183,8 +213,19 @@ export const readinessRouter = {
         dq,
         todayDbMetric ?? null,
       );
+      // Sanitize stale debug-style explanations written by older builds of
+      // the engine, e.g.:
+      //   "Buchheit composite: 67/100 (hrv=74, sleep=52, load=36, ...)"
+      // The current generateExplanation() never emits this shape, but older
+      // rows persist in ReadinessScore. Replace with a generic zone-based
+      // message until the row is recomputed.
+      const explanation =
+        existing.explanation && isLegacyDebugExplanation(existing.explanation)
+          ? defaultZoneExplanation(existing.zone)
+          : existing.explanation;
       return {
         ...existing,
+        explanation,
         confidence,
         dataQuality: dq,
         actionSuggestion,

--- a/packages/api/src/router/trends.ts
+++ b/packages/api/src/router/trends.ts
@@ -150,11 +150,22 @@ export const trendsRouter = {
             ) / 10
           : null;
 
+      const stressVals = metrics
+        .map((m) => m.stressScore)
+        .filter((v): v is number => v !== null && v !== undefined);
+      const avgStress =
+        stressVals.length > 0
+          ? Math.round(
+              stressVals.reduce((sum, v) => sum + v, 0) / stressVals.length,
+            )
+          : null;
+
       return {
         period: input.period,
         avgReadiness,
         avgSleepMinutes: avgSleep,
         avgHrv,
+        avgStress,
         totalDays: metrics.length,
         readinessScores: readinessScores.length,
       };


### PR DESCRIPTION
Addresses 13 issues from pass-2 dashboard screenshot review.

## Visual / layout
- Hamburger overlap: `pl-12 sm:pl-0` on page `<h1>`s + coach header
- YAxis width bumped on `[0,100]` charts (sleep, trends, zones x2) — "100" no longer clipped
- Training Strain: explicit ticks `[0,5,10,15,20]` (no more fractional 82.5)
- Vitals: baseline `ReferenceLine` labels moved to `insideTopRight` to stop overlapping the dashed line

## Data consistency
- **Activities**: filter `startedAt <= now` (no more "Walking Fri May 15" timezone artefacts)
- **Sleep**: reverse chart arrays so they read oldest-left → newest-right; fix `stats.currentDebt` to read newest instead of oldest
- **Activities**: hide pure-numeric `subType` (Garmin sport code leakage like '163')
- **Trends**: extend `METRIC_LABELS` w/ snake_case keys + `prettyMetric()` fallback for correlations
- **Trends**: compute `avgStress` from `DailyMetric.stressScore` (was hard-coded "—")
- **Fitness**: VO2max hero now picks highest-priority source (Firstbeat > Pace+HR > Cooper > UTH) + adds provenance badge — matches Race Predictions
- **Insights**: replace monospace debug dump with friendly chip pills + pretty metric labels
- **Insights**: gate skeleton on `every(.isPending)` not `some(.isLoading)` — no more stuck loading
- **Readiness**: sanitize legacy `Buchheit composite: N/100 (hrv=...)` debug strings stored in DB on read; self-heals on next recompute

Closes #pass-2-screenshots-issues