### PR TITLE
feat: whoop-style daily outlook card + ux cleanups

### DIFF
--- a/apps/nextjs/src/app/_components/daily-outlook-card.tsx
+++ b/apps/nextjs/src/app/_components/daily-outlook-card.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import type { TargetStrainBand } from "@acme/engine";
+
+interface Props {
+  targetStrain: TargetStrainBand | null;
+  isLoading?: boolean;
+}
+
+const ZONE_COLOR: Record<string, string> = {
+  prime: "#22c55e",
+  high: "#14b8a6",
+  moderate: "#eab308",
+  low: "#f97316",
+  poor: "#ef4444",
+};
+
+export function DailyOutlookCard({ targetStrain, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <div className="bg-card animate-pulse rounded-2xl border p-4">
+        <div className="bg-muted h-5 w-40 rounded" />
+        <div className="bg-muted mt-3 h-10 rounded" />
+      </div>
+    );
+  }
+
+  if (!targetStrain) return null;
+
+  const { min, max, target, label, rationale, readinessZone } = targetStrain;
+  const color = ZONE_COLOR[readinessZone] ?? "#888";
+
+  // Visualise band as a 0-21 horizontal scale.
+  const pctLeft = (min / 21) * 100;
+  const pctRight = (max / 21) * 100;
+  const pctTarget = (target / 21) * 100;
+
+  return (
+    <div className="bg-card rounded-2xl border p-4">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold tracking-wide uppercase">
+          Today&apos;s Target Strain
+        </h2>
+        <span
+          className="rounded-full px-2 py-0.5 text-[10px] font-medium tabular-nums"
+          style={{ backgroundColor: `${color}22`, color }}
+        >
+          {label}
+        </span>
+      </div>
+
+      <div className="mt-3 flex items-baseline gap-2">
+        <span
+          className="text-3xl font-bold tabular-nums"
+          style={{ color }}
+        >
+          {min}–{max}
+        </span>
+        <span className="text-muted-foreground text-xs">/ 21</span>
+      </div>
+
+      {/* 0-21 strain scale band */}
+      <div className="mt-3">
+        <div className="relative h-2 w-full overflow-hidden rounded-full bg-zinc-800">
+          <div
+            className="absolute top-0 h-full rounded-full"
+            style={{
+              left: `${pctLeft}%`,
+              width: `${pctRight - pctLeft}%`,
+              backgroundColor: color,
+            }}
+          />
+          <div
+            className="absolute top-1/2 h-3 w-0.5 -translate-y-1/2 bg-white"
+            style={{ left: `${pctTarget}%` }}
+            aria-label="Target midpoint"
+          />
+        </div>
+        <div className="text-muted-foreground mt-1 flex justify-between text-[10px] tabular-nums">
+          <span>0</span>
+          <span>Light</span>
+          <span>Moderate</span>
+          <span>Vigorous</span>
+          <span>21</span>
+        </div>
+      </div>
+
+      <p className="text-muted-foreground mt-3 text-xs leading-snug">
+        {rationale}
+      </p>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "./bottom-nav";
+import { DailyOutlookCard } from "./daily-outlook-card";
 import { IngressLink as Link } from "./ingress-link";
 import { QuickStats } from "./quick-stats";
 import { ReadinessCard } from "./readiness-card";
@@ -165,6 +166,14 @@ export function DashboardHome() {
         }
         actionSuggestion={(r?.actionSuggestion as string) ?? null}
         doNotOverinterpret={(r?.doNotOverinterpret as boolean) ?? null}
+        isLoading={readiness.isLoading}
+      />
+
+      {/* WHOOP-style Daily Outlook — target day-strain band */}
+      <DailyOutlookCard
+        targetStrain={
+          (r?.targetStrain as import("@acme/engine").TargetStrainBand) ?? null
+        }
         isLoading={readiness.isLoading}
       />
 

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -100,6 +100,17 @@ export default function SleepDashboard() {
   // ---- Data queries ----
   const coach = useQuery(trpc.sleep.getCoach.queryOptions());
 
+  // Surface coach data early so it can be referenced by derived data
+  // (e.g. debt chart fallback) declared further down.
+  const coachData = coach.data as
+    | {
+        recommendedDurationMinutes: number;
+        recommendedBedtime: string;
+        sleepDebtMinutes: number;
+        insight: string;
+      }
+    | undefined;
+
   const stages = useQuery(
     trpc.sleep.getStages.queryOptions({ days: sleepDays }),
   );
@@ -236,19 +247,38 @@ export default function SleepDashboard() {
   }, [history.data]);
 
   // ---- Derived: Sleep debt tracker (last 7 days) ----
+  // Daily debt = max(0, sleepNeed - actualSleep). The historic
+  // DailyMetric.sleepDebtMinutes and sleepNeedMinutes columns are
+  // not backfilled by the ETL, so we fall back to the coach's
+  // computed need (constant across the 7-day window) and compute
+  // each day's debt from totalSleepMinutes (which IS populated).
   const debtChartData = useMemo(() => {
     const raw = history.data as
-      | { date: string; sleepDebt: number | null }[]
+      | {
+          date: string;
+          sleepDebt: number | null;
+          sleepNeedMinutes: number | null;
+          totalSleepMinutes: number | null;
+        }[]
       | undefined;
     if (!raw) return [];
     const data = [...raw].reverse();
     const slice = data.slice(-7);
-    return slice.map((d) => ({
-      date: fmtDateShort(d.date, slice.length),
-      debt: d.sleepDebt ?? 0,
-      color: debtColor(d.sleepDebt ?? 0),
-    }));
-  }, [history.data]);
+    const fallbackNeed =
+      coachData?.recommendedDurationMinutes ?? 480; // 8h default
+    return slice.map((d) => {
+      const need = d.sleepNeedMinutes ?? fallbackNeed;
+      const actual = d.totalSleepMinutes;
+      const computed =
+        actual != null ? Math.max(0, need - actual) : 0;
+      const debt = d.sleepDebt ?? computed;
+      return {
+        date: fmtDateShort(d.date, slice.length),
+        debt,
+        color: debtColor(debt),
+      };
+    });
+  }, [history.data, coachData?.recommendedDurationMinutes]);
 
   // ---- Derived: Sleep timing range chart ----
   const timingChartData = useMemo(() => {
@@ -278,16 +308,6 @@ export default function SleepDashboard() {
       };
     });
   }, [history.data]);
