### PR TITLE
fix(readiness): only blame HRV in action copy when component is low

### DIFF
--- a/apps/nextjs/src/app/_components/garmin-training-summary.tsx
+++ b/apps/nextjs/src/app/_components/garmin-training-summary.tsx
@@ -84,9 +84,12 @@ export function GarminTrainingSummary() {
   const recoveryAsOf = staleCaption(
     summary.data?.latestDates.garminRecoveryHours,
   );
+  // Only show the status date when the status itself is available — falling
+  // back to garminTrainingReadinessLevel's date here would attach an unrelated
+  // timestamp to an "unavailable" status (e.g. rendering
+  // "unavailable · as of Mon May 12" when the status column is genuinely null).
   const statusAsOf = staleCaption(
-    summary.data?.latestDates.garminTrainingStatus ??
-      summary.data?.latestDates.garminTrainingReadinessLevel,
+    summary.data?.latestDates.garminTrainingStatus,
   );
   const trend = trendChip(
     (summary.data?.hrvTrend as "rising" | "falling" | "stable" | null) ?? null,

--- a/apps/nextjs/src/app/_components/garmin-training-summary.tsx
+++ b/apps/nextjs/src/app/_components/garmin-training-summary.tsx
@@ -159,7 +159,9 @@ export function GarminTrainingSummary() {
               : "—"}
           </div>
           <div className="text-muted-foreground mt-0.5 text-xs">
-            {latest.garminTrainingReadinessLevel?.toLowerCase() ?? "—"}
+            {latest.garminTrainingStatus
+              ? (latest.garminTrainingReadinessLevel?.toLowerCase() ?? "")
+              : "unavailable"}
             {statusAsOf ? ` · ${statusAsOf}` : ""}
           </div>
         </div>

--- a/packages/api/src/router/__tests__/readiness.test.ts
+++ b/packages/api/src/router/__tests__/readiness.test.ts
@@ -99,6 +99,7 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
       todayRow as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       recent as any,
+      25, // hrvComponentScore — engine flagged HRV as below baseline
     );
     expect(action).not.toMatch(/HRV data is unavailable/);
     expect(action).toMatch(/HRV of 62ms/);
@@ -249,8 +250,42 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       metric as any,
       [],
+      25, // hrvComponentScore — engine flagged HRV as below baseline (19ms is low)
     );
     expect(action).toMatch(/Take it easy today/);
     expect(action).toMatch(/easy 30-min walk/);
+  });
+
+  it("does NOT blame HRV when readiness is low but HRV component is healthy", () => {
+    // Reproduces the home-screen contradiction: readiness 21/100 (poor zone)
+    // but the HRV component score is 76/100 (Optimal in the tile). Previously
+    // buildActionSuggestion still asserted "your HRV of Xms is below baseline"
+    // because it only checked dq.hrv === "missing" and the presence of a
+    // recent HRV value, not whether the engine actually graded HRV as low.
+    // The action should fall through to a non-HRV recovery message instead.
+    const metric = row(today, {
+      hrv: 62, // value is fine; engine scored it 76/100 (optimal)
+      totalSleepMinutes: 360, // short sleep is the actual driver
+      sleepDebtMinutes: 90,
+      restingHr: 50,
+    });
+    const dq = computeDataQuality(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [metric] as any,
+      3,
+      today,
+    );
+    const action = buildActionSuggestion(
+      21,
+      "poor",
+      dq,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metric as any,
+      [],
+      76, // hrvComponentScore — engine scored HRV in the optimal range
+    );
+    expect(action).not.toMatch(/HRV of \d+ms is below baseline/);
   });
 });

