### PR TITLE
fix(readiness): recompute target-strain band on cached branch

### DIFF
--- a/packages/api/src/router/readiness.ts
+++ b/packages/api/src/router/readiness.ts
@@ -329,6 +329,19 @@ export const readinessRouter = {
         existing.explanation && isLegacyDebugExplanation(existing.explanation)
           ? defaultZoneExplanation(existing.zone)
           : existing.explanation;
+      // Recompute the WHOOP-style target-strain band on every call. The
+      // band is derived from readiness score + recent strain history, not
+      // persisted on `ReadinessScore`, so omitting it here causes the
+      // DailyOutlookCard to silently disappear on the second-and-later
+      // page load of the day (cached branch returns no `targetStrain`,
+      // fresh-compute branch below does). See issue #144.
+      const cachedStrainScores = recentActivities.map(
+        (a) => a.strainScore ?? computeStrainScore(a.trimpScore ?? 0),
+      );
+      const targetStrain = computeTargetStrain(
+        existing.score,
+        cachedStrainScores.slice(0, 14),
+      );
       return {
         ...existing,
         explanation,
@@ -336,6 +349,7 @@ export const readinessRouter = {
         dataQuality: dq,
         actionSuggestion,
         doNotOverinterpret,
+        targetStrain,
       };
     }
 


### PR DESCRIPTION
## Summary

`readinessRouter.getToday` has two return paths:

1. **Fresh-compute branch** — when no `ReadinessScore` row exists yet for today. Returns payload **with** `targetStrain`. ✅
2. **Cached-row branch** — runs on every page load after the first. Returns `{...existing, ...}` **without** `targetStrain`. ❌

`DailyOutlookCard` renders `null` when `targetStrain` is missing, so the 'Today's Target Strain' gauge between Readiness and Today's Workout cards appears once and silently disappears on every refresh.

## Fix

Recompute the band in the cached branch using `existing.score` and the already-loaded `recentActivities`. The band is derived state (not persisted on `ReadinessScore`), so recomputing per-request is correct and cheap.

## Verification

- `pnpm --filter @acme/api typecheck` ✅
- Both return paths now produce the same shape.

Fixes #144