-
-  // ---- Coach data ----
-  const coachData = coach.data as
-    | {
-        recommendedDurationMinutes: number;
-        recommendedBedtime: string;
-        sleepDebtMinutes: number;
-        insight: string;
-      }
-    | undefined;
 
   // ---------------------------------------------------------------------------
   return (

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -83,7 +83,7 @@ type TrendMetric =
 type TrendPeriod = "30d" | "90d" | "180d" | "365d";
 type CorrelationPeriod = "30d" | "90d" | "180d";
 
-const CHART_METRICS: TrendMetric[] = ["readiness", "sleep", "hrv"];
+const CHART_METRICS: TrendMetric[] = ["readiness", "sleep", "hrv", "stress"];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -462,6 +462,16 @@ export default function TrendsPage() {
                 width={0}
                 hide
               />
+              <YAxis
+                yAxisId="stress"
+                orientation="right"
+                domain={[0, 100]}
+                tick={false}
+                tickLine={false}
+                axisLine={false}
+                width={0}
+                hide
+              />
               <Tooltip
                 contentStyle={{
                   backgroundColor: "#18181b",
@@ -479,6 +489,8 @@ export default function TrendsPage() {
                     return [`${Math.round(v)} ms`, "HRV"];
                   if (n === "readiness" && v != null)
                     return [`${Math.round(v)}`, "Readiness"];
+                  if (n === "stress" && v != null)
+                    return [`${Math.round(v)}`, "Stress"];
                   return [`${v}`, METRIC_LABELS[n] ?? n];
                 }}
               />
@@ -512,6 +524,16 @@ export default function TrendsPage() {
                 dataKey="hrv"
                 stroke={METRIC_COLORS.hrv}
                 fill={`url(#gradient-hrv)`}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+              />
+              <Area
+                yAxisId="stress"
+                type="monotone"
+                dataKey="stress"
+                stroke={METRIC_COLORS.stress}
+                fill={`url(#gradient-stress)`}
                 strokeWidth={2}
                 dot={false}
                 connectNulls

--- a/packages/api/src/lib/data-context.ts
+++ b/packages/api/src/lib/data-context.ts
@@ -25,6 +25,20 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DB = any;
 
+/**
+ * Render a Garmin sport-code (e.g. "Tennis_v2", "trail_running",
+ * "lap_swimming") as a human-readable label suitable for LLM prompts
+ * and user-facing strings.
+ */
+function prettySport(code: string | null | undefined): string {
+  if (!code) return "Activity";
+  return code
+    .replace(/_v\d+$/i, "") // drop "_v2" / "_v3" variant suffixes
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -321,7 +335,7 @@ export async function buildDataContext(
           ? `${(a.distanceMeters / 1000).toFixed(1)}km`
           : "";
       lines.push(
-        `- ${a.sportType}: ${dur}min${dist ? `, ${dist}` : ""}, ${hr}${strain ? `, ${strain}` : ""}`,
+        `- ${prettySport(a.sportType)}: ${dur}min${dist ? `, ${dist}` : ""}, ${hr}${strain ? `, ${strain}` : ""}`,
       );
     }
     sections.push(lines.join("\n"));

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -13,6 +13,7 @@ import {
   calculateReadiness,
   computeBaselines,
   computeStrainScore,
+  computeTargetStrain,
   computeTRIMP,
   detectAnomalies,
   getReadinessZone,
@@ -272,6 +273,14 @@ export const readinessRouter = {
       todayDbMetric ?? null,
     );
 
+    // Daily target-strain band (WHOOP-style coaching) — uses readiness
+    // zone for the default band and personalises toward the athlete's
+    // recent strain history when ≥7 sessions are available.
+    const targetStrain = computeTargetStrain(
+      result.score,
+      recentStrainScores.slice(0, 14),
+    );
+
     // Store the computed score
     await ctx.db.insert(ReadinessScore).values({
       userId,
@@ -298,6 +307,7 @@ export const readinessRouter = {
       dataQuality: dq,
       actionSuggestion,
       doNotOverinterpret,
+      targetStrain,
     };
   }),
 

--- a/packages/engine/src/__tests__/target-strain.test.ts
+++ b/packages/engine/src/__tests__/target-strain.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+
+import { computeTargetStrain } from "../coaching/target-strain";
+
+describe("computeTargetStrain", () => {
+  it("maps prime readiness to all-out band", () => {
+    const band = computeTargetStrain(90);
+    expect(band.readinessZone).toBe("prime");
+    expect(band.label).toBe("All-out");
+    expect(band.min).toBeGreaterThanOrEqual(13);
+    expect(band.max).toBeGreaterThanOrEqual(15);
+    expect(band.max).toBeLessThanOrEqual(21);
+  });
+
+  it("maps poor readiness to recovery band", () => {
+    const band = computeTargetStrain(10);
+    expect(band.readinessZone).toBe("poor");
+    expect(band.label).toBe("Recovery");
+    expect(band.max).toBeLessThanOrEqual(10);
+  });
+
+  it("clamps out-of-range scores", () => {
+    expect(computeTargetStrain(-50).readinessZone).toBe("poor");
+    expect(computeTargetStrain(150).readinessZone).toBe("prime");
+  });
+
+  it("midpoint is between min and max", () => {
+    const band = computeTargetStrain(70);
+    expect(band.target).toBeGreaterThanOrEqual(band.min);
+    expect(band.target).toBeLessThanOrEqual(band.max);
+  });
+
+  it("personalises toward athlete median when ≥7 days of strain history", () => {
+    // Low-volume athlete: median strain ~5
+    const lowVol = computeTargetStrain(70, [4, 5, 6, 5, 4, 6, 5, 5, 5, 5]);
+    // High-volume athlete: median strain ~16
+    const highVol = computeTargetStrain(70, [15, 16, 17, 16, 15, 17, 16]);
+
+    // Same readiness, but bands should differ by the personalisation shift.
+    expect(lowVol.target).toBeLessThan(highVol.target);
+  });
+
+  it("does not personalise with <7 days of data", () => {
+    const noHistory = computeTargetStrain(70);
+    const fewDays = computeTargetStrain(70, [10, 12, 11]);
+    expect(noHistory.target).toBe(fewDays.target);
+  });
+
+  it("output bounds are within 0-21 WHOOP scale", () => {
+    for (const score of [0, 25, 50, 75, 100]) {
+      const band = computeTargetStrain(score, [20, 20, 20, 20, 20, 20, 20, 20]);
+      expect(band.min).toBeGreaterThanOrEqual(0);
+      expect(band.max).toBeLessThanOrEqual(21);
+    }
+  });
+});

--- a/packages/engine/src/coaching/target-strain.ts
+++ b/packages/engine/src/coaching/target-strain.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReadinessZone } from "../types";
+import { getReadinessZone } from "../readiness";
+
+export interface TargetStrainBand {
+  /** Lower bound of recommended day-strain (0-21 WHOOP scale). */
+  min: number;
+  /** Upper bound of recommended day-strain (0-21 WHOOP scale). */
+  max: number;
+  /** Midpoint, useful for single-number summaries. */
+  target: number;
+  /** Plain-language label (e.g. "All-out", "Moderate", "Recovery"). */
+  label: string;
+  /** Short rationale citing the readiness zone. */
+  rationale: string;
+  /** Echoed readiness zone (driven the band). */
+  readinessZone: ReadinessZone;
+}
+
+/**
+ * Compute today's recommended Day-Strain band.
+ *
+ * Maps the readiness score onto a target Day-Strain (0-21) band on the
+ * WHOOP-style exponential strain scale. The defaults are derived from
+ * WHOOP's published "Strain Coach" guidance (rest, moderate, all-out)
+ * and converted to numeric bands using the asymptotic strain curve in
+ * `computeStrainScore` (where ~14 ≈ "vigorous", ~18 ≈ "all-out").
+ *
+ * Refs:
+ *  - Foster C et al. A new approach to monitoring exercise training.
+ *    J Strength Cond Res. 2001;15(1):109-115.  (session RPE → load)
+ *  - Halson SL. Monitoring training load to understand fatigue in
+ *    athletes. Sports Med. 2014;44(Suppl 2):S139-S147.
+ *  - Soligard T et al. How much is too much? IOC consensus statement
+ *    on load. Br J Sports Med. 2016;50(17):1030-1041.
+ *  - Hulin BT et al. The acute:chronic workload ratio. Br J Sports
+ *    Med. 2016;50(4):231-236.  (ACWR sweet-spot 0.8-1.3 maps to
+ *    "build" vs "consolidate" recommendations below)
+ *
+ * Optionally narrows the band toward the athlete's recent
+ * chronic load (last 14 days) so the recommendation tracks their
+ * actual training level instead of WHOOP's population defaults.
+ *
+ * @param readinessScore readiness 0-100 (see ./readiness)
+ * @param recentDailyStrains last 14 days of daily-strain values (0-21).
+ *        Used only to compute an athlete-specific midpoint (median).
+ */
+export function computeTargetStrain(
+  readinessScore: number,
+  recentDailyStrains: number[] = [],
+): TargetStrainBand {
+  const score = Math.max(0, Math.min(100, readinessScore));
+  const zone = getReadinessZone(score);
+
+  // Population-default bands by readiness zone (WHOOP Strain Coach style).
+  const defaults: Record<
+    ReadinessZone,
+    { min: number; max: number; label: string }
+  > = {
+    prime: { min: 14, max: 18, label: "All-out" },
+    high: { min: 11, max: 15, label: "Vigorous" },
+    moderate: { min: 8, max: 12, label: "Moderate" },
+    low: { min: 4, max: 9, label: "Light" },
+    poor: { min: 0, max: 6, label: "Recovery" },
+  };
+  const base = defaults[zone];
+
+  // Personalise toward the athlete's median chronic strain when we
+  // have ≥7 days of data. Shifts the band by up to ±2 points so we
+  // don't ask a recreational athlete to hit a pro-level number.
+  let { min, max } = base;
+  if (recentDailyStrains.length >= 7) {
+    const sorted = [...recentDailyStrains].sort((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)] ?? 0;
+    const midpoint = (min + max) / 2;
+    const shift = clamp(median - midpoint, -2, 2);
+    min = clamp(min + shift, 0, 21);
+    max = clamp(max + shift, 0, 21);
+  }
+
+  const target = Math.round(((min + max) / 2) * 10) / 10;
+  const rationale = rationaleFor(zone);
+
+  return {
+    min: round1(min),
+    max: round1(max),
+    target,
+    label: base.label,
+    rationale,
+    readinessZone: zone,
+  };
+}
+
+function rationaleFor(zone: ReadinessZone): string {
+  switch (zone) {
+    case "prime":
+      return "Your body is primed for hard work — chase a peak session today.";
+    case "high":
+      return "Good recovery — capacity for a quality session is high.";
+    case "moderate":
+      return "Recovery is partial — train, but stay in the aerobic zone.";
+    case "low":
+      return "Recovery is impaired — keep effort easy and conversational.";
+    case "poor":
+      return "Recovery is poor — prioritise rest, mobility, or a short walk.";
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function round1(v: number): number {
+  return Math.round(v * 10) / 10;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -74,6 +74,9 @@ export {
   adjustDifficulty,
 } from "./coaching";
 
+export { computeTargetStrain } from "./coaching/target-strain";
+export type { TargetStrainBand } from "./coaching/target-strain";
+
 // New modules
 export {
   estimateVO2maxFromRunning,


### PR DESCRIPTION
## Summary

Ships the signature WHOOP-style coaching surface — a **Target Strain band** for today on the home page — plus three deferred polish items spotted in pass-5 screenshots.

## WHOOP Daily Outlook

- New `computeTargetStrain(readiness, recentStrain)` engine helper. Maps readiness zone → 0-21 day-strain band, personalises ±2 toward athlete median chronic strain when ≥7 sessions available. Citations: Foster 2001, Halson 2014, Soligard 2016, Hulin 2016. 7 new vitest cases.
- `readiness.getToday` returns `targetStrain` alongside the existing score.
- New `DailyOutlookCard` on home: zone-tinted band (e.g. `14–18`), 0-21 horizontal scale viz with band highlight + midpoint marker, label badge (All-out / Vigorous / Moderate / Light / Recovery), rationale text.

## UX cleanups

1. **Sport codes for the LLM** — `prettySport()` strips `_v\d+` and snake_case before recent-activity is templated into the Coach prompt (`Tennis_v2` → `Tennis`).
2. **Stress overlay** — Trends > Multi-Metric Trend now toggles Stress alongside Readiness / Sleep / HRV.
3. **Sleep Debt 7-day chart** — recomputes per-day debt from `sleepNeed − actualSleep` because `DailyMetric.sleepDebtMinutes` is never written by the ETL. Previously all dots rendered at 0 despite the +13h17m cumulative debt badge.

## Test plan

- `pnpm turbo typecheck` — all 15 tasks green
- `pnpm --filter @acme/engine test` — 192 tests pass (185 prior + 7 new for target-strain)