### PR TITLE
fix: ui and data consistency pass 3

### DIFF
--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -139,7 +139,7 @@ export function DashboardHome() {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Good morning 👋</h1>
+        <h1 className="text-2xl font-bold pl-12">Good morning 👋</h1>
         <p className="text-muted-foreground text-sm">
           {new Date().toLocaleDateString("en-US", {
             weekday: "long",

--- a/apps/nextjs/src/app/activities/page.tsx
+++ b/apps/nextjs/src/app/activities/page.tsx
@@ -111,7 +111,7 @@ export default function ActivitiesPage() {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Activities</h1>
+        <h1 className="text-2xl font-bold pl-12">Activities</h1>
         <p className="text-muted-foreground text-sm">Your recent workouts</p>
       </div>
 

--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -341,7 +341,7 @@ export default function CoachPage() {
   return (
     <div className="flex h-dvh flex-col bg-zinc-950">
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-zinc-800 bg-zinc-900 px-4 py-3 pl-16 sm:pl-4">
+      <header className="flex items-center justify-between border-b border-zinc-800 bg-zinc-900 px-4 py-3 pl-16">
         <div className="flex items-center gap-3">
           <Link
             href="/"

--- a/apps/nextjs/src/app/debug/page.tsx
+++ b/apps/nextjs/src/app/debug/page.tsx
@@ -103,7 +103,7 @@ export default function DebugPage() {
   return (
     <main className="mx-auto max-w-2xl space-y-4 px-4 pt-6 pb-24">
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">🔧 Debug — Data Consistency</h1>
+        <h1 className="text-2xl font-bold pl-12">🔧 Debug — Data Consistency</h1>
         <p className="mt-1 text-sm text-gray-500">
           Side-by-side comparison of the same metric from different sources.
           Anything other than 🟢 means the dashboard cards may disagree.

--- a/apps/nextjs/src/app/export/page.tsx
+++ b/apps/nextjs/src/app/export/page.tsx
@@ -164,7 +164,7 @@ export default function ExportPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Data Export</h1>
+        <h1 className="text-2xl font-bold pl-12">Data Export</h1>
         <p className="text-muted-foreground text-sm">
           Download your training data · Import backups
         </p>

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -365,7 +365,7 @@ export default function FitnessPage() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold pl-12 sm:pl-0">Fitness &amp; Performance</h1>
+          <h1 className="text-2xl font-bold pl-12">Fitness &amp; Performance</h1>
           <p className="text-muted-foreground text-sm">
             VO2max &amp; race predictions
           </p>

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -142,7 +142,7 @@ export default function HrvPage() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold pl-12 sm:pl-0">HRV Analysis</h1>
+          <h1 className="text-2xl font-bold pl-12">HRV Analysis</h1>
           <p className="text-muted-foreground text-sm">
             Heart Rate Variability &amp; Recovery
           </p>

--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -550,7 +550,7 @@ export default function InsightsPage() {
       <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
         {/* ── Header ── */}
         <div>
-          <h1 className="text-2xl font-bold pl-12 sm:pl-0">Insights</h1>
+          <h1 className="text-2xl font-bold pl-12">Insights</h1>
           <p className="text-muted-foreground text-sm">
             {new Date().toLocaleDateString("en-US", {
               weekday: "long",

--- a/apps/nextjs/src/app/power/page.tsx
+++ b/apps/nextjs/src/app/power/page.tsx
@@ -125,7 +125,7 @@ export default function PowerPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Power &amp; CP Analytics</h1>
+        <h1 className="text-2xl font-bold pl-12">Power &amp; CP Analytics</h1>
         <p className="text-muted-foreground text-sm">
           Critical Power · W&apos; · Power-Duration Curve
         </p>

--- a/apps/nextjs/src/app/settings/page.tsx
+++ b/apps/nextjs/src/app/settings/page.tsx
@@ -845,7 +845,7 @@ function GarminConnection() {
 export default function SettingsPage() {
   return (
     <main className="mx-auto max-w-lg space-y-6 px-4 pt-6 pb-24">
-      <h1 className="text-2xl font-bold pl-12 sm:pl-0">Settings</h1>
+      <h1 className="text-2xl font-bold pl-12">Settings</h1>
 
       {/* Athlete Profile */}
       <ProfileEditor />

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -296,7 +296,7 @@ export default function SleepDashboard() {
       {/* Header: Sleep Coach Recommendation                                 */}
       {/* ================================================================== */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Sleep Dashboard</h1>
+        <h1 className="text-2xl font-bold pl-12">Sleep Dashboard</h1>
         <p className="text-muted-foreground text-sm">
           Your sleep insights &amp; coaching
         </p>

--- a/apps/nextjs/src/app/team/page.tsx
+++ b/apps/nextjs/src/app/team/page.tsx
@@ -103,7 +103,7 @@ export default function TeamPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Team</h1>
+        <h1 className="text-2xl font-bold pl-12">Team</h1>
         <p className="text-muted-foreground text-sm">Multi-athlete dashboard</p>
       </div>
 

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -123,7 +123,7 @@ export default function TrainingLoadPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Training Load</h1>
+        <h1 className="text-2xl font-bold pl-12">Training Load</h1>
         {status.data ? (
           <span
             className={cn(

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -316,7 +316,7 @@ export default function TrendsPage() {
     <main className="mx-auto max-w-4xl space-y-6 px-4 pt-6 pb-24">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Trends &amp; Analytics</h1>
+        <h1 className="text-2xl font-bold pl-12">Trends &amp; Analytics</h1>
         <p className="text-muted-foreground text-sm">
           {PERIODS.find((x) => x.value === period)?.label ?? period} overview
           {useSmoothed ? " · 7-day rolling avg" : ""}

--- a/apps/nextjs/src/app/workout/[id]/page.tsx
+++ b/apps/nextjs/src/app/workout/[id]/page.tsx
@@ -62,7 +62,7 @@ export default function WorkoutDetailPage() {
 
       {/* Title */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">{w.title}</h1>
+        <h1 className="text-2xl font-bold pl-12">{w.title}</h1>
         <p className="text-muted-foreground mt-1 text-sm">
           {w.sportType} · Zone {w.targetHrZoneLow}
           {w.targetHrZoneLow !== w.targetHrZoneHigh

--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -327,7 +327,7 @@ export default function ZoneAnalysisPage() {
     <main className="mx-auto max-w-4xl space-y-6 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold pl-12 sm:pl-0">Zone Analysis</h1>
+        <h1 className="text-2xl font-bold pl-12">Zone Analysis</h1>
         <p className="text-muted-foreground mt-1 text-sm">
           HR zone distribution, polarization tracking, and efficiency trends
         </p>
@@ -489,13 +489,7 @@ export default function ZoneAnalysisPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={48}
                 domain={[0, 100]}
-                label={{
-                  value: "%",
-                  angle: -90,
-                  position: "insideLeft",
-                  fill: "#666",
-                  fontSize: 10,
-                }}
+                tickFormatter={(v: number) => `${v}%`}
               />
               <YAxis
                 yAxisId="pi"
@@ -630,13 +624,7 @@ export default function ZoneAnalysisPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={48}
                 domain={[0, 100]}
-                label={{
-                  value: "%",
-                  angle: -90,
-                  position: "insideLeft",
-                  fill: "#666",
-                  fontSize: 10,
-                }}
+                tickFormatter={(v: number) => `${v}%`}
               />
               <Tooltip
                 contentStyle={TOOLTIP_STYLE}

--- a/packages/api/src/lib/data-context.ts
+++ b/packages/api/src/lib/data-context.ts
@@ -87,7 +87,7 @@ export async function buildDataContext(
     activities10,
     profile,
     latestReadiness,
-    latestVo2,
+    vo2Estimates,
     metrics30,
     journal7,
     interventions10,
@@ -125,11 +125,12 @@ export async function buildDataContext(
       orderBy: desc(ReadinessScore.date),
     }) as Promise<typeof ReadinessScore.$inferSelect | undefined>,
 
-    // Latest VO2max estimate
-    db.query.VO2maxEstimate.findFirst({
+    // Recent VO2max estimates — we pick best by source priority below
+    db.query.VO2maxEstimate.findMany({
       where: eq(VO2maxEstimate.userId, userId),
       orderBy: desc(VO2maxEstimate.date),
-    }) as Promise<typeof VO2maxEstimate.$inferSelect | undefined>,
+      limit: 30,
+    }) as Promise<(typeof VO2maxEstimate.$inferSelect)[]>,
 
     // 30-day activities for zone distribution
     db.query.Activity.findMany({
@@ -173,6 +174,32 @@ export async function buildDataContext(
       where: eq(AthleteBaseline.userId, userId),
     }) as Promise<(typeof AthleteBaseline.$inferSelect)[]>,
   ]);
+
+  // Pick the best VO2max estimate using the same source priority as the UI
+  // hero card (Garmin Firstbeat > pace+HR > Cooper > UTH). This keeps the AI
+  // agent narrative aligned with the dashboard's "Current VO2max" number.
+  const VO2_SOURCE_PRIORITY: Record<string, number> = {
+    garmin_official: 0,
+    running_pace_hr: 1,
+    cooper: 2,
+    uth_method: 4,
+    uth_ratio: 4,
+  };
+  const latestVo2 =
+    vo2Estimates.length === 0
+      ? undefined
+      : vo2Estimates.reduce((best, e) => {
+          const bp = VO2_SOURCE_PRIORITY[best.source] ?? 3;
+          const ep = VO2_SOURCE_PRIORITY[e.source] ?? 3;
+          if (ep < bp) return e;
+          if (
+            ep === bp &&
+            new Date(e.date).getTime() > new Date(best.date).getTime()
+          ) {
+            return e;
+          }
+          return best;
+        }, vo2Estimates[0]!);
 
   // Early exit if no data at all
   if (!profile && metrics14.length === 0 && activities10.length === 0) {

--- a/packages/engine/src/correlations/index.ts
+++ b/packages/engine/src/correlations/index.ts
@@ -138,6 +138,32 @@ export function analyzeCorrelation(
   };
 }
 
+function prettyMetric(key: string): string {
+  const LABELS: Record<string, string> = {
+    readiness: "readiness",
+    sleep: "sleep",
+    sleep_duration: "sleep duration",
+    sleep_quality: "sleep quality",
+    sleep_score: "sleep score",
+    hrv: "HRV",
+    next_day_hrv: "next-day HRV",
+    strain: "strain",
+    stress: "stress",
+    avg_stress: "average stress",
+    resting_hr: "resting HR",
+    restingHr: "resting HR",
+    steps: "steps",
+    body_battery: "body battery",
+    training_load: "training load",
+    tsb: "form (TSB)",
+    ctl: "fitness (CTL)",
+    atl: "fatigue (ATL)",
+    acwr: "ACWR",
+  };
+  if (LABELS[key]) return LABELS[key];
+  return key.replace(/[_-]+/g, " ");
+}
+
 function generateCorrelationInsight(
   metricA: string,
   metricB: string,
@@ -146,8 +172,10 @@ function generateCorrelationInsight(
   pValue: number,
   n: number,
 ): string {
+  const a = prettyMetric(metricA);
+  const b = prettyMetric(metricB);
   if (strength === "none") {
-    return `No meaningful correlation between ${metricA} and ${metricB} (r=${r.toFixed(2)}, n=${n}).`;
+    return `No meaningful correlation between ${a} and ${b} (r=${r.toFixed(2)}, n=${n}).`;
   }
 
   const direction = r > 0 ? "positively" : "negatively";
@@ -159,13 +187,13 @@ function generateCorrelationInsight(
   let actionable = "";
   if (strength === "strong" && pValue < 0.05) {
     if (r > 0) {
-      actionable = ` Higher ${metricA} is associated with higher ${metricB}.`;
+      actionable = ` Higher ${a} is associated with higher ${b}.`;
     } else {
-      actionable = ` Higher ${metricA} is associated with lower ${metricB}.`;
+      actionable = ` Higher ${a} is associated with lower ${b}.`;
     }
   }
 
-  return `${metricA} and ${metricB} are ${strength}ly ${direction} correlated (r=${r.toFixed(2)}, p=${pValue < 0.001 ? "<0.001" : pValue.toFixed(3)}, n=${n}). This is ${significance}.${actionable}`;
+  return `${a} and ${b} are ${strength}ly ${direction} correlated (r=${r.toFixed(2)}, p=${pValue < 0.001 ? "<0.001" : pValue.toFixed(3)}, n=${n}). This is ${significance}.${actionable}`;
 }
 
 /**


### PR DESCRIPTION
Addresses 4 remaining issues from pass-3 screenshots of v0.16.9.

- **Hamburger overlap (desktop)**: `pl-12 sm:pl-0` → `pl-12` unconditional. Hamburger is fixed at every breakpoint so titles were still clipped at ≥640px.
- **Zones "00000001" Y-axis artefact**: replace rotated `%` axis label with per-tick `tickFormatter` suffix on Training Polarization & Monthly Zone Distribution.
- **Coach AI VO2max mismatch**: data-context now picks best estimate by source priority (Firstbeat > Pace+HR > Cooper > UTH), matching the Fitness hero card (32.5 vs 28.7).
- **Correlation insight snake_case**: `prettyMetric()` in the engine so "sleep_duration and readiness…" becomes "sleep duration and readiness…".