--- a/packages/api/src/router/__tests__/readiness.test.ts
+++ b/packages/api/src/router/__tests__/readiness.test.ts
@@ -287,5 +287,11 @@ describe("buildActionSuggestion — no contradiction with engine explanation", (
       76, // hrvComponentScore — engine scored HRV in the optimal range
     );
     expect(action).not.toMatch(/HRV of \d+ms is below baseline/);
+    // Sleep debt is the actual driver in this fixture (90m short),
+    // so the action should route to the sleep-debt fallback. Without
+    // this stronger assertion the test would still pass if
+    // buildActionSuggestion fell through to an unrelated training-load
+    // message — leaving the intended behaviour uncovered.
+    expect(action).toMatch(/Prioritize.*1h 30m of sleep/);
   });
 });

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -104,6 +104,7 @@ export function buildActionSuggestion(
   dq: DataQuality,
   metric: typeof DailyMetric.$inferSelect | null,
   recentMetrics: (typeof DailyMetric.$inferSelect)[] = [],
+  hrvComponentScore: number | null = null,
 ): string {
   const scoreZone = getReadinessZone(score);
   const resolvedZone = zone === scoreZone ? zone : scoreZone;
@@ -133,7 +134,14 @@ export function buildActionSuggestion(
   if (dq.hrv === "missing") {
     return "Take it easy today — HRV data is unavailable. Consider an easy 30-min walk instead of your planned session.";
   }
-  if (recentHrv != null) {
+  // Only blame HRV when the engine actually scored it below baseline.
+  // `hrvComponentScore < 40` matches the same threshold the engine uses in
+  // generateExplanation() to surface "HRV X% below baseline" as a negative
+  // factor. Without this guard the message would assert "HRV of Xms is below
+  // baseline" even when the HRV component is in the optimal range (e.g.,
+  // readiness is low because of sleep debt or training load, not HRV).
+  const hrvIsLow = hrvComponentScore != null && hrvComponentScore < 40;
+  if (hrvIsLow && recentHrv != null) {
     return `Take it easy today — your HRV of ${recentHrv.toFixed(0)}ms is below baseline. Consider an easy 30-min walk instead of your planned session.`;
   }
   if (dq.sleep !== "good" || metric?.sleepDebtMinutes != null) {
@@ -275,6 +283,7 @@ export const readinessRouter = {
         dq,
         todayDbMetric ?? null,
         recentMetricsForDQ,
+        existing.hrvComponent ?? null,
       );
       // Sanitize stale debug-style explanations written by older builds of
       // the engine, e.g.:
@@ -335,6 +344,7 @@ export const readinessRouter = {
       dq,
       todayDbMetric ?? null,
       recentMetricsForDQ,
+      result.components.hrv,
     );
 
     // Daily target-strain band (WHOOP-style coaching) — uses readiness

--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -98,6 +98,31 @@ function computeConfidence(dq: DataQuality): number {
   return Math.max(confidence, 0.3);
 }
 
+/**
+ * Resolve the HRV component score for a cached ReadinessScore row.
+ *
+ * Cached rows can have the dedicated `hrvComponent` column null while
+ * the same value is preserved inside the `factors` JSONB blob — this
+ * was the on-disk shape for Garmin-native rows written by v0.16.18 /
+ * v0.16.19 before the dedicated columns were added.
+ *
+ * Walk the same two layers `getReadinessComponent()` in the UI does
+ * (apps/nextjs/src/app/_components/readiness-helpers.ts), so the
+ * action-copy gate sees the same component score the user sees in
+ * the HRV tile.
+ */
+function pickHrvComponent(
+  topColumn: number | null,
+  factorsBlob: unknown,
+): number | null {
+  if (typeof topColumn === "number") return topColumn;
+  if (factorsBlob && typeof factorsBlob === "object") {
+    const candidate = (factorsBlob as Record<string, unknown>).hrv;
+    if (typeof candidate === "number") return candidate;
+  }
+  return null;
+}
+
 export function buildActionSuggestion(
   score: number,
   zone: ReadinessZone,
@@ -277,13 +302,22 @@ export const readinessRouter = {
         existing.zone === getReadinessZone(existing.score)
           ? (existing.zone as ReadinessZone)
           : getReadinessZone(existing.score);
+      // Cached rows can have `hrvComponent` null while the score is still
+      // present in the `factors` JSONB (Garmin-native rows from v0.16.18 /
+      // v0.16.19). Walk the same layered lookup the UI uses
+      // (apps/nextjs/.../readiness-helpers.ts) so the action-copy gate
+      // does not treat those rows as having no HRV component.
+      const cachedHrvComponent = pickHrvComponent(
+        existing.hrvComponent,
+        existing.factors,
+      );
       const actionSuggestion = buildActionSuggestion(
         existing.score,
         existingZone,
         dq,
         todayDbMetric ?? null,
         recentMetricsForDQ,
-        existing.hrvComponent ?? null,
+        cachedHrvComponent,
       );
       // Sanitize stale debug-style explanations written by older builds of
       // the engine, e.g.:


### PR DESCRIPTION
## Summary

Fixes two contradictions caught during the 2026-05-16 screenshot QA pass:

### 1. Home — Action card contradicts HRV tile
The action card said *"Take it easy today — your HRV of 19ms is below baseline"* while the HRV component tile right next to it showed *"76/100 — Optimal"*. Both reference the same metric.

Root cause: `buildActionSuggestion` in `packages/api/src/router/readiness.ts` was emitting the HRV-specific message whenever `recentHrv != null` and readiness was in the low/poor zone, ignoring whether the engine had actually scored HRV as a negative factor.

Fix: thread the engine's `hrvComponent` score through `buildActionSuggestion` and gate the HRV message on `hrvComponentScore < 40` (the same threshold `generateExplanation()` uses in `packages/engine/src/readiness/index.ts` to call HRV a negative factor). When HRV is healthy, fall through to sleep / load advice. Both callsites updated:
- Cached row (line 272) → passes `existing.hrvComponent`
- Fresh row (line 332) → passes `result.components.hrv`

### 2. Training — Status tile shows '—' above 'poor'
The Training page's *Status* tile rendered `—` when `garminTrainingStatus` was NULL, but its sublabel still recycled `garminTrainingReadinessLevel` (an unrelated field) as `poor`. Result: a dash with the word *poor* under it — contradictory and confusing.

Fix: in `apps/nextjs/src/app/_components/garmin-training-summary.tsx`, when `garminTrainingStatus` is null, show `unavailable` as the sublabel instead.

## Tests

- Updated the two existing low-zone tests in `readiness.test.ts` to pass `hrvComponentScore: 25` so they still hit the HRV branch.
- **Added a regression test** asserting the action message does NOT contain `HRV of Xms is below baseline` when `hrvComponentScore` is healthy (76) even if the readiness zone is `poor`.
- All 11 readiness router tests pass.

## QA

Screenshot trail: `tools/screenshots/screenshots/2026-05-16/` — desktop & mobile home/training screens were the source.

Co-authored-by: Claude <claude@anthropic.com>