### PR TITLE
test: pin Alpine ICU + Invalid time value regressions

### DIFF
--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { dayInTimezone, shiftIsoDay } from "../lib/timezone";
+import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
+
+const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 describe("dayInTimezone", () => {
   it("renders YYYY-MM-DD in UTC by default", () => {
@@ -36,6 +38,129 @@ describe("dayInTimezone", () => {
     expect(dayInTimezone(new Date(NaN), "Australia/Sydney")).toBe(
       "1970-01-01",
     );
+  });
+
+  // ---------------------------------------------------------------------
+  // Regression: Alpine / HA addon minimal-ICU locale fallback
+  // ---------------------------------------------------------------------
+  // The HA addon base image's Alpine `nodejs=~22` package ships a minimal
+  // ICU build (system-icu) without the en-CA CLDR data. In that environment
+  // `Intl.DateTimeFormat('en-CA', …).format()` silently falls back to
+  // en-US `MM/DD/YYYY`, which previously broke `shiftIsoDay` and crashed
+  // `analytics.getTrainingLoads` / `getTrainingStatus` with
+  // `RangeError: Invalid time value`. We fixed this by switching to
+  // `formatToParts()` (locale-independent because each field is named).
+  // These tests pin that behaviour so the bug can never regress.
+  describe("regression: Alpine ICU en-CA fallback", () => {
+    it("output is always YYYY-MM-DD across many timezones", () => {
+      const d = new Date("2026-05-15T10:00:00Z");
+      const zones = [
+        "UTC",
+        "Australia/Sydney",
+        "Australia/Perth",
+        "America/Los_Angeles",
+        "America/New_York",
+        "Europe/London",
+        "Europe/Berlin",
+        "Asia/Tokyo",
+        "Asia/Kolkata",
+        "Pacific/Auckland",
+      ];
+      for (const zone of zones) {
+        expect(
+          dayInTimezone(d, zone),
+          `zone=${zone} must produce YYYY-MM-DD`,
+        ).toMatch(ISO_DAY_RE);
+      }
+    });
+
+    it("never returns MM/DD/YYYY even when the locale falls back to en-US", () => {
+      // Simulate the exact Alpine minimal-ICU pathology: `format()` returns
+      // en-US `MM/DD/YYYY` instead of `YYYY-MM-DD`. `formatToParts()` must
+      // still produce the correct named-field types because parts are named
+      // by contract, not by locale string order. We mock the global rather
+      // than subclassing `Intl.DateTimeFormat` (V8 internal-slot classes
+      // don't subclass cleanly — `super.formatToParts()` throws).
+      //
+      // NOTE: Uses a fresh IANA zone ("Indian/Mauritius") to bypass the
+      // module-level `FORMATTER_CACHE`, otherwise the previously-cached
+      // real formatter would be reused and the stub would be inert.
+      const RealDTF = Intl.DateTimeFormat;
+      function FallbackDTF(
+        _locale?: string | string[],
+        opts?: Intl.DateTimeFormatOptions,
+      ) {
+        const real = new RealDTF("en-CA", opts);
+        return {
+          // Pretend `format()` fell back to en-US `MM/DD/YYYY`.
+          format(date?: Date | number) {
+            const parts = real.formatToParts(date ?? new Date());
+            const get = (t: string) =>
+              parts.find((p) => p.type === t)?.value ?? "??";
+            return `${get("month")}/${get("day")}/${get("year")}`;
+          },
+          // `formatToParts` keeps real semantics — that's what the fix uses.
+          formatToParts(date?: Date | number) {
+            return real.formatToParts(date ?? new Date());
+          },
+          resolvedOptions: () => real.resolvedOptions(),
+        };
+      }
+      vi.stubGlobal("Intl", { ...Intl, DateTimeFormat: FallbackDTF });
+
+      const result = dayInTimezone(
+        new Date("2026-05-15T10:00:00Z"),
+        "Indian/Mauritius",
+      );
+
+      expect(result).toMatch(ISO_DAY_RE);
+      expect(result).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
+      // And it must remain round-trippable through shiftIsoDay (the
+      // actual production throw site).
+      expect(() => shiftIsoDay(result, -1)).not.toThrow();
+      expect(shiftIsoDay(result, -1)).toMatch(ISO_DAY_RE);
+    });
+
+    it("dayInTimezone output is always accepted by shiftIsoDay (round-trip)", () => {
+      // Pin the contract between the two helpers: whatever `dayInTimezone`
+      // emits must be a valid input to `shiftIsoDay`, otherwise
+      // `aggregateDailyLoads` (which composes them) throws.
+      const dates = [
+        new Date("2026-01-01T00:00:00Z"),
+        new Date("2026-06-15T23:59:59Z"),
+        new Date("2026-12-31T23:30:00Z"),
+        new Date("2026-03-09T02:30:00Z"), // US DST spring-forward
+        new Date("2026-04-05T02:30:00Z"), // AU DST autumn-back
+      ];
+      const zones = ["UTC", "Australia/Sydney", "America/Los_Angeles"];
+      for (const date of dates) {
+        for (const zone of zones) {
+          const day = dayInTimezone(date, zone);
+          expect(day).toMatch(ISO_DAY_RE);
+          for (const delta of [-28, -7, -1, 0, 1, 7, 28]) {
+            expect(() => shiftIsoDay(day, delta)).not.toThrow();
+            expect(shiftIsoDay(day, delta)).toMatch(ISO_DAY_RE);
+          }
+        }
+      }
+    });
+
+    it("todayInTimezone never throws and returns YYYY-MM-DD", () => {
+      // The production call chain is `todayInTimezone(profile.tz)` →
+      // `shiftIsoDay(today, -N)` for every day in the load window. If
+      // `todayInTimezone` ever returns a non-ISO string, every analytics
+      // load query crashes.
+      expect(todayInTimezone("Australia/Sydney")).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone("UTC")).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone(null)).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone(undefined)).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone("")).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone("Bogus/Timezone")).toMatch(ISO_DAY_RE);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 });
 

--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
 
@@ -106,19 +106,29 @@ describe("dayInTimezone", () => {
           resolvedOptions: () => real.resolvedOptions(),
         };
       }
-      vi.stubGlobal("Intl", { ...Intl, DateTimeFormat: FallbackDTF });
+      // Swap ONLY `Intl.DateTimeFormat` rather than the whole `Intl`
+      // namespace: most `Intl.*` properties are non-enumerable, so
+      // `{ ...Intl }` is `{}` and spreading would wipe `NumberFormat`,
+      // `Collator`, etc., for the rest of the suite. Restore in afterEach.
+      const originalDTF = Intl.DateTimeFormat;
+      (Intl as unknown as { DateTimeFormat: unknown }).DateTimeFormat =
+        FallbackDTF;
+      try {
+        const result = dayInTimezone(
+          new Date("2026-05-15T10:00:00Z"),
+          "Indian/Mauritius",
+        );
 
-      const result = dayInTimezone(
-        new Date("2026-05-15T10:00:00Z"),
-        "Indian/Mauritius",
-      );
-
-      expect(result).toMatch(ISO_DAY_RE);
-      expect(result).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
-      // And it must remain round-trippable through shiftIsoDay (the
-      // actual production throw site).
-      expect(() => shiftIsoDay(result, -1)).not.toThrow();
-      expect(shiftIsoDay(result, -1)).toMatch(ISO_DAY_RE);
+        expect(result).toMatch(ISO_DAY_RE);
+        expect(result).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
+        // And it must remain round-trippable through shiftIsoDay (the
+        // actual production throw site).
+        expect(() => shiftIsoDay(result, -1)).not.toThrow();
+        expect(shiftIsoDay(result, -1)).toMatch(ISO_DAY_RE);
+      } finally {
+        (Intl as unknown as { DateTimeFormat: unknown }).DateTimeFormat =
+          originalDTF;
+      }
     });
 
     it("dayInTimezone output is always accepted by shiftIsoDay (round-trip)", () => {
@@ -160,7 +170,8 @@ describe("dayInTimezone", () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    // No-op: stub/restore is scoped to a try/finally inside each test
+    // that mocks `Intl.DateTimeFormat`. Kept here for future tests.
   });
 });
 

