### PR TITLE
fix(ui): route last-sync timestamps through tz helper; mobile nav fixes

### DIFF
--- a/apps/nextjs/src/app/_components/bottom-nav.tsx
+++ b/apps/nextjs/src/app/_components/bottom-nav.tsx
@@ -35,6 +35,7 @@ export function BottomNav() {
             <Link
               key={item.href}
               href={item.href}
+              aria-label={item.label}
               className={cn(
                 "flex min-h-12 flex-1 flex-col items-center justify-center gap-0.5 rounded-lg px-1 py-1 text-xs transition-colors",
                 isActive
@@ -42,7 +43,9 @@ export function BottomNav() {
                   : "text-muted-foreground hover:text-foreground",
               )}
             >
-              <span className="text-lg">{item.icon}</span>
+              <span className="text-lg" aria-hidden="true">
+                {item.icon}
+              </span>
               <span className="max-[379px]:hidden">{item.label}</span>
             </Link>
           );

--- a/apps/nextjs/src/app/_components/bottom-nav.tsx
+++ b/apps/nextjs/src/app/_components/bottom-nav.tsx
@@ -24,8 +24,8 @@ export function BottomNav() {
     : pathname;
 
   return (
-    <nav className="bg-card border-border fixed right-0 bottom-0 left-0 z-50 border-t md:hidden">
-      <div className="mx-auto flex max-w-md items-center justify-around py-2">
+    <nav className="bg-card border-border fixed right-0 bottom-0 left-0 z-50 border-t pb-[env(safe-area-inset-bottom)] md:hidden">
+      <div className="mx-auto flex max-w-md items-center justify-around px-1 py-1">
         {navItems.map((item) => {
           const isActive =
             item.href === "/"
@@ -36,14 +36,14 @@ export function BottomNav() {
               key={item.href}
               href={item.href}
               className={cn(
-                "flex flex-col items-center gap-0.5 rounded-lg px-4 py-1.5 text-xs transition-colors",
+                "flex min-h-12 flex-1 flex-col items-center justify-center gap-0.5 rounded-lg px-1 py-1 text-xs transition-colors",
                 isActive
                   ? "text-primary font-semibold"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >
               <span className="text-lg">{item.icon}</span>
-              <span>{item.label}</span>
+              <span className="max-[379px]:hidden">{item.label}</span>
             </Link>
           );
         })}

--- a/apps/nextjs/src/app/_components/data-freshness.tsx
+++ b/apps/nextjs/src/app/_components/data-freshness.tsx
@@ -12,6 +12,12 @@
  */
 import { useEffect, useState } from "react";
 
+import {
+  formatDateInTz,
+  formatTimeInTz,
+  useUserTimezone,
+} from "~/lib/format-date";
+
 function format(deltaMs: number): string {
   if (deltaMs < 0) return "just now";
   const seconds = Math.floor(deltaMs / 1000);
@@ -35,6 +41,7 @@ export function DataFreshness({
   className = "",
   prefix = "updated",
 }: Props) {
+  const timezone = useUserTimezone();
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -49,8 +56,13 @@ export function DataFreshness({
       : computedAt.getTime();
   if (!Number.isFinite(ts)) return null;
 
+  const absolute = `${formatDateInTz(computedAt, timezone, { month: "short", day: "numeric", year: "numeric" })} at ${formatTimeInTz(computedAt, timezone)}`;
+
   return (
-    <span className={`text-muted-foreground text-[10px] ${className}`}>
+    <span
+      className={`text-muted-foreground text-[10px] ${className}`}
+      title={absolute}
+    >
       {prefix} {format(now - ts)}
     </span>
   );

--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { cn } from "@acme/ui";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import { formatTimeInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 
 // ---------------------------------------------------------------------------
@@ -231,14 +232,16 @@ function ChatBubble({
   content,
   createdAt,
   agentConfig,
+  timezone,
 }: {
   role: string;
   content: string;
   createdAt: string | Date;
   agentConfig: AgentConfig;
+  timezone: string;
 }) {
   const isUser = role === "user";
-  const time = new Date(createdAt).toLocaleTimeString([], {
+  const time = formatTimeInTz(createdAt, timezone, {
     hour: "2-digit",
     minute: "2-digit",
   });
@@ -284,6 +287,7 @@ function ChatBubble({
 
 export default function CoachPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const queryClient = useQueryClient();
   const [input, setInput] = useState("");
   const [activeAgent, setActiveAgent] = useState<AgentType>("sport-scientist");
@@ -422,6 +426,7 @@ export default function CoachPage() {
                 content={msg.content}
                 createdAt={msg.createdAt}
                 agentConfig={agentConfig}
+                timezone={timezone}
               />
             ))}
             {sendMutation.isPending && (
@@ -489,7 +494,7 @@ export default function CoachPage() {
       )}
 
       {/* Input Area */}
-      <div className="pb-safe border-t border-zinc-800 bg-zinc-900 px-4 py-3">
+      <div className="border-t border-zinc-800 bg-zinc-900 px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/apps/nextjs/src/app/export/page.tsx
+++ b/apps/nextjs/src/app/export/page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Button } from "@acme/ui/button";
 import { toast } from "@acme/ui/toast";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 
@@ -54,6 +55,7 @@ function formatDateForFilename() {
 
 export default function ExportPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
 
   // Data queries
   const activities = useQuery(trpc.activity.list.queryOptions({ days: 365 }));
@@ -164,7 +166,7 @@ export default function ExportPage() {
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div>
-        <h1 className="text-2xl font-bold pl-12">Data Export</h1>
+        <h1 className="pl-12 text-2xl font-bold">Data Export</h1>
         <p className="text-muted-foreground text-sm">
           Download your training data · Import backups
         </p>
@@ -190,13 +192,10 @@ export default function ExportPage() {
             <div className="bg-secondary/40 col-span-2 rounded-xl p-3 sm:col-span-1">
               <p className="truncate text-sm font-bold">
                 {earliestDate
-                  ? new Date(earliestDate as string).toLocaleDateString(
-                      "en-US",
-                      {
-                        month: "short",
-                        year: "numeric",
-                      },
-                    )
+                  ? formatDateInTz(earliestDate, timezone, {
+                      month: "short",
+                      year: "numeric",
+                    })
                   : "—"}
               </p>
               <p className="text-muted-foreground text-xs">Earliest data</p>

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -15,6 +15,7 @@ import {
 
 import { cn } from "@acme/ui";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 import { DateRangeSelector } from "../_components/date-range-selector";
@@ -117,9 +118,8 @@ function pacePerKm(seconds: number, distanceMeters: number): string {
   return `${mins}:${secs.toString().padStart(2, "0")} /km`;
 }
 
-function fmtDateShort(d: string): string {
-  const date = new Date(d);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+function fmtDateShort(d: string, timezone: string): string {
+  return formatDateInTz(d, timezone, { month: "short", day: "numeric" });
 }
 
 /* ── Confidence interval helper ── */
@@ -164,6 +164,7 @@ function vdotPace(vo2max: number, fraction: number): string {
 
 export default function FitnessPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const [chartDays, setChartDays] = useState(90);
 
   const vo2max = useQuery(
@@ -199,7 +200,7 @@ export default function FitnessPage() {
       if (ep === bp && new Date(e.date) > new Date(best.date)) return e;
       return best;
     }, vo2max.data.estimates[0]!);
-  }, [vo2max.data]);
+  }, [vo2max.data, timezone]);
 
   const trend = vo2max.data?.trend;
   const trendInfo = trend ? TREND_BADGE[trend.trend] : null;
@@ -208,13 +209,13 @@ export default function FitnessPage() {
   const chartData = useMemo(() => {
     if (!vo2max.data?.estimates?.length) return [];
     return [...vo2max.data.estimates].reverse().map((e) => ({
-      date: fmtDateShort(e.date),
+      date: fmtDateShort(e.date, timezone),
       fullDate: e.date,
       value: e.value,
       sport: e.sport,
       source: e.source,
     }));
-  }, [vo2max.data]);
+  }, [vo2max.data, timezone]);
 
   // Garmin official VO2max data (Firstbeat-based).
   // Garmin Firstbeat only emits VO2max after qualifying outdoor runs
@@ -225,7 +226,7 @@ export default function FitnessPage() {
     const inWindow = vo2max.data?.garminEstimates ?? [];
     if (inWindow.length > 0) {
       return [...inWindow].reverse().map((e) => ({
-        date: fmtDateShort(e.date),
+        date: fmtDateShort(e.date, timezone),
         fullDate: e.date,
         value: e.value,
       }));
@@ -233,11 +234,11 @@ export default function FitnessPage() {
     const recent = vo2max.data?.garminEstimatesRecent ?? [];
     if (recent.length === 0) return [];
     return [...recent].reverse().map((e) => ({
-      date: fmtDateShort(e.date),
+      date: fmtDateShort(e.date, timezone),
       fullDate: e.date,
       value: e.value,
     }));
-  }, [vo2max.data]);
+  }, [vo2max.data, timezone]);
 
   const garminUsingFallback =
     (vo2max.data?.garminEstimates?.length ?? 0) === 0 &&
@@ -247,11 +248,11 @@ export default function FitnessPage() {
   const uthChartData = useMemo(() => {
     if (!vo2max.data?.uthEstimates?.length) return [];
     return [...vo2max.data.uthEstimates].reverse().map((e) => ({
-      date: fmtDateShort(e.date),
+      date: fmtDateShort(e.date, timezone),
       fullDate: e.date,
       value: e.value,
     }));
-  }, [vo2max.data]);
+  }, [vo2max.data, timezone]);
 
   // Trendline helper: simple linear regression overlay
   function computeTrendline(
@@ -348,7 +349,7 @@ export default function FitnessPage() {
           diff: diffSecs,
           diffFmt: `${diffSecs >= 0 ? "+" : ""}${fmtTime(Math.abs(diffSecs))}`,
           date: a.startedAt
-            ? new Date(a.startedAt as string).toLocaleDateString("en-US", {
+            ? formatDateInTz(a.startedAt, timezone, {
                 month: "short",
                 day: "numeric",
               })
@@ -356,7 +357,7 @@ export default function FitnessPage() {
         };
       });
     });
-  }, [recentActivities.data, racePredictions.data]);
+  }, [recentActivities.data, racePredictions.data, timezone]);
 
   /* ── Running Shape gauge (0–100) ── */
   const runningShape = useMemo(() => {
@@ -382,7 +383,9 @@ export default function FitnessPage() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold pl-12">Fitness &amp; Performance</h1>
+          <h1 className="pl-12 text-2xl font-bold">
+            Fitness &amp; Performance
+          </h1>
           <p className="text-muted-foreground text-sm">
             VO2max &amp; race predictions
           </p>
@@ -418,7 +421,8 @@ export default function FitnessPage() {
           </p>
           <p className="text-muted-foreground mt-1 text-sm">ml/kg/min</p>
           <p className="text-muted-foreground mt-1 text-[10px] tracking-wider uppercase">
-            via {latestVO2max.source === "garmin_official"
+            via{" "}
+            {latestVO2max.source === "garmin_official"
               ? "Garmin Firstbeat"
               : latestVO2max.source === "running_pace_hr"
                 ? "Pace+HR model"
@@ -472,9 +476,9 @@ export default function FitnessPage() {
           />
           {garminUsingFallback && (
             <p className="text-muted-foreground mb-3 text-xs">
-              ℹ️ No Garmin VO2max updates in the last {chartDays} days —
-              Garmin only records after qualifying outdoor runs (12+ min
-              with heart rate). Showing your most recent readings instead.
+              ℹ️ No Garmin VO2max updates in the last {chartDays} days — Garmin
+              only records after qualifying outdoor runs (12+ min with heart
+              rate). Showing your most recent readings instead.
             </p>
           )}
           {!garminUsingFallback && garminChartData.length < 3 && (

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -16,6 +16,7 @@ import {
 
 import { cn } from "@acme/ui";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 import { DateRangeSelector } from "../_components/date-range-selector";
@@ -62,15 +63,15 @@ const HRV_PRESETS = [
   { label: "1y", days: 365 },
 ];
 
-function fmtDateShort(d: string): string {
-  const date = new Date(d);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+function fmtDateShort(d: string, timezone: string): string {
+  return formatDateInTz(d, timezone, { month: "short", day: "numeric" });
 }
 
 /* ─────────────── page ─────────────── */
 
 export default function HrvPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const [days, setDays] = useState(90);
 
   const { data, isLoading } = useQuery(
@@ -99,7 +100,7 @@ export default function HrvPage() {
     for (const d of data.daily) {
       map.set(d.date, {
         date: d.date,
-        label: fmtDateShort(d.date),
+        label: fmtDateShort(d.date, timezone),
         daily: d.value,
       });
     }
@@ -115,7 +116,7 @@ export default function HrvPage() {
     return Array.from(map.values()).sort((a, b) =>
       a.date.localeCompare(b.date),
     );
-  }, [data]);
+  }, [data, timezone]);
 
   // CV% over time: compute rolling 7-day CV for each point
   const cvData = useMemo(() => {
@@ -130,19 +131,19 @@ export default function HrvPage() {
       const cv = Math.round((std / mean) * 1000) / 10;
       result.push({
         date: data.daily[i]!.date,
-        label: fmtDateShort(data.daily[i]!.date),
+        label: fmtDateShort(data.daily[i]!.date, timezone),
         cv,
       });
     }
     return result;
-  }, [data]);
+  }, [data, timezone]);
 
   return (
     <main className="mx-auto flex max-w-lg flex-col gap-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold pl-12">HRV Analysis</h1>
+          <h1 className="pl-12 text-2xl font-bold">HRV Analysis</h1>
           <p className="text-muted-foreground text-sm">
             Heart Rate Variability &amp; Recovery
           </p>

--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { cn } from "@acme/ui";
 import { toast } from "@acme/ui/toast";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 import { SectionHeader } from "../_components/info-button";
@@ -445,6 +446,7 @@ function InsightCardUI({ insight }: { insight: InsightCard }) {
 
 export default function InsightsPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const queryClient = useQueryClient();
 
   // Proactive AI insights — refetch every 5 minutes to catch post-sync updates
@@ -550,9 +552,9 @@ export default function InsightsPage() {
       <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
         {/* ── Header ── */}
         <div>
-          <h1 className="text-2xl font-bold pl-12">Insights</h1>
+          <h1 className="pl-12 text-2xl font-bold">Insights</h1>
           <p className="text-muted-foreground text-sm">
-            {new Date().toLocaleDateString("en-US", {
+            {formatDateInTz(new Date(), timezone, {
               weekday: "long",
               month: "long",
               day: "numeric",

--- a/apps/nextjs/src/app/interventions/page.tsx
+++ b/apps/nextjs/src/app/interventions/page.tsx
@@ -7,6 +7,7 @@ import { cn } from "@acme/ui";
 import { Button } from "@acme/ui/button";
 import { toast } from "@acme/ui/toast";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 
@@ -38,9 +39,8 @@ function toDateStr(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-function fmtDate(iso: string): string {
-  const d = new Date(iso + "T12:00:00");
-  return d.toLocaleDateString("en-US", {
+function fmtDate(iso: string, timezone: string): string {
+  return formatDateInTz(iso, timezone, {
     weekday: "short",
     month: "short",
     day: "numeric",
@@ -63,6 +63,7 @@ function getTypeInfo(key: string) {
 
 export default function InterventionsPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const queryClient = useQueryClient();
 
   // -- Form state --
@@ -258,7 +259,7 @@ export default function InterventionsPage() {
                           {typeInfo.label}
                         </p>
                         <p className="text-muted-foreground text-xs">
-                          {fmtDate(item.date)}
+                          {fmtDate(item.date, timezone)}
                         </p>
                       </div>
                     </div>

--- a/apps/nextjs/src/app/journal/page.tsx
+++ b/apps/nextjs/src/app/journal/page.tsx
@@ -101,8 +101,16 @@ const NAP_OPTIONS = [0, 15, 20, 30, 45, 60, 90];
 // Helpers
 // ---------------------------------------------------------------------------
 
-function toDateStr(d: Date): string {
-  return d.toISOString().slice(0, 10);
+function toDateStr(d: Date, timezone?: string): string {
+  if (!timezone) return d.toISOString().slice(0, 10);
+  // Use Intl with en-CA (YYYY-MM-DD locale) to get the calendar day in the
+  // user's timezone — avoids a UTC-vs-local-day off-by-one at day boundaries.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
 }
 
 function fmtDate(iso: string, timezone: string): string {
@@ -167,7 +175,9 @@ export default function JournalPage() {
   const queryClient = useQueryClient();
 
   // -- Date selection --
-  const [selectedDate, setSelectedDate] = useState(toDateStr(new Date()));
+  const [selectedDate, setSelectedDate] = useState(
+    toDateStr(new Date(), timezone),
+  );
   const [notes, setNotes] = useState("");
   const [tags, setTags] = useState<Record<string, boolean | number | string>>(
     {},
@@ -344,7 +354,7 @@ export default function JournalPage() {
     const d = new Date(selectedDate + "T12:00:00");
     d.setDate(d.getDate() + dir);
     const next = toDateStr(d);
-    if (next > toDateStr(new Date())) return;
+    if (next > toDateStr(new Date(), timezone)) return;
     setSyncedDate(null);
     setSelectedDate(next);
   }
@@ -370,10 +380,10 @@ export default function JournalPage() {
           className="text-sm font-medium"
           onClick={() => {
             setSyncedDate(null);
-            setSelectedDate(toDateStr(new Date()));
+            setSelectedDate(toDateStr(new Date(), timezone));
           }}
         >
-          {selectedDate === toDateStr(new Date())
+          {selectedDate === toDateStr(new Date(), timezone)
             ? "Today"
             : fmtDate(selectedDate, timezone)}
         </button>
@@ -381,7 +391,7 @@ export default function JournalPage() {
           variant="outline"
           size="sm"
           onClick={() => shiftDate(1)}
-          disabled={selectedDate === toDateStr(new Date())}
+          disabled={selectedDate === toDateStr(new Date(), timezone)}
         >
           →
         </Button>

--- a/apps/nextjs/src/app/journal/page.tsx
+++ b/apps/nextjs/src/app/journal/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@acme/ui/button";
 import { toast } from "@acme/ui/toast";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 
@@ -104,9 +105,8 @@ function toDateStr(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-function fmtDate(iso: string): string {
-  const d = new Date(iso + "T12:00:00");
-  return d.toLocaleDateString("en-US", {
+function fmtDate(iso: string, timezone: string): string {
+  return formatDateInTz(iso, timezone, {
     weekday: "short",
     month: "short",
     day: "numeric",
@@ -163,6 +163,7 @@ function ScoreSlider({
 
 export default function JournalPage() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const queryClient = useQueryClient();
 
   // -- Date selection --
@@ -374,7 +375,7 @@ export default function JournalPage() {
         >
           {selectedDate === toDateStr(new Date())
             ? "Today"
-            : fmtDate(selectedDate)}
+            : fmtDate(selectedDate, timezone)}
         </button>
         <Button
           variant="outline"
@@ -689,7 +690,7 @@ export default function JournalPage() {
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
                       <p className="text-sm font-medium">
-                        {fmtDate(entry.date)}
+                        {fmtDate(entry.date, timezone)}
                       </p>
 
                       {/* Scores summary */}

--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
 
   return (
     <HydrateClient>
-      <main className="mx-auto max-w-lg px-4 pt-6 pb-24">
+      <main className="mx-auto max-w-lg px-4 pt-6 pb-[calc(7rem+env(safe-area-inset-bottom))]">
         <Suspense
           fallback={
             <div className="space-y-4">

--- a/apps/nextjs/src/app/settings/page.tsx
+++ b/apps/nextjs/src/app/settings/page.tsx
@@ -8,6 +8,11 @@ import { Button } from "@acme/ui/button";
 import { Input } from "@acme/ui/input";
 import { Label } from "@acme/ui/label";
 
+import {
+  formatDateInTz,
+  formatTimeInTz,
+  useUserTimezone,
+} from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 
@@ -462,6 +467,7 @@ interface AuthResponse {
 }
 
 function GarminConnection() {
+  const timezone = useUserTimezone();
   const [status, setStatus] = useState<GarminStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -680,7 +686,13 @@ function GarminConnection() {
             </p>
             {status.lastSync && (
               <p className="text-muted-foreground text-xs">
-                Last sync: {new Date(status.lastSync).toLocaleString()}
+                Last sync:{" "}
+                {formatDateInTz(status.lastSync, timezone, {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}{" "}
+                at {formatTimeInTz(status.lastSync, timezone)}
               </p>
             )}
           </div>
@@ -845,7 +857,7 @@ function GarminConnection() {
 export default function SettingsPage() {
   return (
     <main className="mx-auto max-w-lg space-y-6 px-4 pt-6 pb-24">
-      <h1 className="text-2xl font-bold pl-12">Settings</h1>
+      <h1 className="pl-12 text-2xl font-bold">Settings</h1>
 
       {/* Athlete Profile */}
       <ProfileEditor />

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@acme/ui";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 import { DateRangeSelector } from "../_components/date-range-selector";
@@ -44,12 +45,15 @@ function minToHours(min: number): number {
 }
 
 /** Format a date string as short day name or "Mon D" depending on range */
-function fmtDateShort(iso: string, totalDays: number): string {
-  const d = new Date(iso + "T00:00:00");
+function fmtDateShort(
+  iso: string,
+  totalDays: number,
+  timezone: string,
+): string {
   if (totalDays <= 7) {
-    return d.toLocaleDateString("en-US", { weekday: "short" });
+    return formatDateInTz(iso, timezone, { weekday: "short" });
   }
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return formatDateInTz(iso, timezone, { month: "short", day: "numeric" });
 }
 
 /** Format a clock time given as minutes-from-midnight (or decimal hours) */
@@ -95,6 +99,7 @@ function debtTextColor(debt: number): string {
 
 export default function SleepDashboard() {
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const [sleepDays, setSleepDays] = useState(28);
 
   // ---- Data queries ----
@@ -173,7 +178,7 @@ export default function SleepDashboard() {
     }
 
     return { avgDuration, avgScore, currentDebt, avgEfficiency };
-  }, [history.data]);
+  }, [history.data, timezone]);
 
   // ---- Derived: Sleep stages chart data ----
   const stagesChartData = useMemo(() => {
@@ -190,14 +195,14 @@ export default function SleepDashboard() {
     if (!raw) return [];
     const data = [...raw].reverse();
     return data.map((d) => ({
-      date: fmtDateShort(d.date, data.length),
+      date: fmtDateShort(d.date, data.length, timezone),
       deep: minToHours(d.deepMinutes),
       rem: minToHours(d.remMinutes),
       light: minToHours(d.lightMinutes),
       awake: minToHours(d.awakeMinutes),
       need: d.sleepNeedMinutes ? minToHours(d.sleepNeedMinutes) : undefined,
     }));
-  }, [stages.data]);
+  }, [stages.data, timezone]);
 
   // True when data exists but all detailed stage values are zero/null —
   // indicating the device doesn't support sleep stage tracking.
@@ -220,11 +225,11 @@ export default function SleepDashboard() {
     const scores = data.map((d) => d.sleepScore);
     const ma = data.length > 14 ? movingAvg(scores, 7) : null;
     return data.map((d, i) => ({
-      date: fmtDateShort(d.date, data.length),
+      date: fmtDateShort(d.date, data.length, timezone),
       score: d.sleepScore,
       avg: ma ? ma[i] : undefined,
     }));
-  }, [history.data]);
+  }, [history.data, timezone]);
 
   // ---- Derived: Sleep vs Need chart ----
   const vsNeedChartData = useMemo(() => {
@@ -240,11 +245,11 @@ export default function SleepDashboard() {
     // Show last 14 days for readability
     const slice = data.slice(-14);
     return slice.map((d) => ({
-      date: fmtDateShort(d.date, slice.length),
+      date: fmtDateShort(d.date, slice.length, timezone),
       actual: d.totalSleepMinutes ? minToHours(d.totalSleepMinutes) : null,
       need: d.sleepNeedMinutes ? minToHours(d.sleepNeedMinutes) : null,
     }));
-  }, [history.data]);
+  }, [history.data, timezone]);
 
   // ---- Derived: Sleep debt tracker (last 7 days) ----
   // Daily debt = max(0, sleepNeed - actualSleep). The historic
@@ -264,21 +269,19 @@ export default function SleepDashboard() {
     if (!raw) return [];
     const data = [...raw].reverse();
     const slice = data.slice(-7);
-    const fallbackNeed =
-      coachData?.recommendedDurationMinutes ?? 480; // 8h default
+    const fallbackNeed = coachData?.recommendedDurationMinutes ?? 480; // 8h default
     return slice.map((d) => {
       const need = d.sleepNeedMinutes ?? fallbackNeed;
       const actual = d.totalSleepMinutes;
-      const computed =
-        actual != null ? Math.max(0, need - actual) : 0;
+      const computed = actual != null ? Math.max(0, need - actual) : 0;
       const debt = d.sleepDebt ?? computed;
       return {
-        date: fmtDateShort(d.date, slice.length),
+        date: fmtDateShort(d.date, slice.length, timezone),
         debt,
         color: debtColor(debt),
       };
     });
-  }, [history.data, coachData?.recommendedDurationMinutes]);
+  }, [history.data, coachData?.recommendedDurationMinutes, timezone]);
 
   // ---- Derived: Sleep timing range chart ----
   const timingChartData = useMemo(() => {
@@ -298,7 +301,7 @@ export default function SleepDashboard() {
       let start = d.sleepStartTime;
       if (start != null && start < 720) start += 1440;
       return {
-        date: fmtDateShort(d.date, slice.length),
+        date: fmtDateShort(d.date, slice.length, timezone),
         bedtime: start ?? null,
         wakeTime: d.sleepEndTime ?? null,
         range:
@@ -307,7 +310,7 @@ export default function SleepDashboard() {
             : [null, null],
       };
     });
-  }, [history.data]);
+  }, [history.data, timezone]);
 
   // ---------------------------------------------------------------------------
   return (
@@ -316,7 +319,7 @@ export default function SleepDashboard() {
       {/* Header: Sleep Coach Recommendation                                 */}
       {/* ================================================================== */}
       <div>
-        <h1 className="text-2xl font-bold pl-12">Sleep Dashboard</h1>
+        <h1 className="pl-12 text-2xl font-bold">Sleep Dashboard</h1>
         <p className="text-muted-foreground text-sm">
           Your sleep insights &amp; coaching
         </p>

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@acme/ui";
 
 import { IngressLink as Link } from "~/app/_components/ingress-link";
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 import { SectionHeader } from "../_components/info-button";
@@ -68,9 +69,7 @@ const METRIC_LABELS: Record<string, string> = {
 
 function prettyMetric(key: string): string {
   if (METRIC_LABELS[key]) return METRIC_LABELS[key];
-  return key
-    .replace(/[_-]+/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+  return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 type TrendMetric =
@@ -110,9 +109,8 @@ function correlationPeriod(p: Period): CorrelationPeriod {
   return "30d";
 }
 
-function formatDate(iso: string): string {
-  const d = new Date(iso + "T00:00:00");
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+function formatDate(iso: string, timezone: string): string {
+  return formatDateInTz(iso, timezone, { month: "short", day: "numeric" });
 }
 
 function formatSleep(minutes: number | null | undefined): string {
@@ -148,6 +146,7 @@ export default function TrendsPage() {
   const [period, setPeriod] = useState<Period>("28d");
   const days = daysFor(period);
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
   const useSmoothed = days > 90;
 
   // ---- Summary stats ----
@@ -255,7 +254,7 @@ export default function TrendsPage() {
 
       return dates.map((date) => ({
         date,
-        label: formatDate(date),
+        label: formatDate(date, timezone),
         readiness: readMap.get(date) ?? null,
         sleep: sleepMap.get(date) ?? null,
         hrv: hrvMap.get(date) ?? null,
@@ -282,12 +281,13 @@ export default function TrendsPage() {
 
     return dates.map((date) => ({
       date,
-      label: formatDate(date),
+      label: formatDate(date, timezone),
       readiness: maps.readiness?.get(date) ?? null,
       sleep: maps.sleep?.get(date) ?? null,
       hrv: maps.hrv?.get(date) ?? null,
     }));
   }, [
+    timezone,
     useSmoothed,
     multiChart.data,
     rollingReadiness.data,
@@ -316,7 +316,7 @@ export default function TrendsPage() {
     <main className="mx-auto max-w-4xl space-y-6 px-4 pt-6 pb-24">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold pl-12">Trends &amp; Analytics</h1>
+        <h1 className="pl-12 text-2xl font-bold">Trends &amp; Analytics</h1>
         <p className="text-muted-foreground text-sm">
           {PERIODS.find((x) => x.value === period)?.label ?? period} overview
           {useSmoothed ? " · 7-day rolling avg" : ""}
@@ -646,7 +646,7 @@ export default function TrendsPage() {
                 className="bg-card flex items-start gap-3 rounded-xl border p-3"
               >
                 <div className="text-muted-foreground mt-0.5 shrink-0 text-xs font-medium">
-                  {formatDate(nc.date)}
+                  {formatDate(nc.date, timezone)}
                 </div>
                 <div className="flex-1">
                   <p className="text-sm">{nc.description}</p>
@@ -701,8 +701,7 @@ export default function TrendsPage() {
                 >
                   <div className="flex items-center justify-between">
                     <p className="text-sm font-medium">
-                      {prettyMetric(c.metricA)} →{" "}
-                      {prettyMetric(c.metricB)}
+                      {prettyMetric(c.metricA)} → {prettyMetric(c.metricB)}
                     </p>
                     <span
                       className={cn(

--- a/apps/nextjs/src/app/vitals/page.tsx
+++ b/apps/nextjs/src/app/vitals/page.tsx
@@ -16,6 +16,7 @@ import {
 
 import { cn } from "@acme/ui";
 
+import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { BottomNav } from "../_components/bottom-nav";
 import { DateRangeSelector } from "../_components/date-range-selector";
@@ -116,8 +117,8 @@ const TEMP_STATUS: Record<
 
 /* ─────────────── helpers ─────────────── */
 
-function formatDate(d: string) {
-  return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+function formatDate(d: string, timezone: string) {
+  return formatDateInTz(d, timezone, {
     month: "short",
     day: "numeric",
   });
@@ -155,6 +156,7 @@ function StatCard({
 export default function VitalsPage() {
   const [days, setDays] = useState(30);
   const trpc = useTRPC();
+  const timezone = useUserTimezone();
 
   const { data, isLoading } = useQuery(
     trpc.vitals.getTrends.queryOptions({ days }),
@@ -266,7 +268,9 @@ export default function VitalsPage() {
                       />
                       <XAxis
                         dataKey="date"
-                        tickFormatter={formatDate}
+                        tickFormatter={(value) =>
+                          formatDate(String(value), timezone)
+                        }
                         tick={{ fill: "#888", fontSize: 10 }}
                         axisLine={false}
                       />
@@ -278,7 +282,7 @@ export default function VitalsPage() {
                       />
                       <Tooltip
                         labelFormatter={(label: unknown) =>
-                          formatDate(String(label))
+                          formatDate(String(label), timezone)
                         }
                         formatter={(v: unknown) => [`${Number(v)}%`, ""]}
                         contentStyle={{
@@ -412,7 +416,9 @@ export default function VitalsPage() {
                       />
                       <XAxis
                         dataKey="date"
-                        tickFormatter={formatDate}
+                        tickFormatter={(value) =>
+                          formatDate(String(value), timezone)
+                        }
                         tick={{ fill: "#888", fontSize: 10 }}
                         axisLine={false}
                       />
@@ -423,7 +429,7 @@ export default function VitalsPage() {
                       />
                       <Tooltip
                         labelFormatter={(label: unknown) =>
-                          formatDate(String(label))
+                          formatDate(String(label), timezone)
                         }
                         formatter={(v: unknown) => [`${Number(v)} brpm`, ""]}
                         contentStyle={{
@@ -554,7 +560,9 @@ export default function VitalsPage() {
                       />
                       <XAxis
                         dataKey="date"
-                        tickFormatter={formatDate}
+                        tickFormatter={(value) =>
+                          formatDate(String(value), timezone)
+                        }
                         tick={{ fill: "#888", fontSize: 10 }}
                         axisLine={false}
                       />
@@ -565,7 +573,7 @@ export default function VitalsPage() {
                       />
                       <Tooltip
                         labelFormatter={(label: unknown) =>
-                          formatDate(String(label))
+                          formatDate(String(label), timezone)
                         }
                         formatter={(v: unknown) => [`${Number(v)}°C`, ""]}
                         contentStyle={{

--- a/apps/nextjs/src/lib/__tests__/format-date.test.ts
+++ b/apps/nextjs/src/lib/__tests__/format-date.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression tests for `format-date.ts`.
+ *
+ * The fix in PR #119 routed all last-sync / activity timestamps through
+ * these helpers so plain `YYYY-MM-DD` strings no longer fall off-by-one
+ * day for users east of UTC. The bug was that `new Date("2026-05-14")`
+ * yields midnight UTC, which is the previous day's evening in Australia,
+ * so the formatter (with `timeZone: "Australia/Brisbane"`) displayed
+ * "Wed, May 13" for what the user knew as "May 14".
+ *
+ * Normalising bare dates to noon-UTC (`2026-05-14T12:00:00.000Z`) keeps
+ * the wall-clock date stable for every IANA zone between UTC-11 and
+ * UTC+13, which covers every populated timezone.
+ */
+
+// `format-date.ts` imports `~/trpc/react` at module scope (for the
+// `useUserTimezone` hook) which transitively loads superjson (ESM-only).
+// Stub the trpc surface so the pure formatters can be evaluated under
+// the CJS jest runtime.
+jest.mock("~/trpc/react", () => ({ useTRPC: () => ({}) }));
+
+import { formatDateInTz, formatTimeInTz } from "../format-date";
+
+describe("formatDateInTz", () => {
+  it.each<[string, string, string]>([
+    ["Australia/Brisbane", "2026-05-14", "Thu, May 14"],
+    ["America/Los_Angeles", "2026-05-14", "Thu, May 14"],
+    ["Asia/Tokyo", "2026-05-14", "Thu, May 14"],
+    ["UTC", "2026-05-14", "Thu, May 14"],
+  ])(
+    "renders %s wall-clock date for plain %s string",
+    (timezone, input, expected) => {
+      expect(formatDateInTz(input, timezone)).toBe(expected);
+    },
+  );
+
+  it("still formats full ISO timestamps in the requested zone", () => {
+    // 23:30 UTC on May 14 = 09:30 May 15 in Brisbane (UTC+10, no DST).
+    const out = formatDateInTz("2026-05-14T23:30:00.000Z", "Australia/Brisbane");
+    expect(out).toBe("Fri, May 15");
+  });
+
+  it("returns em-dash for null / undefined / invalid", () => {
+    expect(formatDateInTz(null, "UTC")).toBe("—");
+    expect(formatDateInTz(undefined, "UTC")).toBe("—");
+    expect(formatDateInTz("not-a-date", "UTC")).toBe("—");
+  });
+
+  it("accepts Date instances and numeric epochs", () => {
+    expect(formatDateInTz(new Date("2026-05-14T12:00:00Z"), "UTC")).toBe(
+      "Thu, May 14",
+    );
+    const epoch = Date.UTC(2026, 4, 14, 12, 0, 0);
+    expect(formatDateInTz(epoch, "UTC")).toBe("Thu, May 14");
+  });
+});
+
+describe("formatTimeInTz", () => {
+  it("formats UTC timestamps in the configured zone", () => {
+    // 12:00 UTC = 22:00 in Brisbane.
+    const out = formatTimeInTz(
+      "2026-05-14T12:00:00.000Z",
+      "Australia/Brisbane",
+    );
+    expect(out).toMatch(/10:00\s?PM/);
+  });
+
+  it("returns em-dash for nullish values", () => {
+    expect(formatTimeInTz(null, "UTC")).toBe("—");
+    expect(formatTimeInTz(undefined, "UTC")).toBe("—");
+  });
+});

--- a/apps/nextjs/src/lib/__tests__/format-date.test.ts
+++ b/apps/nextjs/src/lib/__tests__/format-date.test.ts
@@ -1,3 +1,5 @@
+import { formatDateInTz, formatTimeInTz } from "../format-date";
+
 // SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,8 +24,6 @@
 // the CJS jest runtime.
 jest.mock("~/trpc/react", () => ({ useTRPC: () => ({}) }));
 
-import { formatDateInTz, formatTimeInTz } from "../format-date";
-
 describe("formatDateInTz", () => {
   it.each<[string, string, string]>([
     ["Australia/Brisbane", "2026-05-14", "Thu, May 14"],
@@ -39,7 +39,10 @@ describe("formatDateInTz", () => {
 
   it("still formats full ISO timestamps in the requested zone", () => {
     // 23:30 UTC on May 14 = 09:30 May 15 in Brisbane (UTC+10, no DST).
-    const out = formatDateInTz("2026-05-14T23:30:00.000Z", "Australia/Brisbane");
+    const out = formatDateInTz(
+      "2026-05-14T23:30:00.000Z",
+      "Australia/Brisbane",
+    );
     expect(out).toBe("Fri, May 15");
   });
 

--- a/apps/nextjs/src/lib/format-date.ts
+++ b/apps/nextjs/src/lib/format-date.ts
@@ -32,7 +32,11 @@ export function useUserTimezone(): string {
 }
 
 function toDate(value: Date | string | number): Date | null {
-  const d = value instanceof Date ? value : new Date(value);
+  const normalized =
+    typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
+      ? `${value}T12:00:00.000Z`
+      : value;
+  const d = normalized instanceof Date ? normalized : new Date(normalized);
   return Number.isNaN(d.getTime()) ? null : d;
 }
 

--- a/apps/nextjs/src/lib/format-date.ts
+++ b/apps/nextjs/src/lib/format-date.ts
@@ -31,12 +31,30 @@ export function useUserTimezone(): string {
   return "UTC";
 }
 
-function toDate(value: Date | string | number): Date | null {
-  const normalized =
-    typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
-      ? `${value}T12:00:00.000Z`
-      : value;
-  const d = normalized instanceof Date ? normalized : new Date(normalized);
+function toDate(value: Date | string | number, timezone?: string): Date | null {
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    // Anchoring a bare YYYY-MM-DD at noon UTC breaks at IANA zones whose
+    // offset from UTC is >12h (e.g. Pacific/Kiritimati at UTC+14, or some
+    // historical zones at UTC-12+DST). When a target timezone is supplied,
+    // probe both 12:00 UTC and 00:00 UTC and pick the one whose calendar
+    // day in `timezone` matches the requested Y-M-D.
+    const noonUtc = new Date(`${value}T12:00:00.000Z`);
+    if (!timezone) return noonUtc;
+    const dayInTz = (d: Date) =>
+      new Intl.DateTimeFormat("en-CA", {
+        timeZone: timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(d);
+    if (dayInTz(noonUtc) === value) return noonUtc;
+    const midnightUtc = new Date(`${value}T00:00:00.000Z`);
+    if (dayInTz(midnightUtc) === value) return midnightUtc;
+    const lateUtc = new Date(`${value}T23:00:00.000Z`);
+    if (dayInTz(lateUtc) === value) return lateUtc;
+    return noonUtc;
+  }
+  const d = value instanceof Date ? value : new Date(value);
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
@@ -54,7 +72,7 @@ export function formatDateInTz(
   },
 ): string {
   if (value == null) return "—";
-  const d = toDate(value);
+  const d = toDate(value, timezone);
   if (!d) return "—";
   return new Intl.DateTimeFormat("en-US", {
     ...options,
@@ -74,7 +92,7 @@ export function formatTimeInTz(
   },
 ): string {
   if (value == null) return "—";
-  const d = toDate(value);
+  const d = toDate(value, timezone);
   if (!d) return "—";
   return new Intl.DateTimeFormat("en-US", {
     ...options,


### PR DESCRIPTION
## Summary
- route rendered dates/times and freshness titles through user timezone helpers
- add safe-area padding, 48px tap targets, and sub-380px label hiding to mobile bottom nav
- increase home bottom padding and coach input safe-area spacing

## Verification
- pnpm typecheck
- pre-commit run --files <modified files>

Closes screenshot QA findings P1-2, P1-3, P1-4, P2-7, P2-9.