### PR TITLE
fix(readiness): align action suggestion copy with engine zone boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "create-t3-turbo",
+  "version": "0.2.11",
   "private": true,
   "engines": {
     "node": "^22.21.0",

--- a/packages/api/src/router/__tests__/readiness.test.ts
+++ b/packages/api/src/router/__tests__/readiness.test.ts
@@ -92,7 +92,8 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
       today,
     );
     const action = buildActionSuggestion(
-      45,
+      30,
+      "low",
       dq,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       todayRow as any,
@@ -113,13 +114,40 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
       today,
     );
     const action = buildActionSuggestion(
-      45,
+      30,
+      "low",
       dq,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       row(today) as any,
       [],
     );
     expect(action).toMatch(/HRV data is unavailable/);
+  });
+
+  it("uses zone-based advice for high readiness", () => {
+    const metric = row(today, {
+      hrv: 60,
+      totalSleepMinutes: 420,
+      restingHr: 50,
+    });
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      [],
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      65,
+      "high",
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      [],
+    );
+    expect(action).toBe(
+      "High readiness — stick to your planned training and execute the session as written.",
+    );
   });
 
   it("uses zone-based advice without contradiction for moderate readiness", () => {
@@ -131,7 +159,8 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
       today,
     );
     const action = buildActionSuggestion(
-      65,
+      45,
+      "moderate",
       dq,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       row(today, { hrv: 60, totalSleepMinutes: 420, restingHr: 50 }) as any,
@@ -139,5 +168,89 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
     );
     expect(action).toMatch(/Moderate readiness/);
     expect(action).not.toMatch(/HRV data is unavailable/);
+  });
+
+  it("keeps planned training for moderate readiness despite HRV deficit", () => {
+    const metric = row(today, {
+      hrv: 19,
+      totalSleepMinutes: 420,
+      restingHr: 50,
+    });
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [metric] as any,
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      45,
+      "moderate",
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [metric] as any,
+    );
+    expect(action).toBe(
+      "Moderate readiness — keep the planned session but trim volume slightly and stay in Zone 2.",
+    );
+    expect(action).not.toMatch(/Take it easy|30-min walk|planned session\./);
+  });
+
+  it("keeps planned training for moderate readiness despite low sleep", () => {
+    const metric = row(today, {
+      hrv: 60,
+      totalSleepMinutes: 240,
+      restingHr: 50,
+      sleepDebtMinutes: 120,
+    });
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [metric] as any,
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      45,
+      "moderate",
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      [],
+    );
+    expect(action).toBe(
+      "Moderate readiness — keep the planned session but trim volume slightly and stay in Zone 2.",
+    );
+    expect(action).not.toMatch(/rest|30-min walk|Prioritize/);
+  });
+
+  it("preserves conservative walk recommendation for low readiness", () => {
+    const metric = row(today, {
+      hrv: 19,
+      totalSleepMinutes: 420,
+      restingHr: 50,
+    });
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [metric] as any,
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      30,
+      "low",
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      [],
+    );
+    expect(action).toMatch(/Take it easy today/);
+    expect(action).toMatch(/easy 30-min walk/);
   });
 });

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -1,7 +1,7 @@
 import type { TRPCRouterRecord } from "@trpc/server";
 import { z } from "zod/v4";
 
-import type { Baselines, DailyMetricInput } from "@acme/engine";
+import type { Baselines, DailyMetricInput, ReadinessZone } from "@acme/engine";
 import { and, desc, eq, gte, lte } from "@acme/db";
 import {
   Activity,
@@ -100,19 +100,34 @@ function computeConfidence(dq: DataQuality): number {
 
 export function buildActionSuggestion(
   score: number,
+  zone: ReadinessZone,
   dq: DataQuality,
   metric: typeof DailyMetric.$inferSelect | null,
   recentMetrics: (typeof DailyMetric.$inferSelect)[] = [],
 ): string {
-  if (score >= 80) {
+  const scoreZone = getReadinessZone(score);
+  const resolvedZone = zone === scoreZone ? zone : scoreZone;
+
+  // Anchor copy on the engine's zone (prime/high/moderate/low/poor) so the
+  // action suggestion stays consistent with the readiness subtitle. Previously
+  // this switched on bare score with a single `>= 60` cutoff, which collided
+  // with the engine's 5-zone scale: a score of 45 produced zone="moderate" but
+  // the action suggestion fell into the `< 60` branch and told the user to
+  // skip their planned session and walk.
+  if (resolvedZone === "prime") {
     return "You're well recovered — today is a good day for a quality session or race effort.";
   }
-  if (score >= 60) {
-    return "Moderate readiness — stick to planned training but listen to your body.";
+  if (resolvedZone === "high") {
+    return "High readiness — stick to your planned training and execute the session as written.";
   }
-  // Below 60: find worst component. Use the same lookback as the engine —
+  if (resolvedZone === "moderate") {
+    return "Moderate readiness — keep the planned session but trim volume slightly and stay in Zone 2.";
+  }
+
+  // Low / poor zones — the user *should* be advised to back off. Keep the
+  // detail actionable while using the same lookback as the engine because
   // today's row may not have HRV yet (Garmin publishes daily HRV the next
-  // morning), but a fresh reading from the last few days is still actionable.
+  // morning).
   const recentHrv =
     metric?.hrv ?? recentMetrics.find((r) => r.hrv != null)?.hrv ?? null;
   if (dq.hrv === "missing") {
@@ -250,8 +265,13 @@ export const readinessRouter = {
       ),
     });
     if (existing) {
+      const existingZone =
+        existing.zone === getReadinessZone(existing.score)
+          ? (existing.zone as ReadinessZone)
+          : getReadinessZone(existing.score);
       const actionSuggestion = buildActionSuggestion(
         existing.score,
+        existingZone,
         dq,
         todayDbMetric ?? null,
         recentMetricsForDQ,
@@ -311,6 +331,7 @@ export const readinessRouter = {
 
     const actionSuggestion = buildActionSuggestion(
       result.score,
+      result.zone,
       dq,
       todayDbMetric ?? null,
       recentMetricsForDQ,


### PR DESCRIPTION
## Summary

This aligns `buildActionSuggestion()` with the engine readiness zone boundaries: prime >=80, high >=60, moderate >=40, low >=20, and poor <20. The action suggestion now validates against the engine-derived zone instead of using the old two-band `score >= 60` branching.

That score-only branch caused the observed contradiction where a score of 45 rendered as moderate readiness with zone-aware explanation copy, but the suggestion still recommended skipping the planned session for a 30-minute walk.

## Tests

- Added regression coverage that moderate readiness with an HRV deficit keeps the moderate-band copy.
- Added regression coverage that moderate readiness with low sleep still avoids rest/walk recommendations.
- Added regression coverage that low readiness preserves the conservative walk recommendation.
- Added regression coverage for the high-readiness branch after Copilot review.

## Validation

- `pnpm --filter @acme/api typecheck`
- `pnpm --filter @acme/api test`
- `pnpm typecheck`
- `pre-commit run --files package.json packages/api/src/router/readiness.ts packages/api/src/router/__tests__/readiness.test.ts`

Note: `pre-commit run --all-files` attempted to auto-format unrelated `.github/workflows/*.lock.yml` files, so those unrelated workflow edits were reverted and not included. The repository-wide CI format/lint jobs also report pre-existing failures in unrelated files (for example `packages/engine/src/__tests__/target-strain.test.ts`, `packages/api/src/__tests__/timezone.test.ts`, `packages/api/src/router/analytics.ts`, and multiple Next.js pages). This PR leaves those unrelated files unchanged.