### PR TITLE
chore(ui): screenshot qa polish batch

### DIFF
--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -207,7 +207,7 @@ export function DashboardHome() {
           <div>
             <p className="text-sm font-semibold">Fitness</p>
             <p className="text-muted-foreground text-xs">
-              VO2max &amp; race predictions
+              VO2max &amp; Race Predictions
             </p>
           </div>
         </Link>
@@ -219,7 +219,7 @@ export function DashboardHome() {
           <div>
             <p className="text-sm font-semibold">Insights</p>
             <p className="text-muted-foreground text-xs">
-              Daily recommendations
+              Daily Recommendations
             </p>
           </div>
         </Link>
@@ -257,8 +257,8 @@ export function DashboardHome() {
                   .replace(/\b\w/g, (c: string) => c.toUpperCase())
               : "Activity";
             const date = formatDateInTz(a.startedAt, timezone, {
-              weekday: "short",
-              month: "short",
+              weekday: "long",
+              month: "long",
               day: "numeric",
             });
             return (

--- a/apps/nextjs/src/app/_components/garmin-training-summary.tsx
+++ b/apps/nextjs/src/app/_components/garmin-training-summary.tsx
@@ -64,7 +64,7 @@ export function GarminTrainingSummary() {
         </h2>
         <DataFreshness computedAt={summary.data?.computedAt} />
       </div>
-      <p className="text-muted-foreground -mt-1 text-[11px]">
+      <p className="text-muted-foreground -mt-1 text-xs leading-relaxed">
         From your watch&apos;s Firstbeat algorithms. Requires Forerunner 245+,
         Fenix 6+, or similar. See the home page for our computed Readiness
         score, which uses HRV / RHR / sleep and works on any device.
@@ -112,7 +112,7 @@ export function GarminTrainingSummary() {
           <div className="text-muted-foreground text-[10px] tracking-wide uppercase">
             Status
           </div>
-          <div className="mt-1 truncate text-lg font-semibold capitalize">
+          <div className="mt-1 text-lg leading-snug font-semibold capitalize">
             {latest.garminTrainingStatus
               ? latest.garminTrainingStatus.toLowerCase().replace(/_/g, " ")
               : "—"}

--- a/apps/nextjs/src/app/_components/readiness-card.tsx
+++ b/apps/nextjs/src/app/_components/readiness-card.tsx
@@ -69,7 +69,7 @@ function DataQualityDots({ dq }: { dq: DataQuality }) {
   ];
   return (
     <div
-      className="mt-2 flex flex-wrap gap-2"
+      className="mt-2 grid grid-cols-2 gap-2 min-[380px]:flex min-[380px]:flex-wrap"
       role="list"
       aria-label="Data quality indicators"
     >
@@ -185,8 +185,8 @@ export function ReadinessCard({
               {score}
             </span>
             {confidencePct != null && (
-              <span className="text-muted-foreground mt-0.5 text-[10px] tabular-nums">
-                {confidencePct}% conf.
+              <span className="text-muted-foreground mt-0.5 text-[9px] tabular-nums">
+                {confidencePct}% confidence
               </span>
             )}
           </div>

--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -470,14 +470,14 @@ export default function CoachPage() {
 
       {/* Quick Actions — always visible above input */}
       {!history.isLoading && (
-        <div className="flex gap-2 overflow-x-auto border-t border-zinc-800/50 px-4 py-2">
+        <div className="flex flex-wrap gap-2 border-t border-zinc-800/50 px-4 py-2">
           {agentConfig.quickActions.map((action) => (
             <button
               key={action.label}
               onClick={() => handleSend(action.message)}
               disabled={sendMutation.isPending}
               className={cn(
-                "shrink-0 rounded-full border px-3 py-1.5 text-xs transition-colors disabled:opacity-50",
+                "max-w-full rounded-full border px-3 py-1.5 text-left text-xs whitespace-normal transition-colors disabled:opacity-50",
                 agentConfig.accentBorder,
                 "bg-zinc-800 text-zinc-300 hover:bg-zinc-700",
               )}

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -382,9 +382,11 @@ export default function FitnessPage() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold pl-12">Fitness &amp; Performance</h1>
+          <h1 className="pl-12 text-2xl font-bold">
+            Fitness &amp; Performance
+          </h1>
           <p className="text-muted-foreground text-sm">
-            VO2max &amp; race predictions
+            VO2max &amp; Race Predictions
           </p>
         </div>
         {trendInfo && (
@@ -418,7 +420,8 @@ export default function FitnessPage() {
           </p>
           <p className="text-muted-foreground mt-1 text-sm">ml/kg/min</p>
           <p className="text-muted-foreground mt-1 text-[10px] tracking-wider uppercase">
-            via {latestVO2max.source === "garmin_official"
+            via{" "}
+            {latestVO2max.source === "garmin_official"
               ? "Garmin Firstbeat"
               : latestVO2max.source === "running_pace_hr"
                 ? "Pace+HR model"
@@ -472,9 +475,9 @@ export default function FitnessPage() {
           />
           {garminUsingFallback && (
             <p className="text-muted-foreground mb-3 text-xs">
-              ℹ️ No Garmin VO2max updates in the last {chartDays} days —
-              Garmin only records after qualifying outdoor runs (12+ min
-              with heart rate). Showing your most recent readings instead.
+              ℹ️ No Garmin VO2max updates in the last {chartDays} days — Garmin
+              only records after qualifying outdoor runs (12+ min with heart
+              rate). Showing your most recent readings instead.
             </p>
           )}
           {!garminUsingFallback && garminChartData.length < 3 && (
@@ -841,6 +844,8 @@ export default function FitnessPage() {
                       "text-xs font-medium",
                       r.diff > 0 ? "text-red-400" : "text-green-400",
                     )}
+                    title="Difference between your actual finish time and the VO2max-based predicted time. Positive means slower than predicted; negative means faster."
+                    aria-label={`${r.diffFmt} versus predicted ${r.predicted}. Positive means slower than predicted; negative means faster.`}
                   >
                     {r.diffFmt} vs predicted {r.predicted}
                   </p>

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -123,7 +123,7 @@ export default function TrainingLoadPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold pl-12">Training Load</h1>
+        <h1 className="pl-12 text-2xl font-bold">Training</h1>
         {status.data ? (
           <span
             className={cn(

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -123,9 +123,10 @@ function formatDate(iso: string): string {
 }
 
 function isToday(iso: string): boolean {
-  const now = new Date();
-  const todayLocal = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-  return iso === todayLocal;
+  // `nc.date` is normalized to UTC YYYY-MM-DD by the engine (see
+  // packages/engine/src/trends/index.ts). Compare against today's UTC date
+  // so the label stays consistent with the underlying data.
+  return iso === new Date().toISOString().split("T")[0];
 }
 
 function splitCategory(description: string): {

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -66,11 +66,18 @@ const METRIC_LABELS: Record<string, string> = {
   acwr: "ACWR",
 };
 
+const TREND_CATEGORY_LABELS: Record<string, string> = {
+  "🔥": "Load",
+  "📊": "Data",
+  "💪": "Training",
+  "🩺": "Health",
+  "🌙": "Sleep",
+  "😴": "Recovery",
+};
+
 function prettyMetric(key: string): string {
   if (METRIC_LABELS[key]) return METRIC_LABELS[key];
-  return key
-    .replace(/[_-]+/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+  return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 type TrendMetric =
@@ -113,6 +120,26 @@ function correlationPeriod(p: Period): CorrelationPeriod {
 function formatDate(iso: string): string {
   const d = new Date(iso + "T00:00:00");
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function isToday(iso: string): boolean {
+  return iso === new Date().toISOString().split("T")[0];
+}
+
+function splitCategory(description: string): {
+  emoji: string;
+  label: string;
+  text: string;
+} | null {
+  const emoji = Array.from(description.trim())[0];
+  if (!emoji) return null;
+  const label = TREND_CATEGORY_LABELS[emoji];
+  if (!label) return null;
+  return {
+    emoji,
+    label,
+    text: description.trim().slice(emoji.length).trim(),
+  };
 }
 
 function formatSleep(minutes: number | null | undefined): string {
@@ -316,7 +343,7 @@ export default function TrendsPage() {
     <main className="mx-auto max-w-4xl space-y-6 px-4 pt-6 pb-24">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12">Trends &amp; Analytics</h1>
+        <h1 className="pl-12 text-2xl font-bold">Trends &amp; Analytics</h1>
         <p className="text-muted-foreground text-sm">
           {PERIODS.find((x) => x.value === period)?.label ?? period} overview
           {useSmoothed ? " · 7-day rolling avg" : ""}
@@ -640,28 +667,49 @@ export default function TrendsPage() {
                 change: number;
                 description: string;
               }[]
-            ).map((nc, i) => (
-              <div
-                key={i}
-                className="bg-card flex items-start gap-3 rounded-xl border p-3"
-              >
-                <div className="text-muted-foreground mt-0.5 shrink-0 text-xs font-medium">
-                  {formatDate(nc.date)}
+            ).map((nc, i) => {
+              const category = splitCategory(nc.description);
+              return (
+                <div
+                  key={i}
+                  className="bg-card flex items-start gap-3 rounded-xl border p-3"
+                >
+                  <div className="text-muted-foreground mt-0.5 w-16 shrink-0 text-xs font-medium">
+                    <div>
+                      {isToday(nc.date) ? "Today" : formatDate(nc.date)}
+                    </div>
+                    <div className="text-[10px] font-normal">vs window avg</div>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {category && (
+                        <span
+                          className="rounded-full bg-zinc-800 px-2 py-0.5 text-[11px] text-zinc-300"
+                          title={`${category.label} category`}
+                          aria-label={`${category.label} category`}
+                        >
+                          <span aria-hidden="true">{category.emoji}</span>{" "}
+                          {category.label}
+                        </span>
+                      )}
+                      <p className="text-sm">
+                        {category ? category.text : nc.description}
+                      </p>
+                    </div>
+                    <p
+                      className={cn(
+                        "text-xs font-medium",
+                        nc.change > 0 ? "text-green-400" : "text-red-400",
+                      )}
+                      title="Today's value compared with the selected window average."
+                    >
+                      Today vs window avg: {nc.change > 0 ? "+" : ""}
+                      {nc.change.toFixed(1)}%
+                    </p>
+                  </div>
                 </div>
-                <div className="flex-1">
-                  <p className="text-sm">{nc.description}</p>
-                  <p
-                    className={cn(
-                      "text-xs font-medium",
-                      nc.change > 0 ? "text-green-400" : "text-red-400",
-                    )}
-                  >
-                    {nc.change > 0 ? "+" : ""}
-                    {nc.change.toFixed(1)}%
-                  </p>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -701,8 +749,7 @@ export default function TrendsPage() {
                 >
                   <div className="flex items-center justify-between">
                     <p className="text-sm font-medium">
-                      {prettyMetric(c.metricA)} →{" "}
-                      {prettyMetric(c.metricB)}
+                      {prettyMetric(c.metricA)} → {prettyMetric(c.metricB)}
                     </p>
                     <span
                       className={cn(

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -123,7 +123,9 @@ function formatDate(iso: string): string {
 }
 
 function isToday(iso: string): boolean {
-  return iso === new Date().toISOString().split("T")[0];
+  const now = new Date();
+  const todayLocal = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  return iso === todayLocal;
 }
 
 function splitCategory(description: string): {
@@ -678,7 +680,9 @@ export default function TrendsPage() {
                     <div>
                       {isToday(nc.date) ? "Today" : formatDate(nc.date)}
                     </div>
-                    <div className="text-[10px] font-normal">vs window avg</div>
+                    <div className="text-[10px] font-normal">
+                      week-over-week
+                    </div>
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
@@ -701,9 +705,9 @@ export default function TrendsPage() {
                         "text-xs font-medium",
                         nc.change > 0 ? "text-green-400" : "text-red-400",
                       )}
-                      title="Today's value compared with the selected window average."
+                      title="Week-over-week percent change (current 7-day avg vs previous 7-day avg)."
                     >
-                      Today vs window avg: {nc.change > 0 ? "+" : ""}
+                      Week-over-week: {nc.change > 0 ? "+" : ""}
                       {nc.change.toFixed(1)}%
                     </p>
                   </div>

--- a/apps/nextjs/src/app/validation/page.tsx
+++ b/apps/nextjs/src/app/validation/page.tsx
@@ -302,8 +302,8 @@ export default function ValidationPage() {
             <p className="text-sm text-muted-foreground">Loading…</p>
           ) : measurements.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              No reference measurements yet. Add one above to compare Garmin
-              accuracy.
+              No reference measurements yet. Add a lab or reference value above
+              to compare it against Garmin&apos;s estimate and track accuracy.
             </p>
           ) : (
             <div className="space-y-3">


### PR DESCRIPTION
Sweep of P2 inconsistencies from the v0.16.19 multi-page screenshot review.

- Home: spell out "confidence", align date formats and title-casing
- Home (mobile): readiness factor row 2x2 grid on narrow viewports
- Training: Firstbeat description no longer truncates; nav/page aligned
- Coach (mobile): action chips wrap instead of ellipsis
- Fitness: race-prediction delta gets explanatory tooltip
- Trends: category emoji rows get text labels
- Validation: empty state explains the page purpose

Closes screenshot QA findings P2-1/2/3/4/5/6/8/10/11/12/17.

Verification: pnpm typecheck