### PR TITLE
feat(vitals): add rhr, body battery, stress, body composition cards

### DIFF
--- a/apps/nextjs/src/app/vitals/page.tsx
+++ b/apps/nextjs/src/app/vitals/page.tsx
@@ -24,10 +24,12 @@ import { IngressLink as Link } from "../_components/ingress-link";
 
 /* ─────────────── status config ─────────────── */
 
-const SPO2_STATUS: Record<
+type StatusConfig = Record<
   string,
   { icon: string; label: string; cls: string; desc: string }
-> = {
+>;
+
+const SPO2_STATUS: StatusConfig = {
   normal: {
     icon: "✅",
     label: "Normal",
@@ -54,10 +56,7 @@ const SPO2_STATUS: Record<
   },
 };
 
-const RR_STATUS: Record<
-  string,
-  { icon: string; label: string; cls: string; desc: string }
-> = {
+const RR_STATUS: StatusConfig = {
   normal: {
     icon: "✅",
     label: "Normal",
@@ -68,13 +67,13 @@ const RR_STATUS: Record<
     icon: "⚠️",
     label: "Elevated",
     cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
-    desc: "Respiration rate is 1-3 brpm above baseline. May indicate stress or early illness.",
+    desc: "Respiration rate is 3-7% above baseline. May indicate stress or early illness.",
   },
   high: {
     icon: "🔴",
     label: "High",
     cls: "bg-red-500/20 text-red-400 border-red-500/30",
-    desc: "Respiration rate is >3 brpm above baseline. Strong illness/overreaching signal.",
+    desc: "Respiration rate is >7% above baseline. Strong illness/overreaching signal.",
   },
   no_data: {
     icon: "📊",
@@ -84,10 +83,7 @@ const RR_STATUS: Record<
   },
 };
 
-const TEMP_STATUS: Record<
-  string,
-  { icon: string; label: string; cls: string; desc: string }
-> = {
+const TEMP_STATUS: StatusConfig = {
   normal: {
     icon: "✅",
     label: "Normal",
@@ -114,7 +110,104 @@ const TEMP_STATUS: Record<
   },
 };
 
+const RHR_STATUS: StatusConfig = {
+  normal: {
+    icon: "✅",
+    label: "Normal",
+    cls: "bg-green-500/20 text-green-400 border-green-500/30",
+    desc: "Resting heart rate is at or below your 30-day baseline.",
+  },
+  elevated: {
+    icon: "⚠️",
+    label: "Elevated",
+    cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+    desc: "RHR is 3-7% above baseline. Watch recovery and illness signals.",
+  },
+  high: {
+    icon: "🔴",
+    label: "High",
+    cls: "bg-red-500/20 text-red-400 border-red-500/30",
+    desc: "RHR is >7% above baseline. Consider rest or easy training.",
+  },
+  no_data: {
+    icon: "📊",
+    label: "No Data",
+    cls: "bg-zinc-500/20 text-zinc-400 border-zinc-500/30",
+    desc: "No resting heart rate data available yet.",
+  },
+};
+
+const BODY_BATTERY_STATUS: StatusConfig = {
+  normal: {
+    icon: "✅",
+    label: "Charged",
+    cls: "bg-green-500/20 text-green-400 border-green-500/30",
+    desc: "Daily Body Battery peak is near or above your 30-day baseline.",
+  },
+  low: {
+    icon: "⚠️",
+    label: "Low",
+    cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+    desc: "Daily peak is 3-7% below baseline. Recovery may be lagging.",
+  },
+  depleted: {
+    icon: "🔴",
+    label: "Depleted",
+    cls: "bg-red-500/20 text-red-400 border-red-500/30",
+    desc: "Daily peak is >7% below baseline. Prioritize recovery.",
+  },
+  no_data: {
+    icon: "📊",
+    label: "No Data",
+    cls: "bg-zinc-500/20 text-zinc-400 border-zinc-500/30",
+    desc: "No Body Battery data available yet.",
+  },
+};
+
+const STRESS_STATUS: StatusConfig = {
+  normal: {
+    icon: "✅",
+    label: "Low",
+    cls: "bg-green-500/20 text-green-400 border-green-500/30",
+    desc: "Stress score is at or below your 30-day baseline.",
+  },
+  elevated: {
+    icon: "⚠️",
+    label: "Elevated",
+    cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+    desc: "Stress is 3-7% above baseline. Recovery load is rising.",
+  },
+  high: {
+    icon: "🔴",
+    label: "High",
+    cls: "bg-red-500/20 text-red-400 border-red-500/30",
+    desc: "Stress is >7% above baseline. Consider reducing training load.",
+  },
+  no_data: {
+    icon: "📊",
+    label: "No Data",
+    cls: "bg-zinc-500/20 text-zinc-400 border-zinc-500/30",
+    desc: "No stress score data available yet.",
+  },
+};
+
 /* ─────────────── helpers ─────────────── */
+
+type TrendPoint = { date: string; value: number };
+type VitalMetric = {
+  daily: TrendPoint[];
+  rolling7d: TrendPoint[];
+  baseline: number | null;
+  latest: number | null;
+  status: string;
+  deviation: number | null;
+  daysWithData: number;
+  baselineDays: number;
+};
+
+type Preference = "higher" | "lower";
+
+const COMPACT_UNITS = new Set(["%", "°C"]);
 
 function formatDate(d: string) {
   return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
@@ -123,30 +216,261 @@ function formatDate(d: string) {
   });
 }
 
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function formatNumber(value: number): string {
+  const rounded = round1(value);
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function formatWithUnit(value: number, unit?: string): string {
+  const formatted = formatNumber(value);
+  if (!unit) return formatted;
+  return COMPACT_UNITS.has(unit)
+    ? `${formatted}${unit}`
+    : `${formatted} ${unit}`;
+}
+
+function formatDeviation(
+  value: number | null,
+  unit: "%" | "°C",
+): string | null {
+  if (value === null) return null;
+  const prefix = value > 0 ? "+" : "";
+  return `${prefix}${formatNumber(value)}${unit}`;
+}
+
+function deviationClass(
+  deviation: number | null,
+  preference: Preference | null,
+): string | undefined {
+  if (deviation === null || preference === null) return undefined;
+
+  if (preference === "higher") {
+    if (deviation < -7) return "text-red-400";
+    if (deviation < -3) return "text-yellow-400";
+    if (deviation > 3) return "text-green-400";
+    return undefined;
+  }
+
+  if (deviation > 7) return "text-red-400";
+  if (deviation > 3) return "text-yellow-400";
+  if (deviation < -3) return "text-green-400";
+  return undefined;
+}
+
+function baselineSubtext(metric: VitalMetric): string | undefined {
+  if (metric.baseline !== null || metric.baselineDays >= 30) return undefined;
+  return `Baseline still warming up (${metric.baselineDays} days)`;
+}
+
+function Unit({ unit, className }: { unit: string; className: string }) {
+  return <span className={className}>{unit}</span>;
+}
+
 function StatCard({
   label,
   value,
   unit,
   subtext,
+  valueClassName,
 }: {
   label: string;
   value: string | number | null;
   unit?: string;
   subtext?: string;
+  valueClassName?: string;
 }) {
+  const isCompactUnit = Boolean(unit && COMPACT_UNITS.has(unit));
+  const displayValue =
+    isCompactUnit && value !== null ? `${value}${unit}` : (value ?? "—");
+
   return (
     <div className="bg-card rounded-lg border p-3">
       <p className="text-muted-foreground text-[11px]">{label}</p>
-      <p className="text-foreground text-lg font-bold">
-        {value ?? "—"}
-        {unit && value !== null && (
-          <span className="text-muted-foreground ml-0.5 text-xs">{unit}</span>
+      <p className={cn("text-foreground text-lg font-bold", valueClassName)}>
+        {displayValue}
+        {unit && !isCompactUnit && value !== null && (
+          <Unit unit={unit} className="text-muted-foreground ml-1 text-xs" />
         )}
       </p>
       {subtext && (
         <p className="text-muted-foreground text-[10px]">{subtext}</p>
       )}
     </div>
+  );
+}
+
+function VitalMetricSection({
+  title,
+  info,
+  metric,
+  statusConfig,
+  unit,
+  color,
+  chartName,
+  emptyMessage,
+  preference,
+  latestLabel = "Latest",
+  deviationUnit = "%",
+  yDomain,
+  referenceLines = [],
+}: {
+  title: string;
+  info: string;
+  metric: VitalMetric | undefined;
+  statusConfig: StatusConfig;
+  unit?: string;
+  color: string;
+  chartName: string;
+  emptyMessage: string;
+  preference: Preference | null;
+  latestLabel?: string;
+  deviationUnit?: "%" | "°C";
+  yDomain?: [number, number];
+  referenceLines?: { y: number; label: string; color: string }[];
+}) {
+  const status = metric ? statusConfig[metric.status] : undefined;
+
+  return (
+    <section className="space-y-3">
+      <SectionHeader title={title} info={info} />
+
+      {metric && status && (
+        <div
+          className={cn(
+            "flex items-center gap-2 rounded-lg border px-3 py-2",
+            status.cls,
+          )}
+        >
+          <span className="text-lg">{status.icon}</span>
+          <div>
+            <p className="text-sm font-semibold">{status.label}</p>
+            <p className="text-[11px] opacity-80">{status.desc}</p>
+          </div>
+        </div>
+      )}
+
+      {metric && (
+        <div className="grid grid-cols-3 gap-2">
+          <StatCard
+            label={latestLabel}
+            value={metric.latest != null ? formatNumber(metric.latest) : null}
+            unit={unit}
+          />
+          <StatCard
+            label="Baseline"
+            value={
+              metric.baseline != null ? formatNumber(metric.baseline) : null
+            }
+            unit={unit}
+            subtext={baselineSubtext(metric)}
+          />
+          <StatCard
+            label="Deviation"
+            value={formatDeviation(metric.deviation, deviationUnit)}
+            valueClassName={deviationClass(metric.deviation, preference)}
+          />
+        </div>
+      )}
+
+      {metric && metric.daily.length > 0 ? (
+        <div className="bg-card rounded-lg border p-3">
+          <ResponsiveContainer width="100%" height={180}>
+            <ComposedChart
+              data={metric.daily.map((d, i) => ({
+                date: d.date,
+                value: round1(d.value),
+                avg: metric.rolling7d[i]?.value,
+              }))}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#333"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="date"
+                tickFormatter={formatDate}
+                tick={{ fill: "#888", fontSize: 10 }}
+                axisLine={false}
+              />
+              <YAxis
+                domain={yDomain}
+                tick={{ fill: "#888", fontSize: 10 }}
+                axisLine={false}
+                width={35}
+              />
+              <Tooltip
+                labelFormatter={(label: unknown) => formatDate(String(label))}
+                formatter={(v: unknown) => [
+                  formatWithUnit(Number(v), unit),
+                  "",
+                ]}
+                contentStyle={{
+                  background: "#1a1a2e",
+                  border: "1px solid #333",
+                  borderRadius: 8,
+                  fontSize: 12,
+                }}
+              />
+              {metric.baseline !== null && (
+                <ReferenceLine
+                  y={metric.baseline}
+                  stroke="#666"
+                  strokeDasharray="4 4"
+                  label={{
+                    value: "baseline",
+                    fill: "#666",
+                    fontSize: 10,
+                    position: "insideTopRight",
+                  }}
+                />
+              )}
+              {referenceLines.map((line) => (
+                <ReferenceLine
+                  key={`${line.y}-${line.label}`}
+                  y={line.y}
+                  stroke={line.color}
+                  strokeDasharray="2 2"
+                  label={{ value: line.label, fill: line.color, fontSize: 10 }}
+                />
+              ))}
+              <Area
+                dataKey="value"
+                fill={color}
+                fillOpacity={0.15}
+                stroke="none"
+              />
+              <Line
+                dataKey="value"
+                stroke={color}
+                strokeWidth={1.5}
+                dot={{ r: 2, fill: color }}
+                name={chartName}
+              />
+              <Line
+                dataKey="avg"
+                stroke="#f59e0b"
+                strokeWidth={2}
+                strokeDasharray="4 2"
+                dot={false}
+                name="7d Avg"
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+          <p className="text-muted-foreground mt-1 text-center text-[10px]">
+            {metric.daysWithData} days with data · 7d rolling avg in amber
+          </p>
+        </div>
+      ) : (
+        <p className="text-muted-foreground py-4 text-center text-xs">
+          {emptyMessage}
+        </p>
+      )}
+    </section>
   );
 }
 
@@ -160,10 +484,6 @@ export default function VitalsPage() {
     trpc.vitals.getTrends.queryOptions({ days }),
   );
 
-  const spo2 = data?.spo2;
-  const rr = data?.respirationRate;
-  const skinTemp = data?.skinTemp;
-
   return (
     <main className="bg-background text-foreground min-h-screen pb-24">
       <div className="mx-auto max-w-md space-y-6 px-4 pt-6">
@@ -172,8 +492,9 @@ export default function VitalsPage() {
           <div>
             <h1 className="text-xl font-bold">🫁 Vitals</h1>
             <p className="text-muted-foreground text-xs">
-              Blood oxygen, respiration, and skin temperature — key recovery
-              biomarkers used by WHOOP, Oura, and sports science research.
+              Blood oxygen, respiration, temperature, heart rate, Body Battery,
+              stress, and body composition — key recovery biomarkers from
+              Garmin.
             </p>
           </div>
           <Link
@@ -203,426 +524,97 @@ export default function VitalsPage() {
 
         {!isLoading && data && (
           <>
-            {/* ────── SpO2 Section ────── */}
+            <VitalMetricSection
+              title="Blood Oxygen (SpO2)"
+              info="Pulse oximeter reading from your Garmin. Normal range is 95-100%. Drops below baseline may indicate altitude exposure, illness onset, sleep apnea, or overtraining. Each 1% below your baseline reduces readiness by ~20 points."
+              metric={data.spo2}
+              statusConfig={SPO2_STATUS}
+              unit="%"
+              color="#3b82f6"
+              chartName="SpO2"
+              emptyMessage="No SpO2 data in this period. Ensure pulse ox is enabled on your Garmin."
+              preference="higher"
+              yDomain={[88, 100]}
+              referenceLines={[{ y: 95, label: "95%", color: "#ef4444" }]}
+            />
+
+            <VitalMetricSection
+              title="Resting Heart Rate"
+              info="Lowest resting heart rate measured by Garmin. Lower values versus your 30-day baseline generally indicate better recovery; sustained elevation can signal fatigue, heat stress, alcohol, or early illness."
+              metric={data.restingHr}
+              statusConfig={RHR_STATUS}
+              unit="bpm"
+              color="#f97316"
+              chartName="RHR"
+              emptyMessage="No resting heart rate data in this period."
+              preference="lower"
+            />
+
+            <VitalMetricSection
+              title="Body Battery"
+              info="Garmin Body Battery estimates available energy from heart-rate variability, stress, and sleep. This card uses the daily peak (body_battery_high, falling back to end-of-day) on a 0-100 scale. Higher is better."
+              metric={data.bodyBattery}
+              statusConfig={BODY_BATTERY_STATUS}
+              color="#22c55e"
+              chartName="Body Battery"
+              emptyMessage="No Body Battery data in this period."
+              preference="higher"
+              latestLabel="Daily Peak"
+              yDomain={[0, 100]}
+            />
+
+            <VitalMetricSection
+              title="Stress"
+              info="Garmin all-day stress score estimates sympathetic load from HRV. Lower stress versus your 30-day baseline is better; sustained elevation can reduce recovery capacity."
+              metric={data.stress}
+              statusConfig={STRESS_STATUS}
+              color="#a855f7"
+              chartName="Stress"
+              emptyMessage="No stress score data in this period."
+              preference="lower"
+              yDomain={[0, 100]}
+            />
+
+            <VitalMetricSection
+              title="Respiration Rate"
+              info="Average breathing rate during sleep (breaths per minute). Normal: 12-20 brpm. Elevated RR (>2 brpm above your baseline) is an early marker of illness, overreaching, or stress (Buchheit 2014). Used in WHOOP's recovery algorithm."
+              metric={data.respirationRate}
+              statusConfig={RR_STATUS}
+              unit="brpm"
+              color="#10b981"
+              chartName="RR"
+              emptyMessage="No respiration data in this period."
+              preference="lower"
+            />
+
+            <VitalMetricSection
+              title="Skin Temperature"
+              info="Wrist skin temperature deviation from your personal baseline. Elevated skin temp (+0.5°C or more) is a strong early indicator of illness — this is one of WHOOP's key recovery signals. Hormonal cycles can also cause regular fluctuations."
+              metric={data.skinTemp}
+              statusConfig={TEMP_STATUS}
+              unit="°C"
+              color="#f43f5e"
+              chartName="Skin Temp"
+              emptyMessage="No skin temperature data in this period."
+              preference={null}
+              deviationUnit="°C"
+            />
+
             <section className="space-y-3">
               <SectionHeader
-                title="Blood Oxygen (SpO2)"
-                info="Pulse oximeter reading from your Garmin. Normal range is 95-100%. Drops below baseline may indicate altitude exposure, illness onset, sleep apnea, or overtraining. Each 1% below your baseline reduces readiness by ~20 points."
+                title="Body Composition"
+                info="Weight and body-fat trends require a compatible Garmin Index scale or body-composition source. The current daily_metric schema does not include weight/body-fat columns, so this card degrades gracefully until those fields are available."
               />
-
-              {/* Status badge */}
-              {spo2 && (
-                <div
-                  className={cn(
-                    "flex items-center gap-2 rounded-lg border px-3 py-2",
-                    SPO2_STATUS[spo2.status]?.cls,
-                  )}
-                >
-                  <span className="text-lg">
-                    {SPO2_STATUS[spo2.status]?.icon}
-                  </span>
-                  <div>
-                    <p className="text-sm font-semibold">
-                      {SPO2_STATUS[spo2.status]?.label}
-                    </p>
-                    <p className="text-[11px] opacity-80">
-                      {SPO2_STATUS[spo2.status]?.desc}
-                    </p>
-                  </div>
-                </div>
-              )}
-
-              {/* Stats */}
-              {spo2 && (
-                <div className="grid grid-cols-3 gap-2">
-                  <StatCard label="Latest" value={spo2.latest} unit="%" />
-                  <StatCard label="Baseline" value={spo2.baseline} unit="%" />
-                  <StatCard
-                    label="Deviation"
-                    value={
-                      spo2.deviation !== null
-                        ? `${spo2.deviation > 0 ? "+" : ""}${spo2.deviation}%`
-                        : null
-                    }
-                  />
-                </div>
-              )}
-
-              {/* Chart */}
-              {spo2 && spo2.daily.length > 0 ? (
-                <div className="bg-card rounded-lg border p-3">
-                  <ResponsiveContainer width="100%" height={180}>
-                    <ComposedChart
-                      data={spo2.daily.map((d, i) => ({
-                        date: d.date,
-                        value: d.value,
-                        avg: spo2.rolling7d[i]?.value,
-                      }))}
-                    >
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        stroke="#333"
-                        vertical={false}
-                      />
-                      <XAxis
-                        dataKey="date"
-                        tickFormatter={formatDate}
-                        tick={{ fill: "#888", fontSize: 10 }}
-                        axisLine={false}
-                      />
-                      <YAxis
-                        domain={[88, 100]}
-                        tick={{ fill: "#888", fontSize: 10 }}
-                        axisLine={false}
-                        width={30}
-                      />
-                      <Tooltip
-                        labelFormatter={(label: unknown) =>
-                          formatDate(String(label))
-                        }
-                        formatter={(v: unknown) => [`${Number(v)}%`, ""]}
-                        contentStyle={{
-                          background: "#1a1a2e",
-                          border: "1px solid #333",
-                          borderRadius: 8,
-                          fontSize: 12,
-                        }}
-                      />
-                      {spo2.baseline && (
-                        <ReferenceLine
-                          y={spo2.baseline}
-                          stroke="#666"
-                          strokeDasharray="4 4"
-                          label={{
-                            value: "baseline",
-                            fill: "#666",
-                            fontSize: 10,
-                            position: "insideTopRight",
-                          }}
-                        />
-                      )}
-                      <ReferenceLine
-                        y={95}
-                        stroke="#ef4444"
-                        strokeDasharray="2 2"
-                        label={{
-                          value: "95%",
-                          fill: "#ef4444",
-                          fontSize: 10,
-                        }}
-                      />
-                      <Area
-                        dataKey="value"
-                        fill="#3b82f6"
-                        fillOpacity={0.15}
-                        stroke="none"
-                      />
-                      <Line
-                        dataKey="value"
-                        stroke="#3b82f6"
-                        strokeWidth={1.5}
-                        dot={{ r: 2, fill: "#3b82f6" }}
-                        name="SpO2"
-                      />
-                      <Line
-                        dataKey="avg"
-                        stroke="#f59e0b"
-                        strokeWidth={2}
-                        strokeDasharray="4 2"
-                        dot={false}
-                        name="7d Avg"
-                      />
-                    </ComposedChart>
-                  </ResponsiveContainer>
-                  <p className="text-muted-foreground mt-1 text-center text-[10px]">
-                    {spo2.daysWithData} days with data · 7d rolling avg in amber
-                  </p>
-                </div>
-              ) : (
-                !isLoading && (
-                  <p className="text-muted-foreground py-4 text-center text-xs">
-                    No SpO2 data in this period. Ensure pulse ox is enabled on
-                    your Garmin.
-                  </p>
-                )
-              )}
-            </section>
-
-            {/* ────── Respiration Rate Section ────── */}
-            <section className="space-y-3">
-              <SectionHeader
-                title="Respiration Rate"
-                info="Average breathing rate during sleep (breaths per minute). Normal: 12-20 brpm. Elevated RR (>2 brpm above your baseline) is an early marker of illness, overreaching, or stress (Buchheit 2014). Used in WHOOP's recovery algorithm."
-              />
-
-              {rr && (
-                <div
-                  className={cn(
-                    "flex items-center gap-2 rounded-lg border px-3 py-2",
-                    RR_STATUS[rr.status]?.cls,
-                  )}
-                >
-                  <span className="text-lg">{RR_STATUS[rr.status]?.icon}</span>
-                  <div>
-                    <p className="text-sm font-semibold">
-                      {RR_STATUS[rr.status]?.label}
-                    </p>
-                    <p className="text-[11px] opacity-80">
-                      {RR_STATUS[rr.status]?.desc}
-                    </p>
-                  </div>
-                </div>
-              )}
-
-              {rr && (
-                <div className="grid grid-cols-3 gap-2">
-                  <StatCard
-                    label="Latest"
-                    value={
-                      rr.latest != null ? Math.round(rr.latest * 10) / 10 : null
-                    }
-                    unit="brpm"
-                  />
-                  <StatCard label="Baseline" value={rr.baseline} unit="brpm" />
-                  <StatCard
-                    label="Deviation"
-                    value={
-                      rr.deviation !== null
-                        ? `${rr.deviation > 0 ? "+" : ""}${rr.deviation}%`
-                        : null
-                    }
-                  />
-                </div>
-              )}
-
-              {rr && rr.daily.length > 0 ? (
-                <div className="bg-card rounded-lg border p-3">
-                  <ResponsiveContainer width="100%" height={180}>
-                    <ComposedChart
-                      data={rr.daily.map((d, i) => ({
-                        date: d.date,
-                        value: Math.round(d.value * 10) / 10,
-                        avg: rr.rolling7d[i]?.value,
-                      }))}
-                    >
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        stroke="#333"
-                        vertical={false}
-                      />
-                      <XAxis
-                        dataKey="date"
-                        tickFormatter={formatDate}
-                        tick={{ fill: "#888", fontSize: 10 }}
-                        axisLine={false}
-                      />
-                      <YAxis
-                        tick={{ fill: "#888", fontSize: 10 }}
-                        axisLine={false}
-                        width={30}
-                      />
-                      <Tooltip
-                        labelFormatter={(label: unknown) =>
-                          formatDate(String(label))
-                        }
-                        formatter={(v: unknown) => [`${Number(v)} brpm`, ""]}
-                        contentStyle={{
-                          background: "#1a1a2e",
-                          border: "1px solid #333",
-                          borderRadius: 8,
-                          fontSize: 12,
-                        }}
-                      />
-                      {rr.baseline && (
-                        <ReferenceLine
-                          y={rr.baseline}
-                          stroke="#666"
-                          strokeDasharray="4 4"
-                          label={{
-                            value: "baseline",
-                            fill: "#666",
-                            fontSize: 10,
-                            position: "insideTopRight",
-                          }}
-                        />
-                      )}
-                      <Area
-                        dataKey="value"
-                        fill="#10b981"
-                        fillOpacity={0.15}
-                        stroke="none"
-                      />
-                      <Line
-                        dataKey="value"
-                        stroke="#10b981"
-                        strokeWidth={1.5}
-                        dot={{ r: 2, fill: "#10b981" }}
-                        name="RR"
-                      />
-                      <Line
-                        dataKey="avg"
-                        stroke="#f59e0b"
-                        strokeWidth={2}
-                        strokeDasharray="4 2"
-                        dot={false}
-                        name="7d Avg"
-                      />
-                    </ComposedChart>
-                  </ResponsiveContainer>
-                  <p className="text-muted-foreground mt-1 text-center text-[10px]">
-                    {rr.daysWithData} days with data · 7d rolling avg in amber
-                  </p>
-                </div>
-              ) : (
-                !isLoading && (
-                  <p className="text-muted-foreground py-4 text-center text-xs">
-                    No respiration data in this period.
-                  </p>
-                )
-              )}
-            </section>
-
-            {/* ────── Skin Temperature Section ────── */}
-            <section className="space-y-3">
-              <SectionHeader
-                title="Skin Temperature"
-                info="Wrist skin temperature deviation from your personal baseline. Elevated skin temp (+0.5°C or more) is a strong early indicator of illness — this is one of WHOOP's key recovery signals. Hormonal cycles can also cause regular fluctuations."
-              />
-
-              {skinTemp && (
-                <div
-                  className={cn(
-                    "flex items-center gap-2 rounded-lg border px-3 py-2",
-                    TEMP_STATUS[skinTemp.status]?.cls,
-                  )}
-                >
-                  <span className="text-lg">
-                    {TEMP_STATUS[skinTemp.status]?.icon}
-                  </span>
-                  <div>
-                    <p className="text-sm font-semibold">
-                      {TEMP_STATUS[skinTemp.status]?.label}
-                    </p>
-                    <p className="text-[11px] opacity-80">
-                      {TEMP_STATUS[skinTemp.status]?.desc}
-                    </p>
-                  </div>
-                </div>
-              )}
-
-              {skinTemp && (
-                <div className="grid grid-cols-3 gap-2">
-                  <StatCard
-                    label="Latest"
-                    value={
-                      skinTemp.latest != null
-                        ? Math.round(skinTemp.latest * 10) / 10
-                        : null
-                    }
-                    unit="°C"
-                  />
-                  <StatCard
-                    label="Baseline"
-                    value={skinTemp.baseline}
-                    unit="°C"
-                  />
-                  <StatCard
-                    label="Deviation"
-                    value={
-                      skinTemp.deviation !== null
-                        ? `${skinTemp.deviation > 0 ? "+" : ""}${skinTemp.deviation}°C`
-                        : null
-                    }
-                  />
-                </div>
-              )}
-
-              {skinTemp && skinTemp.daily.length > 0 ? (
-                <div className="bg-card rounded-lg border p-3">
-                  <ResponsiveContainer width="100%" height={180}>
-                    <ComposedChart
-                      data={skinTemp.daily.map((d, i) => ({
-                        date: d.date,
-                        value: Math.round(d.value * 10) / 10,
-                        avg: skinTemp.rolling7d[i]?.value,
-                      }))}
-                    >
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        stroke="#333"
-                        vertical={false}
-                      />
-                      <XAxis
-                        dataKey="date"
-                        tickFormatter={formatDate}
-                        tick={{ fill: "#888", fontSize: 10 }}
-                        axisLine={false}
-                      />
-                      <YAxis
-                        tick={{ fill: "#888", fontSize: 10 }}
-                        axisLine={false}
-                        width={35}
-                      />
-                      <Tooltip
-                        labelFormatter={(label: unknown) =>
-                          formatDate(String(label))
-                        }
-                        formatter={(v: unknown) => [`${Number(v)}°C`, ""]}
-                        contentStyle={{
-                          background: "#1a1a2e",
-                          border: "1px solid #333",
-                          borderRadius: 8,
-                          fontSize: 12,
-                        }}
-                      />
-                      {skinTemp.baseline && (
-                        <ReferenceLine
-                          y={skinTemp.baseline}
-                          stroke="#666"
-                          strokeDasharray="4 4"
-                          label={{
-                            value: "baseline",
-                            fill: "#666",
-                            fontSize: 10,
-                            position: "insideTopRight",
-                          }}
-                        />
-                      )}
-                      <Area
-                        dataKey="value"
-                        fill="#f43f5e"
-                        fillOpacity={0.15}
-                        stroke="none"
-                      />
-                      <Line
-                        dataKey="value"
-                        stroke="#f43f5e"
-                        strokeWidth={1.5}
-                        dot={{ r: 2, fill: "#f43f5e" }}
-                        name="Skin Temp"
-                      />
-                      <Line
-                        dataKey="avg"
-                        stroke="#f59e0b"
-                        strokeWidth={2}
-                        strokeDasharray="4 2"
-                        dot={false}
-                        name="7d Avg"
-                      />
-                    </ComposedChart>
-                  </ResponsiveContainer>
-                  <p className="text-muted-foreground mt-1 text-center text-[10px]">
-                    {skinTemp.daysWithData} days with data · 7d rolling avg in
-                    amber
-                  </p>
-                </div>
-              ) : (
-                !isLoading && (
-                  <p className="text-muted-foreground py-4 text-center text-xs">
-                    No skin temperature data in this period.
-                  </p>
-                )
-              )}
+              <div className="bg-card rounded-lg border p-4 text-center">
+                <div className="mb-2 text-3xl">⚖️</div>
+                <p className="text-foreground text-sm font-semibold">
+                  {data.bodyComposition.message}
+                </p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Weight and body-fat metrics will appear here when body
+                  composition columns are available in daily_metric.
+                </p>
+              </div>
             </section>
 
             {/* ────── Science / WHOOP Context ────── */}
@@ -632,10 +624,20 @@ export default function VitalsPage() {
               </h3>
               <div className="text-muted-foreground space-y-2 text-xs leading-relaxed">
                 <p>
+                  <strong className="text-foreground">RHR + Stress</strong> —
+                  Elevated resting HR and stress versus a personal 30-day
+                  baseline indicate higher autonomic load and reduced readiness.
+                </p>
+                <p>
+                  <strong className="text-foreground">Body Battery</strong> — A
+                  lower daily peak suggests incomplete overnight recharge or
+                  elevated stress load, even when training volume is unchanged.
+                </p>
+                <p>
                   <strong className="text-foreground">SpO2</strong> — Nocturnal
-                  oxygen saturation dips below your personal baseline correlate
-                  with altitude acclimatization stress, sleep apnea, and
-                  overtraining syndrome (Millet et al., 2016).
+                  oxygen saturation dips below baseline correlate with altitude
+                  acclimatization stress, sleep apnea, and overtraining syndrome
+                  (Millet et al., 2016).
                 </p>
                 <p>
                   <strong className="text-foreground">Respiration Rate</strong>{" "}
@@ -648,11 +650,6 @@ export default function VitalsPage() {
                   — WHOOP&apos;s recovery model heavily weights wrist skin temp
                   deviation. A +0.5°C shift predicts illness 1-2 days before
                   symptoms appear (Miller et al., 2018).
-                </p>
-                <p className="pt-1 italic opacity-70">
-                  These vitals are integrated into your readiness score
-                  calculation when the addon&apos;s metrics-compute runs (SpO2:
-                  8%, RR: 7%, Skin Temp: 7%).
                 </p>
               </div>
             </section>

--- a/packages/api/src/router/vitals.ts
+++ b/packages/api/src/router/vitals.ts
@@ -152,13 +152,16 @@ export const vitalsRouter = {
               ? "elevated"
               : "high";
 
-      const bodyBatteryStatus: MetricStatus =
+      const bodyBatteryAssessment =
         bodyBattery.latest === null || bodyBattery.baseline === null
+          ? null
+          : assessHigherIsBetter(bodyBattery.latest, bodyBattery.baseline);
+      const bodyBatteryStatus: MetricStatus =
+        bodyBatteryAssessment === null
           ? "no_data"
-          : assessHigherIsBetter(bodyBattery.latest, bodyBattery.baseline) ===
-              "critical"
+          : bodyBatteryAssessment === "critical"
             ? "depleted"
-            : assessHigherIsBetter(bodyBattery.latest, bodyBattery.baseline);
+            : bodyBatteryAssessment;
 
       return {
         spo2: {

--- a/packages/api/src/router/vitals.ts
+++ b/packages/api/src/router/vitals.ts
@@ -12,11 +12,19 @@ function getDateString(daysAgo: number): string {
   return d.toISOString().split("T")[0]!;
 }
 
+type DailyMetricRow = typeof DailyMetric.$inferSelect;
+type TrendPoint = { date: string; value: number };
+type MetricStatus =
+  | "normal"
+  | "low"
+  | "critical"
+  | "elevated"
+  | "high"
+  | "depleted"
+  | "no_data";
+
 /** Compute a rolling average over `window` days. */
-function computeRolling(
-  data: { date: string; value: number }[],
-  window: number,
-) {
+function computeRolling(data: TrendPoint[], window: number) {
   return data.map((d, i) => {
     const start = Math.max(0, i - window + 1);
     const slice = data.slice(start, i + 1);
@@ -37,13 +45,71 @@ function deviationAbs(current: number, baseline: number): number | null {
   return Math.round((current - baseline) * 10) / 10;
 }
 
+function latestValue(data: TrendPoint[]): number | null {
+  return data.length > 0 ? data[data.length - 1]!.value : null;
+}
+
+function buildTrend(
+  metrics: DailyMetricRow[],
+  displaySince: string,
+  getValue: (metric: DailyMetricRow) => number | null | undefined,
+) {
+  const allData = metrics
+    .map((m) => ({ date: m.date as string, value: getValue(m) }))
+    .filter((m): m is TrendPoint => m.value !== null && m.value !== undefined);
+  const displayData = allData.filter((m) => m.date >= displaySince);
+  const baselineWindow = allData.slice(-30);
+  const baselineDays = baselineWindow.length;
+  const baseline =
+    baselineDays >= 30
+      ? Math.round(
+          (baselineWindow.reduce((sum, m) => sum + m.value, 0) / baselineDays) *
+            10,
+        ) / 10
+      : null;
+
+  return {
+    daily: displayData,
+    rolling7d: computeRolling(displayData, 7),
+    baseline,
+    latest: latestValue(displayData),
+    daysWithData: displayData.length,
+    baselineDays,
+  };
+}
+
+function assessLowerIsBetter(
+  latest: number | null,
+  baseline: number | null,
+): "normal" | "elevated" | "high" | "no_data" {
+  if (latest === null || baseline === null) return "no_data";
+  const deviation = deviationPct(latest, baseline);
+  if (deviation === null) return "no_data";
+  if (deviation <= 3) return "normal";
+  if (deviation <= 7) return "elevated";
+  return "high";
+}
+
+function assessHigherIsBetter(
+  latest: number | null,
+  baseline: number | null,
+): "normal" | "low" | "critical" | "no_data" {
+  if (latest === null || baseline === null) return "no_data";
+  const deviation = deviationPct(latest, baseline);
+  if (deviation === null) return "no_data";
+  if (deviation >= -3) return "normal";
+  if (deviation >= -7) return "low";
+  return "critical";
+}
+
 export const vitalsRouter = {
-  /** SpO2, respiration rate, and skin temperature trends with baselines */
+  /** Recovery vitals from daily Garmin metrics with 30-day baselines. */
   getTrends: protectedProcedure
     .input(z.object({ days: z.number().min(7).max(365).default(30) }))
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const since = getDateString(input.days);
+      const displaySince = getDateString(input.days);
+      const since = getDateString(Math.max(input.days, 30));
 
       const metrics = await ctx.db.query.DailyMetric.findMany({
         where: and(
@@ -53,111 +119,104 @@ export const vitalsRouter = {
         orderBy: asc(DailyMetric.date),
       });
 
-      // --- SpO2 ---
-      const spo2Data = metrics
-        .filter((m) => m.spo2 !== null)
-        .map((m) => ({ date: m.date as string, value: m.spo2! }));
+      const spo2 = buildTrend(metrics, displaySince, (m) => m.spo2);
+      const respirationRate = buildTrend(
+        metrics,
+        displaySince,
+        (m) => m.respirationRate,
+      );
+      const skinTemp = buildTrend(metrics, displaySince, (m) => m.skinTemp);
+      const restingHr = buildTrend(metrics, displaySince, (m) => m.restingHr);
+      const bodyBattery = buildTrend(
+        metrics,
+        displaySince,
+        (m) => m.bodyBatteryHigh ?? m.bodyBatteryEnd,
+      );
+      const stress = buildTrend(metrics, displaySince, (m) => m.stressScore);
 
-      const spo2Rolling7d = computeRolling(spo2Data, 7);
-      const spo2Baseline =
-        spo2Rolling7d.length > 0
-          ? spo2Rolling7d[spo2Rolling7d.length - 1]!.value
-          : null;
-      const latestSpo2 =
-        spo2Data.length > 0 ? spo2Data[spo2Data.length - 1]!.value : null;
-
-      // --- Respiration Rate ---
-      const rrData = metrics
-        .filter((m) => m.respirationRate !== null)
-        .map((m) => ({ date: m.date as string, value: m.respirationRate! }));
-
-      const rrRolling7d = computeRolling(rrData, 7);
-      const rrBaseline =
-        rrRolling7d.length > 0
-          ? rrRolling7d[rrRolling7d.length - 1]!.value
-          : null;
-      const latestRR =
-        rrData.length > 0 ? rrData[rrData.length - 1]!.value : null;
-
-      // --- Skin Temperature ---
-      const skinTempData = metrics
-        .filter((m) => m.skinTemp !== null)
-        .map((m) => ({ date: m.date as string, value: m.skinTemp! }));
-
-      const skinTempRolling7d = computeRolling(skinTempData, 7);
-      const skinTempBaseline =
-        skinTempRolling7d.length > 0
-          ? skinTempRolling7d[skinTempRolling7d.length - 1]!.value
-          : null;
-      const latestSkinTemp =
-        skinTempData.length > 0
-          ? skinTempData[skinTempData.length - 1]!.value
-          : null;
-
-      // --- Status assessment ---
       const spo2Status: "normal" | "low" | "critical" | "no_data" =
-        latestSpo2 === null
+        spo2.latest === null
           ? "no_data"
-          : latestSpo2 >= 95
+          : spo2.latest >= 95
             ? "normal"
-            : latestSpo2 >= 90
+            : spo2.latest >= 90
               ? "low"
               : "critical";
 
-      const rrStatus: "normal" | "elevated" | "high" | "no_data" =
-        latestRR === null || rrBaseline === null
+      const skinTempStatus: "normal" | "elevated" | "high" | "no_data" =
+        skinTemp.latest === null || skinTemp.baseline === null
           ? "no_data"
-          : latestRR <= rrBaseline + 1
+          : Math.abs(skinTemp.latest - skinTemp.baseline) <= 0.3
             ? "normal"
-            : latestRR <= rrBaseline + 3
+            : Math.abs(skinTemp.latest - skinTemp.baseline) <= 0.8
               ? "elevated"
               : "high";
 
-      const skinTempStatus: "normal" | "elevated" | "high" | "no_data" =
-        latestSkinTemp === null || skinTempBaseline === null
+      const bodyBatteryStatus: MetricStatus =
+        bodyBattery.latest === null || bodyBattery.baseline === null
           ? "no_data"
-          : Math.abs(latestSkinTemp - skinTempBaseline) <= 0.3
-            ? "normal"
-            : Math.abs(latestSkinTemp - skinTempBaseline) <= 0.8
-              ? "elevated"
-              : "high";
+          : assessHigherIsBetter(bodyBattery.latest, bodyBattery.baseline) ===
+              "critical"
+            ? "depleted"
+            : assessHigherIsBetter(bodyBattery.latest, bodyBattery.baseline);
 
       return {
         spo2: {
-          daily: spo2Data,
-          rolling7d: spo2Rolling7d,
-          baseline: spo2Baseline,
-          latest: latestSpo2,
+          ...spo2,
           status: spo2Status,
           deviation:
-            latestSpo2 != null && spo2Baseline != null
-              ? deviationPct(latestSpo2, spo2Baseline)
+            spo2.latest != null && spo2.baseline != null
+              ? deviationPct(spo2.latest, spo2.baseline)
               : null,
-          daysWithData: spo2Data.length,
         },
         respirationRate: {
-          daily: rrData,
-          rolling7d: rrRolling7d,
-          baseline: rrBaseline,
-          latest: latestRR,
-          status: rrStatus,
+          ...respirationRate,
+          status: assessLowerIsBetter(
+            respirationRate.latest,
+            respirationRate.baseline,
+          ),
           deviation:
-            latestRR != null && rrBaseline != null
-              ? deviationPct(latestRR, rrBaseline)
+            respirationRate.latest != null && respirationRate.baseline != null
+              ? deviationPct(respirationRate.latest, respirationRate.baseline)
               : null,
-          daysWithData: rrData.length,
         },
         skinTemp: {
-          daily: skinTempData,
-          rolling7d: skinTempRolling7d,
-          baseline: skinTempBaseline,
-          latest: latestSkinTemp,
+          ...skinTemp,
           status: skinTempStatus,
           deviation:
-            latestSkinTemp != null && skinTempBaseline != null
-              ? deviationAbs(latestSkinTemp, skinTempBaseline)
+            skinTemp.latest != null && skinTemp.baseline != null
+              ? deviationAbs(skinTemp.latest, skinTemp.baseline)
               : null,
-          daysWithData: skinTempData.length,
+        },
+        restingHr: {
+          ...restingHr,
+          status: assessLowerIsBetter(restingHr.latest, restingHr.baseline),
+          deviation:
+            restingHr.latest != null && restingHr.baseline != null
+              ? deviationPct(restingHr.latest, restingHr.baseline)
+              : null,
+        },
+        bodyBattery: {
+          ...bodyBattery,
+          status: bodyBatteryStatus,
+          deviation:
+            bodyBattery.latest != null && bodyBattery.baseline != null
+              ? deviationPct(bodyBattery.latest, bodyBattery.baseline)
+              : null,
+        },
+        stress: {
+          ...stress,
+          status: assessLowerIsBetter(stress.latest, stress.baseline),
+          deviation:
+            stress.latest != null && stress.baseline != null
+              ? deviationPct(stress.latest, stress.baseline)
+              : null,
+        },
+        bodyComposition: {
+          hasData: false,
+          weightKg: null,
+          bodyFatPct: null,
+          message: "Connect a Garmin Index scale",
         },
       };
     }),


### PR DESCRIPTION
Closes screenshot QA findings **P2-13/14/15/16**.

## Changes

The Vitals page only rendered 3 cards (SpO2, Respiration, Skin Temp) despite the rest of the app referencing these metrics. Adds:

| Card | Source | Direction | Baseline |
|------|--------|-----------|----------|
| Resting Heart Rate | `resting_hr` | lower-is-better | 30-day rolling |
| Body Battery | `body_battery_high` (fallback `body_battery_end`) | higher-is-better | 30-day peak |
| Stress | `stress_score` | lower-is-better | 30-day rolling |
| Body Composition | (placeholder) | — | requires Garmin Index scale |

## Polish

- **P2-14** — Tightened unit spacing: `93%` (no space) for percentages, `17 brpm` (space) for words.
- **P2-15** — Direction-aware deviation colouring. >3% deviation = amber, >7% = red. Lower-is-better metrics (RHR, stress, respiration) flip the colour direction so 'elevated' = bad.
- **P2-16** — Replaced confusing '30 days with data — 70 rolling avg in amber' copy. ≥30 days populated → show baseline value only; <30 days → `Baseline still warming up (N days)`.

## Verification

- `pnpm -F @acme/api typecheck` ✓
- `pnpm -F @acme/nextjs typecheck` ✓

Part of the v0.16.19 screenshot QA sweep (2026-05-16).