### PR TITLE
fix: TZ-aware activity times, Garmin Native card, readiness no-contradiction

### DIFF
--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -2,10 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import {
-  formatDateInTz,
-  useUserTimezone,
-} from "~/lib/format-date";
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "./bottom-nav";
 import { DailyOutlookCard } from "./daily-outlook-card";
@@ -145,7 +142,7 @@ export function DashboardHome() {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12">Good morning 👋</h1>
+        <h1 className="pl-12 text-2xl font-bold">Good morning 👋</h1>
         <p className="text-muted-foreground text-sm">
           {formatDateInTz(new Date(), timezone, {
             weekday: "long",

--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -2,6 +2,10 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import {
+  formatDateInTz,
+  useUserTimezone,
+} from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "./bottom-nav";
 import { DailyOutlookCard } from "./daily-outlook-card";
@@ -12,6 +16,7 @@ import { WorkoutCard } from "./workout-card";
 
 export function DashboardHome() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const queryClient = useQueryClient();
 
   const readiness = useQuery(trpc.readiness.getToday.queryOptions());
@@ -142,7 +147,7 @@ export function DashboardHome() {
       <div>
         <h1 className="text-2xl font-bold pl-12">Good morning 👋</h1>
         <p className="text-muted-foreground text-sm">
-          {new Date().toLocaleDateString("en-US", {
+          {formatDateInTz(new Date(), timezone, {
             weekday: "long",
             month: "long",
             day: "numeric",
@@ -254,7 +259,7 @@ export function DashboardHome() {
                   .replace(/_/g, " ")
                   .replace(/\b\w/g, (c: string) => c.toUpperCase())
               : "Activity";
-            const date = new Date(a.startedAt).toLocaleDateString("en-US", {
+            const date = formatDateInTz(a.startedAt, timezone, {
               weekday: "short",
               month: "short",
               day: "numeric",

--- a/apps/nextjs/src/app/activities/[id]/page.tsx
+++ b/apps/nextjs/src/app/activities/[id]/page.tsx
@@ -19,6 +19,11 @@ import { Button } from "@acme/ui/button";
 import { toast } from "@acme/ui/toast";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import {
+  formatDateInTz,
+  formatTimeInTz,
+  useUserTimezone,
+} from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../../_components/bottom-nav";
 
@@ -46,23 +51,9 @@ function formatPace(secPerKm: number | null): string {
   return `${m}:${s.toString().padStart(2, "0")}/km`;
 }
 
-function formatDate(date: Date | string): string {
-  const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleDateString("en-US", {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function formatTime(date: Date | string): string {
-  const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
+// Date/time formatting is timezone-aware and lives in
+// ~/lib/format-date so it respects the user's profile timezone
+// instead of the SSR container's UTC.
 
 function sportLabel(sportType: string | null): string {
   if (!sportType) return "Activity";
@@ -417,6 +408,7 @@ export default function ActivityDetailPage({
 }) {
   const { id } = use(params);
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const queryClient = useQueryClient();
 
   const { data: activity, isLoading } = useQuery(
@@ -554,8 +546,13 @@ export default function ActivityDetailPage({
               {sportLabel(activity.sportType)}
             </h1>
             <p className="text-muted-foreground text-sm">
-              {formatDate(activity.startedAt)} ·{" "}
-              {formatTime(activity.startedAt)}
+              {formatDateInTz(activity.startedAt, timezone, {
+                weekday: "long",
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}{" "}
+              · {formatTimeInTz(activity.startedAt, timezone)}
             </p>
           </div>
         </div>

--- a/apps/nextjs/src/app/activities/page.tsx
+++ b/apps/nextjs/src/app/activities/page.tsx
@@ -104,7 +104,7 @@ export default function ActivitiesPage() {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12">Activities</h1>
+        <h1 className="pl-12 text-2xl font-bold">Activities</h1>
         <p className="text-muted-foreground text-sm">Your recent workouts</p>
       </div>
 

--- a/apps/nextjs/src/app/activities/page.tsx
+++ b/apps/nextjs/src/app/activities/page.tsx
@@ -6,6 +6,11 @@ import { useQuery } from "@tanstack/react-query";
 import { cn } from "@acme/ui";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import {
+  formatDateInTz,
+  formatTimeInTz,
+  useUserTimezone,
+} from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 
@@ -70,22 +75,9 @@ function formatPace(secPerKm: number | null): string {
   return `${m}:${s.toString().padStart(2, "0")}/km`;
 }
 
-function formatDate(date: Date | string): string {
-  const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-function formatTime(date: Date | string): string {
-  const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
+// Date/time formatting is timezone-aware and lives in
+// ~/lib/format-date so it respects the user's profile timezone
+// instead of the SSR container's UTC.
 
 function sportLabel(sportType: string | null): string {
   if (!sportType) return "Activity";
@@ -98,6 +90,7 @@ function sportLabel(sportType: string | null): string {
 
 export default function ActivitiesPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const [sportFilter, setSportFilter] = useState<string | undefined>(undefined);
 
   const { data: activities, isLoading } = useQuery(
@@ -174,7 +167,8 @@ export default function ActivitiesPage() {
                 </div>
                 <div className="text-muted-foreground flex flex-wrap gap-x-3 text-xs">
                   <span>
-                    {formatDate(a.startedAt)} · {formatTime(a.startedAt)}
+                    {formatDateInTz(a.startedAt, timezone)} ·{" "}
+                    {formatTimeInTz(a.startedAt, timezone)}
                   </span>
                 </div>
               </div>

--- a/apps/nextjs/src/lib/format-date.ts
+++ b/apps/nextjs/src/lib/format-date.ts
@@ -52,8 +52,10 @@ export function formatDateInTz(
   if (value == null) return "—";
   const d = toDate(value);
   if (!d) return "—";
-  return new Intl.DateTimeFormat("en-US", { ...options, timeZone: timezone })
-    .format(d);
+  return new Intl.DateTimeFormat("en-US", {
+    ...options,
+    timeZone: timezone,
+  }).format(d);
 }
 
 /**
@@ -70,6 +72,8 @@ export function formatTimeInTz(
   if (value == null) return "—";
   const d = toDate(value);
   if (!d) return "—";
-  return new Intl.DateTimeFormat("en-US", { ...options, timeZone: timezone })
-    .format(d);
+  return new Intl.DateTimeFormat("en-US", {
+    ...options,
+    timeZone: timezone,
+  }).format(d);
 }

--- a/apps/nextjs/src/lib/format-date.ts
+++ b/apps/nextjs/src/lib/format-date.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useTRPC } from "~/trpc/react";
+
+/**
+ * Returns the user's configured IANA timezone (e.g. "Australia/Brisbane")
+ * from the Profile record, falling back to the browser's resolved zone,
+ * and finally to "UTC" if both are unavailable.
+ *
+ * Why a hook? Server-side rendering uses the container's TZ (UTC in the
+ * HAOS addon) which makes raw `Date.toLocaleString()` show times 10+ hours
+ * off for AEST users. Resolving the user's TZ from their profile and
+ * passing it into every `Intl.DateTimeFormat` call fixes that.
+ */
+export function useUserTimezone(): string {
+  const trpc = useTRPC();
+  const profile = useQuery(trpc.profile.get.queryOptions());
+  if (profile.data?.timezone) return profile.data.timezone;
+  if (typeof Intl !== "undefined") {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    } catch {
+      // fall through
+    }
+  }
+  return "UTC";
+}
+
+function toDate(value: Date | string | number): Date | null {
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Format a date in the user's timezone. Returns "—" for invalid inputs
+ * so callers can pass DB values directly without null-guarding.
+ */
+export function formatDateInTz(
+  value: Date | string | number | null | undefined,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions = {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  },
+): string {
+  if (value == null) return "—";
+  const d = toDate(value);
+  if (!d) return "—";
+  return new Intl.DateTimeFormat("en-US", { ...options, timeZone: timezone })
+    .format(d);
+}
+
+/**
+ * Format the time-of-day in the user's timezone.
+ */
+export function formatTimeInTz(
+  value: Date | string | number | null | undefined,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "2-digit",
+  },
+): string {
+  if (value == null) return "—";
+  const d = toDate(value);
+  if (!d) return "—";
+  return new Intl.DateTimeFormat("en-US", { ...options, timeZone: timezone })
+    .format(d);
+}

--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { dayInTimezone, shiftIsoDay } from "../lib/timezone";
+import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
+
+const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 describe("dayInTimezone", () => {
   it("renders YYYY-MM-DD in UTC by default", () => {
@@ -36,6 +38,129 @@ describe("dayInTimezone", () => {
     expect(dayInTimezone(new Date(NaN), "Australia/Sydney")).toBe(
       "1970-01-01",
     );
+  });
+
+  // ---------------------------------------------------------------------
+  // Regression: Alpine / HA addon minimal-ICU locale fallback
+  // ---------------------------------------------------------------------
+  // The HA addon base image's Alpine `nodejs=~22` package ships a minimal
+  // ICU build (system-icu) without the en-CA CLDR data. In that environment
+  // `Intl.DateTimeFormat('en-CA', …).format()` silently falls back to
+  // en-US `MM/DD/YYYY`, which previously broke `shiftIsoDay` and crashed
+  // `analytics.getTrainingLoads` / `getTrainingStatus` with
+  // `RangeError: Invalid time value`. We fixed this by switching to
+  // `formatToParts()` (locale-independent because each field is named).
+  // These tests pin that behaviour so the bug can never regress.
+  describe("regression: Alpine ICU en-CA fallback", () => {
+    it("output is always YYYY-MM-DD across many timezones", () => {
+      const d = new Date("2026-05-15T10:00:00Z");
+      const zones = [
+        "UTC",
+        "Australia/Sydney",
+        "Australia/Perth",
+        "America/Los_Angeles",
+        "America/New_York",
+        "Europe/London",
+        "Europe/Berlin",
+        "Asia/Tokyo",
+        "Asia/Kolkata",
+        "Pacific/Auckland",
+      ];
+      for (const zone of zones) {
+        expect(
+          dayInTimezone(d, zone),
+          `zone=${zone} must produce YYYY-MM-DD`,
+        ).toMatch(ISO_DAY_RE);
+      }
+    });
+
+    it("never returns MM/DD/YYYY even when the locale falls back to en-US", () => {
+      // Simulate the exact Alpine minimal-ICU pathology: `format()` returns
+      // en-US `MM/DD/YYYY` instead of `YYYY-MM-DD`. `formatToParts()` must
+      // still produce the correct named-field types because parts are named
+      // by contract, not by locale string order. We mock the global rather
+      // than subclassing `Intl.DateTimeFormat` (V8 internal-slot classes
+      // don't subclass cleanly — `super.formatToParts()` throws).
+      //
+      // NOTE: Uses a fresh IANA zone ("Indian/Mauritius") to bypass the
+      // module-level `FORMATTER_CACHE`, otherwise the previously-cached
+      // real formatter would be reused and the stub would be inert.
+      const RealDTF = Intl.DateTimeFormat;
+      function FallbackDTF(
+        _locale?: string | string[],
+        opts?: Intl.DateTimeFormatOptions,
+      ) {
+        const real = new RealDTF("en-CA", opts);
+        return {
+          // Pretend `format()` fell back to en-US `MM/DD/YYYY`.
+          format(date?: Date | number) {
+            const parts = real.formatToParts(date ?? new Date());
+            const get = (t: string) =>
+              parts.find((p) => p.type === t)?.value ?? "??";
+            return `${get("month")}/${get("day")}/${get("year")}`;
+          },
+          // `formatToParts` keeps real semantics — that's what the fix uses.
+          formatToParts(date?: Date | number) {
+            return real.formatToParts(date ?? new Date());
+          },
+          resolvedOptions: () => real.resolvedOptions(),
+        };
+      }
+      vi.stubGlobal("Intl", { ...Intl, DateTimeFormat: FallbackDTF });
+
+      const result = dayInTimezone(
+        new Date("2026-05-15T10:00:00Z"),
+        "Indian/Mauritius",
+      );
+
+      expect(result).toMatch(ISO_DAY_RE);
+      expect(result).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
+      // And it must remain round-trippable through shiftIsoDay (the
+      // actual production throw site).
+      expect(() => shiftIsoDay(result, -1)).not.toThrow();
+      expect(shiftIsoDay(result, -1)).toMatch(ISO_DAY_RE);
+    });
+
+    it("dayInTimezone output is always accepted by shiftIsoDay (round-trip)", () => {
+      // Pin the contract between the two helpers: whatever `dayInTimezone`
+      // emits must be a valid input to `shiftIsoDay`, otherwise
+      // `aggregateDailyLoads` (which composes them) throws.
+      const dates = [
+        new Date("2026-01-01T00:00:00Z"),
+        new Date("2026-06-15T23:59:59Z"),
+        new Date("2026-12-31T23:30:00Z"),
+        new Date("2026-03-09T02:30:00Z"), // US DST spring-forward
+        new Date("2026-04-05T02:30:00Z"), // AU DST autumn-back
+      ];
+      const zones = ["UTC", "Australia/Sydney", "America/Los_Angeles"];
+      for (const date of dates) {
+        for (const zone of zones) {
+          const day = dayInTimezone(date, zone);
+          expect(day).toMatch(ISO_DAY_RE);
+          for (const delta of [-28, -7, -1, 0, 1, 7, 28]) {
+            expect(() => shiftIsoDay(day, delta)).not.toThrow();
+            expect(shiftIsoDay(day, delta)).toMatch(ISO_DAY_RE);
+          }
+        }
+      }
+    });
+
+    it("todayInTimezone never throws and returns YYYY-MM-DD", () => {
+      // The production call chain is `todayInTimezone(profile.tz)` →
+      // `shiftIsoDay(today, -N)` for every day in the load window. If
+      // `todayInTimezone` ever returns a non-ISO string, every analytics
+      // load query crashes.
+      expect(todayInTimezone("Australia/Sydney")).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone("UTC")).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone(null)).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone(undefined)).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone("")).toMatch(ISO_DAY_RE);
+      expect(todayInTimezone("Bogus/Timezone")).toMatch(ISO_DAY_RE);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 });
 

--- a/packages/api/src/__tests__/timezone.test.ts
+++ b/packages/api/src/__tests__/timezone.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
 
@@ -106,19 +106,29 @@ describe("dayInTimezone", () => {
           resolvedOptions: () => real.resolvedOptions(),
         };
       }
-      vi.stubGlobal("Intl", { ...Intl, DateTimeFormat: FallbackDTF });
+      // Swap ONLY `Intl.DateTimeFormat` rather than the whole `Intl`
+      // namespace: most `Intl.*` properties are non-enumerable, so
+      // `{ ...Intl }` is `{}` and spreading would wipe `NumberFormat`,
+      // `Collator`, etc., for the rest of the suite. Restore in afterEach.
+      const originalDTF = Intl.DateTimeFormat;
+      (Intl as unknown as { DateTimeFormat: unknown }).DateTimeFormat =
+        FallbackDTF;
+      try {
+        const result = dayInTimezone(
+          new Date("2026-05-15T10:00:00Z"),
+          "Indian/Mauritius",
+        );
 
-      const result = dayInTimezone(
-        new Date("2026-05-15T10:00:00Z"),
-        "Indian/Mauritius",
-      );
-
-      expect(result).toMatch(ISO_DAY_RE);
-      expect(result).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
-      // And it must remain round-trippable through shiftIsoDay (the
-      // actual production throw site).
-      expect(() => shiftIsoDay(result, -1)).not.toThrow();
-      expect(shiftIsoDay(result, -1)).toMatch(ISO_DAY_RE);
+        expect(result).toMatch(ISO_DAY_RE);
+        expect(result).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
+        // And it must remain round-trippable through shiftIsoDay (the
+        // actual production throw site).
+        expect(() => shiftIsoDay(result, -1)).not.toThrow();
+        expect(shiftIsoDay(result, -1)).toMatch(ISO_DAY_RE);
+      } finally {
+        (Intl as unknown as { DateTimeFormat: unknown }).DateTimeFormat =
+          originalDTF;
+      }
     });
 
     it("dayInTimezone output is always accepted by shiftIsoDay (round-trip)", () => {
@@ -160,7 +170,8 @@ describe("dayInTimezone", () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    // No-op: stub/restore is scoped to a try/finally inside each test
+    // that mocks `Intl.DateTimeFormat`. Kept here for future tests.
   });
 });
 

--- a/packages/api/src/router/__tests__/analytics.test.ts
+++ b/packages/api/src/router/__tests__/analytics.test.ts
@@ -535,20 +535,20 @@ describe("analytics router", () => {
 
     it("never includes invalid `computedAt` in the response payload", async () => {
       // The superjson serializer threw on `new Date(NaN).toISOString()`
-      // when `computedAt` was a `Date` object. Router now returns ISO
-      // strings only — verify the contract holds.
+      // when `computedAt` was a `Date` object. Router now returns ISO-8601
+      // strings only — verify the contract holds (must contain `T`, end
+      // with `Z`, and be a finite Date).
       mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(7));
 
       const result = await caller.analytics.getTrainingLoads();
       const r = result as unknown as { computedAt?: unknown };
 
       if (r.computedAt !== undefined) {
-        // Must be a parseable ISO string (or a valid Date — but the fix
-        // emits strings).
         expect(typeof r.computedAt).toBe("string");
-        expect(Number.isFinite(new Date(r.computedAt as string).getTime())).toBe(
-          true,
-        );
+        const s = r.computedAt as string;
+        // Reject locale-formatted dates like `05/15/2026` — must be ISO-8601.
+        expect(s).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/);
+        expect(Number.isFinite(new Date(s).getTime())).toBe(true);
       }
     });
 

--- a/packages/api/src/router/__tests__/analytics.test.ts
+++ b/packages/api/src/router/__tests__/analytics.test.ts
@@ -500,6 +500,102 @@ describe("analytics router", () => {
       // loadFocus must be one of the valid classifications
       expect(["aerobic", "anaerobic", "mixed"]).toContain(result.loadFocus);
     });
+
+    // ---------------------------------------------------------------------
+    // Regression: production "Invalid time value" crash (v0.16.15 / v0.2.8)
+    // ---------------------------------------------------------------------
+    // `analytics.getTrainingLoads` and `getTrainingStatus` were returning
+    // HTTP 500 from a `RangeError: Invalid time value` thrown deep inside
+    // `aggregateDailyLoads` → `shiftIsoDay` → `new Date().toISOString()`.
+    // Root cause was the HA addon's Alpine `nodejs=~22` shipping a
+    // minimal ICU build, which made `Intl.DateTimeFormat('en-CA').format()`
+    // fall back to en-US `MM/DD/YYYY`. These integration tests pin every
+    // contributing failure mode end-to-end so neither endpoint can ever
+    // regress to throwing on the same inputs.
+
+    it("does not throw when an activity has an invalid startedAt", async () => {
+      const bad = [
+        ...makeActivities(3),
+        {
+          id: "act-bad",
+          userId: TEST_USER_ID,
+          startedAt: new Date("not-a-date"), // NaN time
+          strainScore: 10,
+          trimpScore: null,
+          aerobicTE: 3,
+          anaerobicTE: 1,
+          sportType: "running",
+        },
+      ];
+      mockDb.query.Activity.findMany.mockResolvedValue(bad);
+
+      // The whole point: this must NOT throw RangeError.
+      await expect(caller.analytics.getTrainingLoads()).resolves.toBeDefined();
+    });
+
+    it("never includes invalid `computedAt` in the response payload", async () => {
+      // The superjson serializer threw on `new Date(NaN).toISOString()`
+      // when `computedAt` was a `Date` object. Router now returns ISO
+      // strings only — verify the contract holds.
+      mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(7));
+
+      const result = await caller.analytics.getTrainingLoads();
+      const r = result as unknown as { computedAt?: unknown };
+
+      if (r.computedAt !== undefined) {
+        // Must be a parseable ISO string (or a valid Date — but the fix
+        // emits strings).
+        expect(typeof r.computedAt).toBe("string");
+        expect(Number.isFinite(new Date(r.computedAt as string).getTime())).toBe(
+          true,
+        );
+      }
+    });
+
+    it("returns a response containing only primitives + plain objects (superjson-safe)", async () => {
+      // The whole crash was triggered by superjson trying to serialize
+      // an invalid Date. Pin the shape: no Date instances at the boundary.
+      mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(7));
+
+      const result = await caller.analytics.getTrainingLoads();
+
+      // JSON-roundtrip must succeed without throwing.
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: getTrainingStatus production crash
+  // -------------------------------------------------------------------------
+  describe("getTrainingStatus regression coverage", () => {
+    it("does not throw when activities contain invalid startedAt", async () => {
+      mockDb.query.VO2maxEstimate.findMany.mockResolvedValue([]);
+      const bad = [
+        ...makeActivities(5),
+        {
+          id: "act-bad-1",
+          userId: TEST_USER_ID,
+          startedAt: new Date(NaN),
+          strainScore: 12,
+          trimpScore: null,
+          aerobicTE: 4,
+          anaerobicTE: 1,
+          sportType: "running",
+        },
+      ];
+      mockDb.query.Activity.findMany.mockResolvedValue(bad);
+
+      await expect(caller.analytics.getTrainingStatus()).resolves.toBeDefined();
+    });
+
+    it("returns a JSON-stringifiable response (no raw Date instances)", async () => {
+      mockDb.query.VO2maxEstimate.findMany.mockResolvedValue([]);
+      mockDb.query.Activity.findMany.mockResolvedValue(makeActivities(14));
+
+      const result = await caller.analytics.getTrainingStatus();
+
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/api/src/router/__tests__/readiness.test.ts
+++ b/packages/api/src/router/__tests__/readiness.test.ts
@@ -3,10 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  buildActionSuggestion,
-  computeDataQuality,
-} from "../readiness";
+import { buildActionSuggestion, computeDataQuality } from "../readiness";
 
 // Minimal shape — only the fields the helpers actually read.
 type Row = {
@@ -17,10 +14,7 @@ type Row = {
   sleepDebtMinutes?: number | null;
 };
 
-function row(
-  date: string,
-  overrides: Partial<Row> = {},
-): Row {
+function row(date: string, overrides: Partial<Row> = {}): Row {
   return {
     date,
     hrv: null,
@@ -65,10 +59,7 @@ describe("computeDataQuality — Garmin next-morning publish lag", () => {
   });
 
   it("reports HRV as 'stale' when the most recent reading is 5 days old", () => {
-    const recent = [
-      row(today),
-      row("2026-05-11", { hrv: 65 }),
-    ];
+    const recent = [row(today), row("2026-05-11", { hrv: 65 })];
     const dq = computeDataQuality(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       recent[0] as any,

--- a/packages/api/src/router/__tests__/readiness.test.ts
+++ b/packages/api/src/router/__tests__/readiness.test.ts
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildActionSuggestion,
+  computeDataQuality,
+} from "../readiness";
+
+// Minimal shape — only the fields the helpers actually read.
+type Row = {
+  date: string;
+  hrv: number | null;
+  totalSleepMinutes: number | null;
+  restingHr: number | null;
+  sleepDebtMinutes?: number | null;
+};
+
+function row(
+  date: string,
+  overrides: Partial<Row> = {},
+): Row {
+  return {
+    date,
+    hrv: null,
+    totalSleepMinutes: null,
+    restingHr: null,
+    ...overrides,
+  };
+}
+
+describe("computeDataQuality — Garmin next-morning publish lag", () => {
+  const today = "2026-05-16";
+
+  it("reports HRV as 'good' when yesterday has a reading and today does not", () => {
+    // Garmin typically publishes today's daily HRV the next morning. The
+    // engine still uses yesterday's HRV (most recent non-null) and scores
+    // confidently — the data-quality view must agree.
+    const recent = [
+      row(today, { restingHr: 50, totalSleepMinutes: 480 }),
+      row("2026-05-15", { hrv: 62, restingHr: 49, totalSleepMinutes: 470 }),
+    ];
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recent[0] as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recent as any,
+      3,
+      today,
+    );
+    expect(dq.hrv).toBe("good");
+  });
+
+  it("reports HRV as 'missing' when no reading in the last 8 days", () => {
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row(today) as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [row(today)] as any,
+      3,
+      today,
+    );
+    expect(dq.hrv).toBe("missing");
+  });
+
+  it("reports HRV as 'stale' when the most recent reading is 5 days old", () => {
+    const recent = [
+      row(today),
+      row("2026-05-11", { hrv: 65 }),
+    ];
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recent[0] as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recent as any,
+      3,
+      today,
+    );
+    expect(dq.hrv).toBe("stale");
+  });
+});
+
+describe("buildActionSuggestion — no contradiction with engine explanation", () => {
+  const today = "2026-05-16";
+
+  it("does NOT claim 'HRV data is unavailable' when yesterday's HRV is present", () => {
+    // Reproduces the prod bug: score < 60, today's row is empty (Garmin
+    // hasn't published yet), yesterday's HRV is fine. The engine's
+    // explanation cites yesterday's HRV against baseline ("0.9 SD above")
+    // and the action suggestion previously contradicted it with
+    // "HRV data is unavailable".
+    const todayRow = row(today);
+    const recent = [todayRow, row("2026-05-15", { hrv: 62 })];
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      todayRow as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recent as any,
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      45,
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      todayRow as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      recent as any,
+    );
+    expect(action).not.toMatch(/HRV data is unavailable/);
+    expect(action).toMatch(/HRV of 62ms/);
+  });
+
+  it("still says 'HRV data is unavailable' when there is truly no recent HRV", () => {
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row(today) as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [row(today)] as any,
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      45,
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row(today) as any,
+      [],
+    );
+    expect(action).toMatch(/HRV data is unavailable/);
+  });
+
+  it("uses zone-based advice without contradiction for moderate readiness", () => {
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row(today, { hrv: 60, totalSleepMinutes: 420, restingHr: 50 }) as any,
+      [],
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      65,
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      row(today, { hrv: 60, totalSleepMinutes: 420, restingHr: 50 }) as any,
+      [],
+    );
+    expect(action).toMatch(/Moderate readiness/);
+    expect(action).not.toMatch(/HRV data is unavailable/);
+  });
+});

--- a/packages/api/src/router/garmin.ts
+++ b/packages/api/src/router/garmin.ts
@@ -144,7 +144,36 @@ export const garminRouter = {
         )
         .orderBy(desc(DailyMetric.date));
 
-      const latest = rows[0] ?? null;
+      // Build a "latest non-null" view for each Garmin Firstbeat field.
+      // Watches only publish today's training-readiness / status / recovery
+      // after the next morning sync, so today's daily_metric row often has
+      // all of these as NULL even though yesterday's row is populated. The
+      // UI's "Garmin Native" card was rendering all em-dashes because it
+      // pulled `rows[0]` (today) verbatim. Fall back per-field to the most
+      // recent date in the window that actually has data.
+      function latestNonNull<K extends keyof (typeof rows)[number]>(
+        key: K,
+      ): (typeof rows)[number][K] | null {
+        for (const row of rows) {
+          const v = row[key];
+          if (v != null) return v;
+        }
+        return null;
+      }
+
+      const latest = rows[0]
+        ? {
+            ...rows[0],
+            garminTrainingReadiness: latestNonNull("garminTrainingReadiness"),
+            garminTrainingReadinessLevel: latestNonNull(
+              "garminTrainingReadinessLevel",
+            ),
+            garminTrainingLoad: latestNonNull("garminTrainingLoad"),
+            garminTrainingStatus: latestNonNull("garminTrainingStatus"),
+            garminLoadFocus: latestNonNull("garminLoadFocus"),
+            garminRecoveryHours: latestNonNull("garminRecoveryHours"),
+          }
+        : null;
       const hrvSeries = rows
         .filter((r) => r.hrv != null)
         .map((r) => ({ date: r.date, hrv: r.hrv! }))

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -37,8 +37,9 @@ function daysBetween(dateStr: string, today: string): number {
   );
 }
 
-function computeDataQuality(
+export function computeDataQuality(
   metric: typeof DailyMetric.$inferSelect | null,
+  recentMetrics: (typeof DailyMetric.$inferSelect)[],
   recentActivityCount: number,
   today: string,
 ): DataQuality {
@@ -51,11 +52,38 @@ function computeDataQuality(
   const daysOld = metricDate ? daysBetween(metricDate, today) : 999;
   const stale = daysOld > 3;
 
+  // Garmin publishes daily HRV / sleep / RHR with a delay — today's row is
+  // often created by an activity sync hours before the next-morning health
+  // snapshot lands. Treat each field as "good" if any of the last 3 days
+  // has a value, "stale" if the most recent value is 4-7 days old, and
+  // "missing" only when there has been no value for >7 days. This matches
+  // how the engine actually consumes these metrics (it uses the most recent
+  // non-null reading against the baseline window).
+  function fieldQuality(
+    pick: (row: typeof DailyMetric.$inferSelect) => number | null | undefined,
+  ): DataQualityStatus {
+    const todayValue = metric ? pick(metric) : null;
+    if (todayValue != null) return stale ? "stale" : "good";
+    for (const row of recentMetrics) {
+      const v = pick(row);
+      if (v != null) {
+        const rowDate =
+          typeof row.date === "string"
+            ? row.date
+            : (row.date as Date).toISOString().split("T")[0]!;
+        const age = daysBetween(rowDate, today);
+        if (age <= 3) return "good";
+        if (age <= 7) return "stale";
+        return "missing";
+      }
+    }
+    return "missing";
+  }
+
   return {
-    hrv: metric?.hrv == null ? "missing" : stale ? "stale" : "good",
-    sleep:
-      metric?.totalSleepMinutes == null ? "missing" : stale ? "stale" : "good",
-    restingHr: metric?.restingHr == null ? "missing" : stale ? "stale" : "good",
+    hrv: fieldQuality((r) => r.hrv),
+    sleep: fieldQuality((r) => r.totalSleepMinutes),
+    restingHr: fieldQuality((r) => r.restingHr),
     trainingLoad:
       recentActivityCount === 0 ? "missing" : daysOld > 7 ? "stale" : "good",
   };
@@ -70,10 +98,11 @@ function computeConfidence(dq: DataQuality): number {
   return Math.max(confidence, 0.3);
 }
 
-function buildActionSuggestion(
+export function buildActionSuggestion(
   score: number,
   dq: DataQuality,
   metric: typeof DailyMetric.$inferSelect | null,
+  recentMetrics: (typeof DailyMetric.$inferSelect)[] = [],
 ): string {
   if (score >= 80) {
     return "You're well recovered — today is a good day for a quality session or race effort.";
@@ -81,15 +110,18 @@ function buildActionSuggestion(
   if (score >= 60) {
     return "Moderate readiness — stick to planned training but listen to your body.";
   }
-  // Below 60: find worst component
-  if (dq.hrv !== "good" || metric?.hrv != null) {
-    const hrv = metric?.hrv;
-    if (dq.hrv !== "good") {
-      return "Take it easy today — HRV data is unavailable. Consider an easy 30-min walk instead of your planned session.";
-    }
-    if (hrv != null) {
-      return `Take it easy today — your HRV of ${hrv.toFixed(0)}ms is below baseline. Consider an easy 30-min walk instead of your planned session.`;
-    }
+  // Below 60: find worst component. Use the same lookback as the engine —
+  // today's row may not have HRV yet (Garmin publishes daily HRV the next
+  // morning), but a fresh reading from the last few days is still actionable.
+  const recentHrv =
+    metric?.hrv ??
+    recentMetrics.find((r) => r.hrv != null)?.hrv ??
+    null;
+  if (dq.hrv === "missing") {
+    return "Take it easy today — HRV data is unavailable. Consider an easy 30-min walk instead of your planned session.";
+  }
+  if (recentHrv != null) {
+    return `Take it easy today — your HRV of ${recentHrv.toFixed(0)}ms is below baseline. Consider an easy 30-min walk instead of your planned session.`;
   }
   if (dq.sleep !== "good" || metric?.sleepDebtMinutes != null) {
     const debt = metric?.sleepDebtMinutes ?? 0;
@@ -184,6 +216,16 @@ export const readinessRouter = {
       where: and(eq(DailyMetric.userId, userId), eq(DailyMetric.date, today)),
     });
 
+    // Fetch the last 8 days of metrics so computeDataQuality can fall back
+    // to the most recent non-null reading for each field (HRV, sleep, RHR).
+    const recentMetricsForDQ = await ctx.db.query.DailyMetric.findMany({
+      where: and(
+        eq(DailyMetric.userId, userId),
+        gte(DailyMetric.date, getDateString(8)),
+      ),
+      orderBy: desc(DailyMetric.date),
+    });
+
     // Fetch recent activities to determine training load data quality
     const recentActivities = await ctx.db.query.Activity.findMany({
       where: and(
@@ -195,6 +237,7 @@ export const readinessRouter = {
 
     const dq = computeDataQuality(
       todayDbMetric ?? null,
+      recentMetricsForDQ,
       recentActivities.length,
       today,
     );
@@ -213,6 +256,7 @@ export const readinessRouter = {
         existing.score,
         dq,
         todayDbMetric ?? null,
+        recentMetricsForDQ,
       );
       // Sanitize stale debug-style explanations written by older builds of
       // the engine, e.g.:
@@ -271,6 +315,7 @@ export const readinessRouter = {
       result.score,
       dq,
       todayDbMetric ?? null,
+      recentMetricsForDQ,
     );
 
     // Daily target-strain band (WHOOP-style coaching) — uses readiness

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -114,9 +114,7 @@ export function buildActionSuggestion(
   // today's row may not have HRV yet (Garmin publishes daily HRV the next
   // morning), but a fresh reading from the last few days is still actionable.
   const recentHrv =
-    metric?.hrv ??
-    recentMetrics.find((r) => r.hrv != null)?.hrv ??
-    null;
+    metric?.hrv ?? recentMetrics.find((r) => r.hrv != null)?.hrv ?? null;
   if (dq.hrv === "missing") {
     return "Take it easy today — HRV data is unavailable. Consider an easy 30-min walk instead of your planned session.";
   }


### PR DESCRIPTION
Three follow-ups from in-prod reports on v0.16.16 (app v0.2.9).

## 1. Activity timestamps not in user timezone

Three client components called `toLocaleDateString`/`toLocaleTimeString`
without a `timeZone` option:

- `apps/nextjs/src/app/activities/page.tsx`
- `apps/nextjs/src/app/activities/[id]/page.tsx`
- `apps/nextjs/src/app/_components/dashboard-home.tsx`

Next.js SSRs the first paint, so those calls resolve against the
container's TZ — UTC in the HAOS addon — and the browser never
re-renders them after hydration. AEST users saw workout timestamps
10 hours off.

Added `apps/nextjs/src/lib/format-date.ts` with a `useUserTimezone()`
hook (reads `Profile.timezone` via `trpc.profile.get`, falls back to
the browser's resolved zone) and `formatDateInTz` / `formatTimeInTz`
helpers that thread the resolved IANA zone into `Intl.DateTimeFormat`.

## 2. Training → "Garmin Native (Firstbeat)" card empty

`garmin.getTrainingSummary` returned `rows[0]` (today's daily_metric
row). Garmin watches only publish today's readiness/status/recovery
after the next morning sync, so today's row is almost always NULL for
those fields. The card was rendering em-dashes even when yesterday's
row was fully populated.

Compute a per-field "latest non-null" view across the window before
returning. HRV already used the same pattern for its trend calc; this
extends it to the five remaining Firstbeat fields the card displays.

## 3. Readiness card contradicting itself

Real production session showed:

```
Readiness — Moderate
HRV 0.9 SD above baseline and only 4.7h sleep → consider a moderate session.
● HRV (red dot)
💡 Take it easy today — HRV data is unavailable.
```

The engine cited yesterday's HRV (its most recent non-null) but
`computeDataQuality` / `buildActionSuggestion` strictly checked today's
row — which is missing HRV until Garmin's next-morning publish. Same
publish-lag root cause as (2).

- `computeDataQuality`: walks back 8 days per field. "good" if ≤3d
  old, "stale" if 4-7d, "missing" only if >7d. Mirrors what the
  engine actually uses.
- `buildActionSuggestion`: same lookback for the unavailable / value
  branches.
- 6 new tests in `packages/api/src/router/__tests__/readiness.test.ts`
  pinning HRV-yesterday-only, HRV-truly-missing, HRV-good-today.

## Tests

- `pnpm turbo typecheck` — clean
- `pnpm --filter @acme/api test` — 66 pass (was 60)