### PR TITLE
fix: zones y-axis explicit ticks + insights tabular-nums

### DIFF
--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -139,7 +139,7 @@ function ProactiveInsightCard({
               <span
                 key={k}
                 className={cn(
-                  "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                  "rounded-full px-2 py-0.5 text-[10px] font-medium tabular-nums",
                   style.badge,
                 )}
               >

--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -489,6 +489,8 @@ export default function ZoneAnalysisPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={48}
                 domain={[0, 100]}
+                ticks={[0, 25, 50, 75, 100]}
+                allowDataOverflow
                 tickFormatter={(v: number) => `${v}%`}
               />
               <YAxis
@@ -624,6 +626,8 @@ export default function ZoneAnalysisPage() {
                 tick={{ fill: "#888", fontSize: 10 }}
                 width={48}
                 domain={[0, 100]}
+                ticks={[0, 25, 50, 75, 100]}
+                allowDataOverflow
                 tickFormatter={(v: number) => `${v}%`}
               />
               <Tooltip


### PR DESCRIPTION
Pass-5 UX. Two issues spotted after v0.16.11:

- **Zones Y-axis `3000001%`** — replaced auto-ticks with explicit `ticks=[0,25,50,75,100]` + `allowDataOverflow` on Training Polarization + Monthly Zone Distribution charts.
- **Insights chip `Fatigue (ATL): 4 4.8`** — adjacent identical digits at 10pt SVG kerning. Added `tabular-nums` className.

Typecheck ✅