### PR TITLE
chore(release): v0.2.12 — readiness action-copy fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
Version bump only. Picks up #123 readiness fixes.