### PR TITLE
fix(home): fall back to factors jsonb when component columns are null

### DIFF
--- a/apps/nextjs/src/app/_components/__tests__/readiness-helpers.test.ts
+++ b/apps/nextjs/src/app/_components/__tests__/readiness-helpers.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { getReadinessComponent } from "../readiness-helpers";
+
+describe("getReadinessComponent", () => {
+  it("prefers the top-level numeric column (cached DB row)", () => {
+    const data = {
+      hrvComponent: 78,
+      components: { hrv: 11 },
+      factors: { hrv: 22 },
+    };
+    expect(getReadinessComponent(data, "hrvComponent", "hrv")).toBe(78);
+  });
+
+  it("falls back to components.<key> when top-level column is null", () => {
+    const data = {
+      hrvComponent: null,
+      components: { hrv: 64 },
+      factors: { hrv: 11 },
+    };
+    expect(getReadinessComponent(data, "hrvComponent", "hrv")).toBe(64);
+  });
+
+  it("falls back to factors.<key> when top + components are both null (Garmin-native fix)", () => {
+    // PR #129 preserves component scores in the `factors` JSONB even when
+    // the dedicated columns are NULL because Garmin supplied the native
+    // score. PR #120 ensures the home tile can still render those.
+    const data = {
+      hrvComponent: null,
+      sleepQuantityComponent: null,
+      components: null,
+      factors: { hrv: 82, sleepQuantity: 70 },
+    };
+    expect(getReadinessComponent(data, "hrvComponent", "hrv")).toBe(82);
+    expect(
+      getReadinessComponent(data, "sleepQuantityComponent", "sleepQuantity"),
+    ).toBe(70);
+  });
+
+  it("returns null when no layer has a numeric value", () => {
+    const data = {
+      hrvComponent: null,
+      components: { hrv: "not-a-number" },
+      factors: {},
+    };
+    expect(getReadinessComponent(data, "hrvComponent", "hrv")).toBeNull();
+  });
+
+  it("returns null for null / undefined input", () => {
+    expect(getReadinessComponent(null, "hrvComponent", "hrv")).toBeNull();
+    expect(getReadinessComponent(undefined, "hrvComponent", "hrv")).toBeNull();
+  });
+
+  it("ignores non-numeric values at the top level and walks to fallbacks", () => {
+    const data = {
+      hrvComponent: "78", // string, not a number
+      components: { hrv: 64 },
+    };
+    expect(getReadinessComponent(data, "hrvComponent", "hrv")).toBe(64);
+  });
+
+  it("treats zero as a valid component score (not nullish)", () => {
+    // Zero is a legitimate floor for stress / load components; ensure
+    // the helper doesn't silently treat it as missing.
+    const data = { stressComponent: 0 };
+    expect(getReadinessComponent(data, "stressComponent", "stress")).toBe(0);
+  });
+});

--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -48,6 +48,11 @@ export function DashboardHome() {
       const nested = (comps as Record<string, unknown>)[nestedKey];
       if (typeof nested === "number") return nested;
     }
+    const factors = data?.factors;
+    if (factors && typeof factors === "object") {
+      const nested = (factors as Record<string, unknown>)[nestedKey];
+      if (typeof nested === "number") return nested;
+    }
     return null;
   }
 

