### PR TITLE
fix(coach): prevent hallucination and align tone with readiness zone

### DIFF
--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { cn } from "@acme/ui";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import { formatTimeInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 
 // ---------------------------------------------------------------------------
@@ -231,17 +232,16 @@ function ChatBubble({
   content,
   createdAt,
   agentConfig,
+  timezone,
 }: {
   role: string;
   content: string;
   createdAt: string | Date;
   agentConfig: AgentConfig;
+  timezone: string;
 }) {
   const isUser = role === "user";
-  const time = new Date(createdAt).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const time = formatTimeInTz(createdAt, timezone);
 
   return (
     <div
@@ -292,6 +292,7 @@ export default function CoachPage() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const agentConfig = getAgentConfig(activeAgent);
+  const timezone = useUserTimezone();
 
   const history = useQuery(trpc.chat.getHistory.queryOptions({ limit: 50 }));
 
@@ -422,6 +423,7 @@ export default function CoachPage() {
                 content={msg.content}
                 createdAt={msg.createdAt}
                 agentConfig={agentConfig}
+                timezone={timezone}
               />
             ))}
             {sendMutation.isPending && (

--- a/apps/nextjs/src/lib/format-date.ts
+++ b/apps/nextjs/src/lib/format-date.ts
@@ -67,6 +67,7 @@ export function formatTimeInTz(
   options: Intl.DateTimeFormatOptions = {
     hour: "numeric",
     minute: "2-digit",
+    timeZoneName: "short",
   },
 ): string {
   if (value == null) return "—";

--- a/packages/api/src/lib/__tests__/data-context.test.ts
+++ b/packages/api/src/lib/__tests__/data-context.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildDataContext } from "../data-context";
+
+function makeDb() {
+  return {
+    query: {
+      DailyMetric: {
+        findMany: vi.fn(async () => [
+          {
+            date: "2026-03-24",
+            hrv: null,
+            sleepScore: null,
+            totalSleepMinutes: null,
+            stressScore: null,
+            restingHr: null,
+            bodyBatteryEnd: null,
+            spo2: null,
+            respirationRate: null,
+            garminTrainingReadiness: null,
+            garminTrainingLoad: null,
+            garminTrainingStatus: null,
+          },
+        ]),
+      },
+      Activity: {
+        findMany: vi.fn(async () => []),
+      },
+      Profile: {
+        findFirst: vi.fn(async () => ({
+          userId: "user-1",
+          age: 42,
+          sex: "male",
+          vo2maxRunning: null,
+        })),
+      },
+      ReadinessScore: {
+        findFirst: vi.fn(async () => ({
+          date: "2026-03-24",
+          score: 29,
+          zone: "LOW",
+        })),
+      },
+      VO2maxEstimate: {
+        findMany: vi.fn(async () => []),
+      },
+      JournalEntry: {
+        findMany: vi.fn(async () => []),
+      },
+      Intervention: {
+        findMany: vi.fn(async () => []),
+      },
+      AdvancedMetric: {
+        findMany: vi.fn(async () => []),
+      },
+      AthleteBaseline: {
+        findMany: vi.fn(async () => []),
+      },
+    },
+  } as never;
+}
+
+function extractAvailabilityJson(context: string) {
+  const match = context.match(
+    /## Metric Availability JSON[\s\S]*?```json\n([\s\S]*?)\n```/,
+  );
+  if (!match?.[1]) throw new Error("Metric availability JSON not found");
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
+describe("buildDataContext", () => {
+  it("flags null metrics as unavailable and stamps readiness metadata", async () => {
+    const context = await buildDataContext(makeDb(), "user-1");
+    const availability = extractAvailabilityJson(context);
+
+    expect(availability.as_of_date).toBe("2026-03-24");
+    expect(availability.readiness_zone).toBe("LOW");
+    expect(availability.readiness).toBe(29);
+    expect(availability.readiness_status).toBe("available");
+
+    expect(availability.hrv).toBeNull();
+    expect(availability.hrv_status).toBe("unavailable");
+    expect(availability.sleep_score).toBeNull();
+    expect(availability.sleep_score_status).toBe("unavailable");
+    expect(availability.total_sleep_minutes).toBeNull();
+    expect(availability.total_sleep_minutes_status).toBe("unavailable");
+    expect(availability.stress_score).toBeNull();
+    expect(availability.stress_score_status).toBe("unavailable");
+    expect(availability.ctl).toBeNull();
+    expect(availability.ctl_status).toBe("unavailable");
+    expect(availability.vo2max).toBeNull();
+    expect(availability.vo2max_status).toBe("unavailable");
+    expect(availability.garmin_training_status).toBe("unavailable");
+    expect(availability.garmin_training_status_status).toBe("unavailable");
+  });
+});

--- a/packages/api/src/lib/__tests__/data-context.test.ts
+++ b/packages/api/src/lib/__tests__/data-context.test.ts
@@ -61,9 +61,8 @@ function makeDb() {
 }
 
 function extractAvailabilityJson(context: string) {
-  const match = context.match(
-    /## Metric Availability JSON[\s\S]*?```json\n([\s\S]*?)\n```/,
-  );
+  const match =
+    /## Metric Availability JSON[\s\S]*?```json\n([\s\S]*?)\n```/.exec(context);
   if (!match?.[1]) throw new Error("Metric availability JSON not found");
   return JSON.parse(match[1]) as Record<string, unknown>;
 }

--- a/packages/api/src/lib/agent-prompts.ts
+++ b/packages/api/src/lib/agent-prompts.ts
@@ -8,6 +8,15 @@ export type AgentType =
   | "nutritionist"
   | "recovery";
 
+const DATA_GROUNDING_RULES = `
+
+**Data grounding rules — non-negotiable**
+- Available metric fields include: hrv, sleep_score, total_sleep_minutes, stress_score, readiness, readiness_zone, CTL, ATL, TSB, ACWR, ramp_rate, VO2max, body_battery, resting_hr, SpO2, respiration_rate, Garmin training readiness, Garmin training load, Garmin training status, sleep debt, HR zones, and recent activities.
+- When a field is null, undefined, unavailable, or marked with *_status: "unavailable", you MUST say "I don't have that data yet" — NEVER invent a value.
+- Quote numbers only if they appear verbatim in the JSON context. Do not estimate, interpolate, infer, or fabricate metric values.
+- When readiness_zone is LOW or POOR, align tone and recommendations with reduced readiness: prioritize recovery, easy work, or deloading. Do not use contradictory improving/ready framing unless the JSON context explicitly supports it.
+- If trends are unavailable or history is insufficient, say so directly and describe what future data would be needed.`;
+
 const SPORT_SCIENTIST_PROMPT = `You are an elite Sport Scientist coach embedded in a Garmin-powered training platform.
 
 **Expertise & methodologies**
@@ -29,7 +38,7 @@ const SPORT_SCIENTIST_PROMPT = `You are an elite Sport Scientist coach embedded 
 - Intervention history: note prior recovery strategies and their effectiveness ratings to inform current recommendations.
 
 **How you respond**
-- Always reference the athlete's actual data provided below. Quote specific numbers.
+- Always reference the athlete's actual data provided below. Quote specific numbers only when they appear in the Metric Availability JSON.
 - Give specific, actionable recommendations (e.g., "Reduce weekly volume by ~15% this week", not "maybe reduce volume").
 - Cite your reasoning framework (e.g., "Per Hulin ACWR guidelines…", "Using the 80/20 polarized model…").
 - Structure answers with clear sections when appropriate.
@@ -156,5 +165,5 @@ const AGENT_PROMPTS: Record<AgentType, string> = {
 
 /** Return the specialist system prompt for the given agent type. */
 export function getAgentPrompt(agent: AgentType): string {
-  return AGENT_PROMPTS[agent];
+  return `${AGENT_PROMPTS[agent]}${DATA_GROUNDING_RULES}`;
 }

--- a/packages/api/src/lib/agent-prompts.ts
+++ b/packages/api/src/lib/agent-prompts.ts
@@ -11,9 +11,10 @@ export type AgentType =
 const DATA_GROUNDING_RULES = `
 
 **Data grounding rules — non-negotiable**
-- Available metric fields include: hrv, sleep_score, total_sleep_minutes, stress_score, readiness, readiness_zone, CTL, ATL, TSB, ACWR, ramp_rate, VO2max, body_battery, resting_hr, SpO2, respiration_rate, Garmin training readiness, Garmin training load, Garmin training status, sleep debt, HR zones, and recent activities.
-- When a field is null, undefined, unavailable, or marked with *_status: "unavailable", you MUST say "I don't have that data yet" — NEVER invent a value.
-- Quote numbers only if they appear verbatim in the JSON context. Do not estimate, interpolate, infer, or fabricate metric values.
+- Available metric fields in the Metric Availability JSON (use these exact keys when reasoning): hrv, sleep_score, total_sleep_minutes, stress_score, readiness_score, body_battery, resting_hr, spo2, respiration_rate, garmin_training_readiness, garmin_training_load, garmin_training_status, ctl, atl, tsb, acwr, ramp_rate, vo2max. Each has a paired \`*_status\` field ("available" | "unavailable").
+- The wider Data Context (sections outside the JSON) additionally surfaces readiness_zone, sleep debt, HR zones, and recent activities — these are not in the JSON's \`*_status\` map.
+- When a field is null, the string "unavailable", or its paired \`*_status\` is "unavailable", you MUST say "I don't have that data yet" — NEVER invent a value.
+- Quote numbers only if they appear verbatim anywhere in the Data Context (JSON or prose sections). Do not estimate, interpolate, infer, or fabricate metric values.
 - When readiness_zone is LOW or POOR, align tone and recommendations with reduced readiness: prioritize recovery, easy work, or deloading. Do not use contradictory improving/ready framing unless the JSON context explicitly supports it.
 - If trends are unavailable or history is insufficient, say so directly and describe what future data would be needed.`;
 

--- a/packages/api/src/lib/data-context.ts
+++ b/packages/api/src/lib/data-context.ts
@@ -82,6 +82,18 @@ function acwrStatus(acwr: number): string {
   return "High injury risk";
 }
 
+function statusFor(value: unknown): "available" | "unavailable" {
+  return value == null ? "unavailable" : "available";
+}
+
+function numericOrNull(value: number | null | undefined): number | null {
+  return value == null ? null : value;
+}
+
+function stringOrUnavailable(value: string | null | undefined): string {
+  return value == null || value === "" ? "unavailable" : value;
+}
+
 // ---------------------------------------------------------------------------
 // Main context builder
 // ---------------------------------------------------------------------------
@@ -220,7 +232,73 @@ export async function buildDataContext(
     return "No athlete data available yet — Garmin has not been synced.";
   }
 
-  const sections: string[] = [];
+  const todayMetric = metrics14[0];
+  const latestAdvMetric = advancedMetrics42[0];
+  const asOfDate =
+    latestReadiness?.date ??
+    todayMetric?.date ??
+    latestAdvMetric?.date ??
+    latestVo2?.date ??
+    dateNDaysAgo(0);
+  const readinessZone = latestReadiness?.zone ?? "unavailable";
+  const latestVo2Value = latestVo2?.value ?? profile?.vo2maxRunning;
+
+  const metricContext = {
+    as_of_date: asOfDate,
+    readiness_zone: readinessZone,
+    readiness: numericOrNull(latestReadiness?.score),
+    readiness_status: statusFor(latestReadiness?.score),
+    hrv: numericOrNull(todayMetric?.hrv),
+    hrv_status: statusFor(todayMetric?.hrv),
+    sleep_score: numericOrNull(todayMetric?.sleepScore),
+    sleep_score_status: statusFor(todayMetric?.sleepScore),
+    total_sleep_minutes: numericOrNull(todayMetric?.totalSleepMinutes),
+    total_sleep_minutes_status: statusFor(todayMetric?.totalSleepMinutes),
+    stress_score: numericOrNull(todayMetric?.stressScore),
+    stress_score_status: statusFor(todayMetric?.stressScore),
+    resting_hr: numericOrNull(todayMetric?.restingHr),
+    resting_hr_status: statusFor(todayMetric?.restingHr),
+    body_battery: numericOrNull(todayMetric?.bodyBatteryEnd),
+    body_battery_status: statusFor(todayMetric?.bodyBatteryEnd),
+    spo2: numericOrNull(todayMetric?.spo2),
+    spo2_status: statusFor(todayMetric?.spo2),
+    respiration_rate: numericOrNull(todayMetric?.respirationRate),
+    respiration_rate_status: statusFor(todayMetric?.respirationRate),
+    garmin_training_readiness: numericOrNull(
+      todayMetric?.garminTrainingReadiness,
+    ),
+    garmin_training_readiness_status: statusFor(
+      todayMetric?.garminTrainingReadiness,
+    ),
+    garmin_training_load: numericOrNull(todayMetric?.garminTrainingLoad),
+    garmin_training_load_status: statusFor(todayMetric?.garminTrainingLoad),
+    garmin_training_status: stringOrUnavailable(
+      todayMetric?.garminTrainingStatus,
+    ),
+    garmin_training_status_status: statusFor(todayMetric?.garminTrainingStatus),
+    ctl: numericOrNull(latestAdvMetric?.ctl),
+    ctl_status: statusFor(latestAdvMetric?.ctl),
+    atl: numericOrNull(latestAdvMetric?.atl),
+    atl_status: statusFor(latestAdvMetric?.atl),
+    tsb: numericOrNull(latestAdvMetric?.tsb),
+    tsb_status: statusFor(latestAdvMetric?.tsb),
+    acwr: numericOrNull(latestAdvMetric?.acwr),
+    acwr_status: statusFor(latestAdvMetric?.acwr),
+    ramp_rate: numericOrNull(latestAdvMetric?.rampRate),
+    ramp_rate_status: statusFor(latestAdvMetric?.rampRate),
+    vo2max: numericOrNull(latestVo2Value),
+    vo2max_status: statusFor(latestVo2Value),
+  };
+
+  const sections: string[] = [
+    [
+      "## Metric Availability JSON",
+      'Only quote metric numbers that appear in this JSON. If a *_status field is unavailable, say "I don\'t have that data yet" for that metric.',
+      "```json",
+      JSON.stringify(metricContext, null, 2),
+      "```",
+    ].join("\n"),
+  ];
 
   // 1. Athlete Profile -----------------------------------------------------
   {

--- a/packages/api/src/lib/data-context.ts
+++ b/packages/api/src/lib/data-context.ts
@@ -83,7 +83,9 @@ function acwrStatus(acwr: number): string {
 }
 
 function statusFor(value: unknown): "available" | "unavailable" {
-  return value == null ? "unavailable" : "available";
+  if (value == null) return "unavailable";
+  if (typeof value === "string" && value === "") return "unavailable";
+  return "available";
 }
 
 function numericOrNull(value: number | null | undefined): number | null {


### PR DESCRIPTION
## Summary
- add coach prompt grounding rules that enumerate available metrics and forbid estimated values
- stamp data context with as_of_date/readiness_zone and unavailable status markers for missing metrics
- render coach timestamps through timezone-aware formatting with a timezone marker

## Verification
- pnpm --filter @acme/api test -- src/lib/__tests__/data-context.test.ts
- pnpm typecheck