--- a/packages/api/src/router/__tests__/analytics.test.ts
+++ b/packages/api/src/router/__tests__/analytics.test.ts
@@ -535,20 +535,20 @@ describe("analytics router", () => {
 
     it("never includes invalid `computedAt` in the response payload", async () => {
       // The superjson serializer threw on `new Date(NaN).toISOString()`
-      // when `computedAt` was a `Date` object. Router now returns ISO
-      // strings only — verify the contract holds.
+      // when `computedAt` was a `Date` object. Router now returns ISO-8601
+      // strings only — verify the contract holds (must contain `T`, end
+      // with `Z`, and be a finite Date).
       mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(7));
 
       const result = await caller.analytics.getTrainingLoads();
       const r = result as unknown as { computedAt?: unknown };
 
       if (r.computedAt !== undefined) {
-        // Must be a parseable ISO string (or a valid Date — but the fix
-        // emits strings).
         expect(typeof r.computedAt).toBe("string");
-        expect(Number.isFinite(new Date(r.computedAt as string).getTime())).toBe(
-          true,
-        );
+        const s = r.computedAt as string;
+        // Reject locale-formatted dates like `05/15/2026` — must be ISO-8601.
+        expect(s).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+        expect(Number.isFinite(new Date(s).getTime())).toBe(true);
       }
     });
 

--- a/packages/api/src/router/__tests__/analytics.test.ts
+++ b/packages/api/src/router/__tests__/analytics.test.ts
@@ -500,6 +500,102 @@ describe("analytics router", () => {
       // loadFocus must be one of the valid classifications
       expect(["aerobic", "anaerobic", "mixed"]).toContain(result.loadFocus);
     });
+
+    // ---------------------------------------------------------------------
+    // Regression: production "Invalid time value" crash (v0.16.15 / v0.2.8)
+    // ---------------------------------------------------------------------
+    // `analytics.getTrainingLoads` and `getTrainingStatus` were returning
+    // HTTP 500 from a `RangeError: Invalid time value` thrown deep inside
+    // `aggregateDailyLoads` → `shiftIsoDay` → `new Date().toISOString()`.
+    // Root cause was the HA addon's Alpine `nodejs=~22` shipping a
+    // minimal ICU build, which made `Intl.DateTimeFormat('en-CA').format()`
+    // fall back to en-US `MM/DD/YYYY`. These integration tests pin every
+    // contributing failure mode end-to-end so neither endpoint can ever
+    // regress to throwing on the same inputs.
+
+    it("does not throw when an activity has an invalid startedAt", async () => {
+      const bad = [
+        ...makeActivities(3),
+        {
+          id: "act-bad",
+          userId: TEST_USER_ID,
+          startedAt: new Date("not-a-date"), // NaN time
+          strainScore: 10,
+          trimpScore: null,
+          aerobicTE: 3,
+          anaerobicTE: 1,
+          sportType: "running",
+        },
+      ];
+      mockDb.query.Activity.findMany.mockResolvedValue(bad);
+
+      // The whole point: this must NOT throw RangeError.
+      await expect(caller.analytics.getTrainingLoads()).resolves.toBeDefined();
+    });
+
+    it("never includes invalid `computedAt` in the response payload", async () => {
+      // The superjson serializer threw on `new Date(NaN).toISOString()`
+      // when `computedAt` was a `Date` object. Router now returns ISO
+      // strings only — verify the contract holds.
+      mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(7));
+
+      const result = await caller.analytics.getTrainingLoads();
+      const r = result as unknown as { computedAt?: unknown };
+
+      if (r.computedAt !== undefined) {
+        // Must be a parseable ISO string (or a valid Date — but the fix
+        // emits strings).
+        expect(typeof r.computedAt).toBe("string");
+        expect(Number.isFinite(new Date(r.computedAt as string).getTime())).toBe(
+          true,
+        );
+      }
+    });
+
+    it("returns a response containing only primitives + plain objects (superjson-safe)", async () => {
+      // The whole crash was triggered by superjson trying to serialize
+      // an invalid Date. Pin the shape: no Date instances at the boundary.
+      mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(7));
+
+      const result = await caller.analytics.getTrainingLoads();
+
+      // JSON-roundtrip must succeed without throwing.
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: getTrainingStatus production crash
+  // -------------------------------------------------------------------------
+  describe("getTrainingStatus regression coverage", () => {
+    it("does not throw when activities contain invalid startedAt", async () => {
+      mockDb.query.VO2maxEstimate.findMany.mockResolvedValue([]);
+      const bad = [
+        ...makeActivities(5),
+        {
+          id: "act-bad-1",
+          userId: TEST_USER_ID,
+          startedAt: new Date(NaN),
+          strainScore: 12,
+          trimpScore: null,
+          aerobicTE: 4,
+          anaerobicTE: 1,
+          sportType: "running",
+        },
+      ];
+      mockDb.query.Activity.findMany.mockResolvedValue(bad);
+
+      await expect(caller.analytics.getTrainingStatus()).resolves.toBeDefined();
+    });
+
+    it("returns a JSON-stringifiable response (no raw Date instances)", async () => {
+      mockDb.query.VO2maxEstimate.findMany.mockResolvedValue([]);
+      mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(14));
+
+      const result = await caller.analytics.getTrainingStatus();
+
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Adds **9 regression tests** that lock down the failure modes behind the production crashes fixed in v0.16.15 (PR #111) and v0.16.16 (PR #112). 70 tests pass (was 61); typecheck clean.

## What's tested

### `packages/api/src/__tests__/timezone.test.ts` (4 new)
1. `dayInTimezone` output is `YYYY-MM-DD` across 10 IANA zones (UTC, Sydney, Perth, LA, NY, London, Berlin, Tokyo, Kolkata, Auckland)
2. **Mock `Intl.DateTimeFormat.format()` to simulate Alpine minimal-ICU en-US fallback (`MM/DD/YYYY`)** — `dayInTimezone` must still emit `YYYY-MM-DD` because the fix uses `formatToParts()` whose fields are named, not locale-ordered
3. `shiftIsoDay(dayInTimezone(...))` round-trip never throws for a matrix of dates × zones × deltas (including DST boundaries)
4. `todayInTimezone` never throws and always returns `YYYY-MM-DD`

### `packages/api/src/router/__tests__/analytics.test.ts` (5 new)
5. `getTrainingLoads` does not throw on Activity row with `startedAt = new Date('not-a-date')`
6. `getTrainingLoads` response is JSON-stringifiable
7. `getTrainingLoads.computedAt` is an ISO string (not a raw Date)
8. `getTrainingStatus` does not throw on `new Date(NaN)` startedAt
9. `getTrainingStatus` response is JSON-stringifiable

## Why the Intl mock matters

Without it, a future revert from `formatToParts()` to `format()` would silently pass under the test runner's full-ICU Node and re-introduce the production bug **only on Alpine**. The mock simulates the en-US fallback so the regression is caught in CI rather than by users.