### PR TITLE
fix(training): widen firstbeat lookback and label stale data

### DIFF
--- a/apps/nextjs/src/app/_components/garmin-training-summary.tsx
+++ b/apps/nextjs/src/app/_components/garmin-training-summary.tsx
@@ -60,14 +60,18 @@ export function GarminTrainingSummary() {
   });
   const staleCaption = (date: string | null | undefined) => {
     if (!date) return null;
-    const value = `${date}T12:00:00Z`;
-    const dateKey = formatDateInTz(value, timezone, {
+    // `date` is YYYY-MM-DD from the API. Anchor at noon in the *target*
+    // timezone (not UTC) so we don't drift a day at UTC±12. We do this by
+    // building the ISO timestamp `${date}T12:00:00` and parsing it as local
+    // (no Z), then formatting with `timeZone: timezone`.
+    const local = new Date(`${date}T12:00:00`);
+    const dateKey = formatDateInTz(local, timezone, {
       year: "numeric",
       month: "2-digit",
       day: "2-digit",
     });
     if (dateKey === todayKey) return null;
-    return `as of ${formatDateInTz(value, timezone, {
+    return `as of ${formatDateInTz(local, timezone, {
       month: "short",
       day: "numeric",
     })}`;
@@ -163,7 +167,7 @@ export function GarminTrainingSummary() {
         {/* HRV (weekly avg + trend) */}
         <div className="bg-background/40 rounded-lg p-3">
           <div className="text-muted-foreground text-[10px] tracking-wide uppercase">
-            HRV (7d)
+            HRV (14d)
           </div>
           <div className="mt-1 flex items-baseline gap-1">
             <span className="text-2xl font-bold">

--- a/apps/nextjs/src/app/_components/garmin-training-summary.tsx
+++ b/apps/nextjs/src/app/_components/garmin-training-summary.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { cn } from "@acme/ui";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { DataFreshness } from "./data-freshness";
 
@@ -33,8 +34,9 @@ function trendChip(trend: "rising" | "falling" | "stable" | null): {
 /* ── component ──────────────────────────────────────────────────── */
 export function GarminTrainingSummary() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const summary = useQuery(
-    trpc.garmin.getTrainingSummary.queryOptions({ days: 7 }),
+    trpc.garmin.getTrainingSummary.queryOptions({ days: 14 }),
   );
 
   if (summary.isLoading) {
@@ -51,7 +53,37 @@ export function GarminTrainingSummary() {
     );
   }
 
+  const todayKey = formatDateInTz(new Date(), timezone, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const staleCaption = (date: string | null | undefined) => {
+    if (!date) return null;
+    const value = `${date}T12:00:00Z`;
+    const dateKey = formatDateInTz(value, timezone, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    if (dateKey === todayKey) return null;
+    return `as of ${formatDateInTz(value, timezone, {
+      month: "short",
+      day: "numeric",
+    })}`;
+  };
+
   const readiness = readinessZone(latest.garminTrainingReadiness ?? null);
+  const readinessAsOf = staleCaption(
+    summary.data?.latestDates.garminTrainingReadiness,
+  );
+  const recoveryAsOf = staleCaption(
+    summary.data?.latestDates.garminRecoveryHours,
+  );
+  const statusAsOf = staleCaption(
+    summary.data?.latestDates.garminTrainingStatus ??
+      summary.data?.latestDates.garminTrainingReadinessLevel,
+  );
   const trend = trendChip(
     (summary.data?.hrvTrend as "rising" | "falling" | "stable" | null) ?? null,
   );
@@ -86,6 +118,9 @@ export function GarminTrainingSummary() {
           </div>
           <div className={cn("mt-0.5 text-xs", readiness.className)}>
             {readiness.label}
+            {readinessAsOf && (
+              <span className="text-muted-foreground"> · {readinessAsOf}</span>
+            )}
           </div>
         </div>
 
@@ -104,7 +139,9 @@ export function GarminTrainingSummary() {
               <span className="text-muted-foreground text-xs">h</span>
             )}
           </div>
-          <div className="text-muted-foreground mt-0.5 text-xs">remaining</div>
+          <div className="text-muted-foreground mt-0.5 text-xs">
+            remaining{recoveryAsOf ? ` · ${recoveryAsOf}` : ""}
+          </div>
         </div>
 
         {/* Training Status */}
@@ -119,6 +156,7 @@ export function GarminTrainingSummary() {
           </div>
           <div className="text-muted-foreground mt-0.5 text-xs">
             {latest.garminTrainingReadinessLevel?.toLowerCase() ?? "—"}
+            {statusAsOf ? ` · ${statusAsOf}` : ""}
           </div>
         </div>
 

--- a/packages/api/src/router/__tests__/garmin.test.ts
+++ b/packages/api/src/router/__tests__/garmin.test.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { appRouter } from "../../root";
+
+const TEST_USER_ID = "test-user-garmin";
+
+function makeSession(userId = TEST_USER_ID) {
+  const now = new Date();
+  return {
+    user: {
+      id: userId,
+      name: "Test User",
+      email: "test@local",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+    session: {
+      id: "test-session",
+      userId,
+      token: "test-token",
+      expiresAt: new Date(Date.now() + 86_400_000),
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+function dateString(daysAgo: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().split("T")[0]!;
+}
+
+type TrainingSummaryRow = {
+  date: string;
+  hrv: number | null;
+  garminTrainingReadiness: number | null;
+  garminTrainingReadinessLevel: string | null;
+  garminTrainingLoad: number | null;
+  garminTrainingStatus: string | null;
+  garminLoadFocus: unknown | null;
+  garminRecoveryHours: number | null;
+};
+
+function makeMockDb(rows: TrainingSummaryRow[]) {
+  const orderBy = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ orderBy }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+
+  return { select };
+}
+
+function createCaller(mockDb: ReturnType<typeof makeMockDb>) {
+  return appRouter.createCaller({
+    authApi: null as never,
+    session: makeSession(),
+    db: mockDb as never,
+  });
+}
+
+describe("garmin.getTrainingSummary", () => {
+  it("uses a 14-day default and reports per-field latest non-null dates", async () => {
+    const recoveryDate = dateString(10);
+    const statusDate = dateString(5);
+    const readinessDate = dateString(1);
+    const rows: TrainingSummaryRow[] = [
+      {
+        date: dateString(0),
+        hrv: 42,
+        garminTrainingReadiness: null,
+        garminTrainingReadinessLevel: null,
+        garminTrainingLoad: null,
+        garminTrainingStatus: null,
+        garminLoadFocus: null,
+        garminRecoveryHours: null,
+      },
+      {
+        date: readinessDate,
+        hrv: 44,
+        garminTrainingReadiness: 73,
+        garminTrainingReadinessLevel: "GOOD",
+        garminTrainingLoad: null,
+        garminTrainingStatus: null,
+        garminLoadFocus: null,
+        garminRecoveryHours: null,
+      },
+      {
+        date: statusDate,
+        hrv: null,
+        garminTrainingReadiness: null,
+        garminTrainingReadinessLevel: null,
+        garminTrainingLoad: 424,
+        garminTrainingStatus: "PRODUCTIVE",
+        garminLoadFocus: { highAerobic: 120 },
+        garminRecoveryHours: null,
+      },
+      {
+        date: recoveryDate,
+        hrv: null,
+        garminTrainingReadiness: null,
+        garminTrainingReadinessLevel: null,
+        garminTrainingLoad: null,
+        garminTrainingStatus: null,
+        garminLoadFocus: null,
+        garminRecoveryHours: 16.7,
+      },
+    ];
+    const caller = createCaller(makeMockDb(rows));
+
+    const result = await caller.garmin.getTrainingSummary();
+
+    expect(result.days).toBe(14);
+    expect(result.latest?.garminTrainingReadiness).toBe(73);
+    expect(result.latest?.garminTrainingReadinessLevel).toBe("GOOD");
+    expect(result.latest?.garminTrainingLoad).toBe(424);
+    expect(result.latest?.garminTrainingStatus).toBe("PRODUCTIVE");
+    expect(result.latest?.garminLoadFocus).toEqual({ highAerobic: 120 });
+    expect(result.latest?.garminRecoveryHours).toBe(16.7);
+    expect(result.latestDates).toEqual({
+      garminTrainingReadiness: readinessDate,
+      garminTrainingReadinessLevel: readinessDate,
+      garminTrainingLoad: statusDate,
+      garminTrainingStatus: statusDate,
+      garminLoadFocus: statusDate,
+      garminRecoveryHours: recoveryDate,
+    });
+  });
+});

--- a/packages/api/src/router/__tests__/garmin.test.ts
+++ b/packages/api/src/router/__tests__/garmin.test.ts
@@ -42,7 +42,7 @@ type TrainingSummaryRow = {
   garminTrainingReadinessLevel: string | null;
   garminTrainingLoad: number | null;
   garminTrainingStatus: string | null;
-  garminLoadFocus: unknown | null;
+  garminLoadFocus: unknown;
   garminRecoveryHours: number | null;
 };
 

--- a/packages/api/src/router/garmin.ts
+++ b/packages/api/src/router/garmin.ts
@@ -120,8 +120,8 @@ export const garminRouter = {
       const userId = ctx.session.user.id;
       const days = input?.days ?? 14;
 
-      // Use an exclusive lower bound so a `days=7` window returns 7 calendar
-      // days, not 8. `gte` against `since + 1` is equivalent to `gt(since)`.
+      // Use an exclusive lower bound so a `days=N` window returns N calendar
+      // days, not N+1. `gte` against `since + 1` is equivalent to `gt(since)`.
       const since = new Date();
       since.setUTCDate(since.getUTCDate() - days + 1);
       const sinceStr = since.toISOString().split("T")[0]!;

--- a/packages/api/src/router/garmin.ts
+++ b/packages/api/src/router/garmin.ts
@@ -115,10 +115,10 @@ export const garminRouter = {
     }),
 
   getTrainingSummary: protectedProcedure
-    .input(z.object({ days: z.number().min(1).max(30).default(7) }).optional())
+    .input(z.object({ days: z.number().min(1).max(30).default(14) }).optional())
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const days = input?.days ?? 7;
+      const days = input?.days ?? 14;
 
       // Use an exclusive lower bound so a `days=7` window returns 7 calendar
       // days, not 8. `gte` against `since + 1` is equivalent to `gt(since)`.
@@ -151,29 +151,47 @@ export const garminRouter = {
       // UI's "Garmin Native" card was rendering all em-dashes because it
       // pulled `rows[0]` (today) verbatim. Fall back per-field to the most
       // recent date in the window that actually has data.
-      function latestNonNull<K extends keyof (typeof rows)[number]>(
+      function latestNonNullRow<K extends keyof (typeof rows)[number]>(
         key: K,
-      ): (typeof rows)[number][K] | null {
+      ): (typeof rows)[number] | null {
         for (const row of rows) {
           const v = row[key];
-          if (v != null) return v;
+          if (v != null) return row;
         }
         return null;
       }
 
+      const readinessRow = latestNonNullRow("garminTrainingReadiness");
+      const readinessLevelRow = latestNonNullRow(
+        "garminTrainingReadinessLevel",
+      );
+      const trainingLoadRow = latestNonNullRow("garminTrainingLoad");
+      const trainingStatusRow = latestNonNullRow("garminTrainingStatus");
+      const loadFocusRow = latestNonNullRow("garminLoadFocus");
+      const recoveryHoursRow = latestNonNullRow("garminRecoveryHours");
+
       const latest = rows[0]
         ? {
             ...rows[0],
-            garminTrainingReadiness: latestNonNull("garminTrainingReadiness"),
-            garminTrainingReadinessLevel: latestNonNull(
-              "garminTrainingReadinessLevel",
-            ),
-            garminTrainingLoad: latestNonNull("garminTrainingLoad"),
-            garminTrainingStatus: latestNonNull("garminTrainingStatus"),
-            garminLoadFocus: latestNonNull("garminLoadFocus"),
-            garminRecoveryHours: latestNonNull("garminRecoveryHours"),
+            garminTrainingReadiness:
+              readinessRow?.garminTrainingReadiness ?? null,
+            garminTrainingReadinessLevel:
+              readinessLevelRow?.garminTrainingReadinessLevel ?? null,
+            garminTrainingLoad: trainingLoadRow?.garminTrainingLoad ?? null,
+            garminTrainingStatus:
+              trainingStatusRow?.garminTrainingStatus ?? null,
+            garminLoadFocus: loadFocusRow?.garminLoadFocus ?? null,
+            garminRecoveryHours: recoveryHoursRow?.garminRecoveryHours ?? null,
           }
         : null;
+      const latestDates = {
+        garminTrainingReadiness: readinessRow?.date ?? null,
+        garminTrainingReadinessLevel: readinessLevelRow?.date ?? null,
+        garminTrainingLoad: trainingLoadRow?.date ?? null,
+        garminTrainingStatus: trainingStatusRow?.date ?? null,
+        garminLoadFocus: loadFocusRow?.date ?? null,
+        garminRecoveryHours: recoveryHoursRow?.date ?? null,
+      };
       const hrvSeries = rows
         .filter((r) => r.hrv != null)
         .map((r) => ({ date: r.date, hrv: r.hrv! }))
@@ -198,6 +216,7 @@ export const garminRouter = {
       return {
         days,
         latest,
+        latestDates,
         hrvSeries,
         hrvAvg: hrvAvg != null ? Math.round(hrvAvg * 10) / 10 : null,
         hrvTrend,


### PR DESCRIPTION
Closes screenshot QA finding P0-2.

The Garmin Native (Firstbeat) card on /training showed Recovery as '—' even though daily_metric.garmin_recovery_hours was populated on older days. This widens the getTrainingSummary lookback to 14 days and labels each field with 'as of <date>' when sourced from a non-today row.

- `getTrainingSummary` lookback default raised from 7d → 14d
- Per-field 'latest non-null date' surfaced in response payload
- Firstbeat card renders 'as of May 14' caption when value is stale

Part of the screenshot QA sweep (2026-05-16).

Co-authored-by: Claude <claude@anthropic.com>