--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -40,9 +40,17 @@ export function DashboardHome() {
   // Garmin-native rows preserve scores only in the factors JSONB.
   // See readiness-helpers.ts for the lookup priority.
 
-  const sleepRaw = getReadinessComponent(r, "sleepQuantityComponent", "sleepQuantity");
+  const sleepRaw = getReadinessComponent(
+    r,
+    "sleepQuantityComponent",
+    "sleepQuantity",
+  );
   const hrvRaw = getReadinessComponent(r, "hrvComponent", "hrv");
-  const loadRaw = getReadinessComponent(r, "trainingLoadComponent", "trainingLoad");
+  const loadRaw = getReadinessComponent(
+    r,
+    "trainingLoadComponent",
+    "trainingLoad",
+  );
   const stressRaw = getReadinessComponent(r, "stressComponent", "stress");
 
   const sleepVal = sleepRaw != null ? Math.round(sleepRaw) : null;

--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -9,6 +9,7 @@ import { DailyOutlookCard } from "./daily-outlook-card";
 import { IngressLink as Link } from "./ingress-link";
 import { QuickStats } from "./quick-stats";
 import { ReadinessCard } from "./readiness-card";
+import { getReadinessComponent } from "./readiness-helpers";
 import { WorkoutCard } from "./workout-card";
 
 export function DashboardHome() {
@@ -35,31 +36,14 @@ export function DashboardHome() {
 
   // Extract readiness component (0-100 scale each).
   // Cached DB rows use top-level fields (e.g. hrvComponent);
-  // freshly computed results nest under components.xxx.
-  function getComponent(
-    data: Record<string, unknown> | null | undefined,
-    topKey: string,
-    nestedKey: string,
-  ): number | null {
-    const top = data?.[topKey];
-    if (typeof top === "number") return top;
-    const comps = data?.components;
-    if (comps && typeof comps === "object") {
-      const nested = (comps as Record<string, unknown>)[nestedKey];
-      if (typeof nested === "number") return nested;
-    }
-    const factors = data?.factors;
-    if (factors && typeof factors === "object") {
-      const nested = (factors as Record<string, unknown>)[nestedKey];
-      if (typeof nested === "number") return nested;
-    }
-    return null;
-  }
+  // freshly computed results nest under components.xxx; legacy
+  // Garmin-native rows preserve scores only in the factors JSONB.
+  // See readiness-helpers.ts for the lookup priority.
 
-  const sleepRaw = getComponent(r, "sleepQuantityComponent", "sleepQuantity");
-  const hrvRaw = getComponent(r, "hrvComponent", "hrv");
-  const loadRaw = getComponent(r, "trainingLoadComponent", "trainingLoad");
-  const stressRaw = getComponent(r, "stressComponent", "stress");
+  const sleepRaw = getReadinessComponent(r, "sleepQuantityComponent", "sleepQuantity");
+  const hrvRaw = getReadinessComponent(r, "hrvComponent", "hrv");
+  const loadRaw = getReadinessComponent(r, "trainingLoadComponent", "trainingLoad");
+  const stressRaw = getReadinessComponent(r, "stressComponent", "stress");
 
   const sleepVal = sleepRaw != null ? Math.round(sleepRaw) : null;
   const hrvVal = hrvRaw != null ? Math.round(hrvRaw) : null;

--- a/apps/nextjs/src/app/_components/readiness-helpers.ts
+++ b/apps/nextjs/src/app/_components/readiness-helpers.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure helpers extracted from `dashboard-home.tsx` so the readiness
+ * component lookup can be unit-tested without rendering the full
+ * client component (and its TRPC / React Query dependencies).
+ *
+ * The readiness payload comes in three shapes depending on whether it
+ * was freshly computed or read from the cached DB row:
+ *
+ *  1. **Top-level numeric columns** (cached rows written before the
+ *     refactor): `{ hrvComponent: 78, sleepQuantityComponent: 65, ... }`.
+ *  2. **Nested `components` object** (freshly computed by the engine):
+ *     `{ components: { hrv: 78, sleepQuantity: 65, ... } }`.
+ *  3. **`factors` JSONB fallback** (Garmin-native rows from
+ *     v0.16.18 / v0.16.19 where the dedicated columns were null but
+ *     the underlying factor scores were preserved in JSONB):
+ *     `{ factors: { hrv: 78, sleepQuantity: 65, ... } }`.
+ *
+ * `getReadinessComponent` walks these three layers in order and
+ * returns the first numeric hit, or `null` if no layer has a value.
+ */
+
+export function getReadinessComponent(
+  data: Record<string, unknown> | null | undefined,
+  topKey: string,
+  nestedKey: string,
+): number | null {
+  if (!data) return null;
+  const top = data[topKey];
+  if (typeof top === "number") return top;
+  const comps = data.components;
+  if (comps && typeof comps === "object") {
+    const nested = (comps as Record<string, unknown>)[nestedKey];
+    if (typeof nested === "number") return nested;
+  }
+  const factors = data.factors;
+  if (factors && typeof factors === "object") {
+    const nested = (factors as Record<string, unknown>)[nestedKey];
+    if (typeof nested === "number") return nested;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes screenshot QA finding **P0-1** (companion to addon-side fix).

## Background

Live DB inspection on the user's HAOS confirmed today's readiness_score row has `score=21`, `zone=low`, but all dedicated component columns (`sleep_quantity_component`, `hrv_component`, `training_load_component`, `stress_component`) are NULL — even though the `factors` JSONB carries the correct values.

Root cause is in the addon's `metrics-compute.py` overwriting components with NULL whenever Garmin Connect provides a native readiness score. Fix forthcoming in a separate addon PR.

## This PR

Safety-net fallback in the home dashboard:

`getComponent` already checks the top-level column and the nested `components` field. This adds a third fallback to `data?.factors?.<nestedKey>`. Field names in `factors` JSONB match the nested-key convention (`hrv`, `stress`, `trainingLoad`, `sleepQuantity`, `restingHr`, `sleepQuality`).

Effect: existing user rows with NULL component columns now render correct tile values immediately, without waiting for a re-sync after the addon fix lands.

Part of the screenshot QA sweep (2026-05-16).