### PR TITLE
chore(release): v0.2.13 — activity future-row filter TZ-tolerant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
Release bump for v0.2.13. Companion to addon v0.16.22 (PR askb/ha-garmin-fitness-coach-addon#133).