### PR TITLE
fix(data): tame sleep-debt math, drop stale insights, polish carousels

### DIFF
--- a/apps/nextjs/src/__tests__/athlete-accuracy.test.ts
+++ b/apps/nextjs/src/__tests__/athlete-accuracy.test.ts
@@ -288,15 +288,19 @@ describe("Ramp rate and load spikes", () => {
 // ── Block 8: Sleep debt detection ────────────────────────────────────────────
 
 describe("Sleep debt", () => {
-  it("test 19 — 7 nights of 5.5h sleep → total sleep debt > 300 min", () => {
-    // Need = 480 min; actual = 330 min; debt per night = 150 min × 7 = 1050 min
+  it("test 19 — 7 nights of 5.5h sleep → sustained shortfall surfaces (EW-decay window)", () => {
+    // Need = 480 min; actual = 330 min; nightly deficit = 150 min.
+    // Under exponential decay (weight = 0.5^i) the same chronic
+    // restriction lands ~298 min instead of the naive 1050 min
+    // (see calculateSleepDebt comment + issue #128).
     const shortSleepMetrics = Array.from({ length: 7 }, (_, i) => ({
       ...athleteAData[0]!,
       date: `2024-04-${String(i + 1).padStart(2, "0")}`,
       totalSleepMinutes: 330, // 5.5 hours
     }));
     const debt = calculateSleepDebt(shortSleepMetrics, 480);
-    expect(debt).toBeGreaterThan(300);
+    expect(debt).toBeGreaterThan(200);
+    expect(debt).toBeLessThan(400);
   });
 
   it("test 19b — 7 nights of adequate sleep → sleep debt near zero", () => {

--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -305,6 +305,7 @@ export default function FitnessPage() {
     sportType?: string | null;
     durationMinutes?: number | null;
     distanceMeters?: number | null;
+    avgPaceSecPerKm?: number | null;
     startedAt?: Date | string | null;
   }
   interface RacePred {
@@ -337,7 +338,13 @@ export default function FitnessPage() {
         (a) =>
           a.distanceMeters != null &&
           Math.abs(a.distanceMeters - targetDist) / targetDist < 0.1 &&
-          a.durationMinutes != null,
+          a.durationMinutes != null &&
+          // Exclude walks misclassified as runs. A 5K at >8:00/km
+          // (480 s/km) pace is almost certainly a walk regardless of
+          // what `sportType` says — Garmin will occasionally label
+          // long brisk walks as `running`. Only count entries whose
+          // pace is plausible for a *run* at that distance.
+          (a.avgPaceSecPerKm == null || a.avgPaceSecPerKm < 480),
       );
       return matching.slice(0, 2).map((a) => {
         const actualSecs = (a.durationMinutes ?? 0) * 60;

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -341,7 +341,14 @@ export default function TrendsPage() {
     { key: "strain", query: trendStrain },
     { key: "stress", query: trendStress },
   ];
-  const topCorrelations = (correlations.data ?? []).slice(0, 6);
+  // Drop statistically insignificant correlations (p ≥ 0.05). A pearson r
+  // with p = 0.456 is indistinguishable from noise and showing it next to
+  // a "strong/moderate/weak" badge implies a relationship that doesn't
+  // exist (issue #138: HRV → Readiness r=-0.22, p=0.456 was being
+  // surfaced with a contradictory negative sign).
+  const topCorrelations = (correlations.data ?? [])
+    .filter((c) => c.pValue < 0.05)
+    .slice(0, 6);
 
   // ---------------------------------------------------------------------------
   return (
@@ -743,7 +750,8 @@ export default function TrendsPage() {
           ) : topCorrelations.length === 0 ? (
             <div className="bg-card rounded-xl border p-4">
               <p className="text-muted-foreground text-sm">
-                Not enough data for correlation analysis.
+                No statistically significant correlations yet (p &lt; 0.05).
+                More data will surface relationships as patterns emerge.
               </p>
             </div>
           ) : (

--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -992,9 +992,9 @@ function CalendarHeatmap({ data }: { data: CalendarDay[] }) {
         ))}
       </div>
 
-      <div className="mt-4 flex gap-0.5">
+      <div className="mt-4 flex min-w-0 gap-0.5">
         {/* Day labels */}
-        <div className="flex flex-col gap-0.5 pr-1">
+        <div className="flex shrink-0 flex-col gap-0.5 pr-1">
           {DAYS.map((d, i) => (
             <div
               key={d}
@@ -1006,7 +1006,7 @@ function CalendarHeatmap({ data }: { data: CalendarDay[] }) {
         </div>
 
         {/* Grid */}
-        <div className="flex gap-0.5 overflow-x-auto">
+        <div className="flex min-w-0 flex-1 gap-0.5 overflow-x-auto">
           {weeks.map((week, wIdx) => (
             <div key={wIdx} className="flex flex-col gap-0.5">
               {Array.from({ length: 7 }, (_, dIdx) => {

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -125,13 +125,18 @@ export const activityRouter = {
     // protects against the TZ-correctness regression that used to
     // hide AEST morning workouts (see `list` above for details)
     // while still excluding actual clock-skew / seed-data anomalies.
+    //
+    // We over-fetch (15) then filter client-side for the home page
+    // top-3 so auto-detected micro-activities (Garmin's "incidental"
+    // 1-minute walks etc.) don't push the user's real workout out
+    // of the carousel. See issue #143.
     const activities = await ctx.db.query.Activity.findMany({
       where: and(
         eq(Activity.userId, userId),
         lte(Activity.startedAt, futureRowCutoff()),
       ),
       orderBy: desc(Activity.startedAt),
-      limit: 5,
+      limit: 15,
       columns: {
         id: true,
         sportType: true,
@@ -145,6 +150,13 @@ export const activityRouter = {
       },
     });
 
-    return activities;
+    // Hide tiny incidental activities (< 10 min AND < 500 m) so a real
+    // workout always surfaces on the home carousel. If everything we
+    // have is "incidental", fall back to the raw list rather than
+    // showing nothing.
+    const meaningful = activities.filter(
+      (a) => (a.durationMinutes ?? 0) >= 10 || (a.distanceMeters ?? 0) >= 500,
+    );
+    return (meaningful.length > 0 ? meaningful : activities).slice(0, 5);
   }),
 } satisfies TRPCRouterRecord;

--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -461,8 +461,14 @@ export const analyticsRouter = {
       limit: 7,
     });
 
+    // Match the engine's exponentially-weighted sleep-debt convention
+    // (see calculateSleepDebt in @acme/engine). Raw summation produced
+    // physically implausible totals (~17h) for chronically short
+    // sleepers, and `estimateRecoveryTime` then capped at >60 / >120
+    // thresholds anyway. Aligning the metric here keeps the recovery
+    // gauge and the insights card telling the same story.
     const sleepDebtMinutes = recentMetrics.reduce(
-      (sum, m) => sum + (m.sleepDebtMinutes ?? 0),
+      (sum, m, i) => sum + (m.sleepDebtMinutes ?? 0) * Math.pow(0.5, i),
       0,
     );
 

--- a/packages/api/src/router/proactive.ts
+++ b/packages/api/src/router/proactive.ts
@@ -1,8 +1,9 @@
 import type { TRPCRouterRecord } from "@trpc/server";
 import { z } from "zod/v4";
 
-import { and, desc, eq, gte, sql } from "@acme/db";
+import { and, desc, eq, gte, max, sql } from "@acme/db";
 import {
+  Activity,
   AdvancedMetric,
   AiInsight,
   AthleteBaseline,
@@ -487,10 +488,37 @@ export const proactiveRouter = {
       if (unreadOnly) {
         conditions.push(eq(AiInsight.isRead, false));
       }
-      return ctx.db.query.AiInsight.findMany({
-        where: and(...conditions),
-        orderBy: desc(AiInsight.createdAt),
-        limit: 20,
+      const [rows, latestActivity] = await Promise.all([
+        ctx.db.query.AiInsight.findMany({
+          where: and(...conditions),
+          orderBy: desc(AiInsight.createdAt),
+          limit: 20,
+        }),
+        ctx.db
+          .select({ latest: max(Activity.startedAt) })
+          .from(Activity)
+          .where(eq(Activity.userId, userId)),
+      ]);
+
+      // Suppress load-derived insights when a newer activity has landed
+      // since they were generated. ACWR / TSB / ramp-rate snapshots go
+      // stale the moment a new workout syncs, so a "Training Spike"
+      // card showing ACWR 1.27 after the live load has drifted to 1.24
+      // disagrees with the rule-based card on the same page (issue
+      // #129). Sleep / HRV / readiness insights are independent of
+      // activity sync and pass through unchanged.
+      const latestActivityAt = latestActivity[0]?.latest ?? null;
+      if (!latestActivityAt) return rows;
+
+      const LOAD_DERIVED = new Set([
+        "injury_risk",
+        "load_spike",
+        "overreaching",
+        "peaking",
+      ]);
+      return rows.filter((r) => {
+        if (!LOAD_DERIVED.has(r.insightType)) return true;
+        return r.createdAt >= latestActivityAt;
       });
     }),
 

--- a/packages/engine/src/__tests__/sleep-coach.test.ts
+++ b/packages/engine/src/__tests__/sleep-coach.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { DailyMetricInput } from "../types";
+import { calculateSleepDebt } from "../sleep-coach";
+
+function metric(totalSleepMinutes: number | null): DailyMetricInput {
+  return {
+    date: "2026-01-01",
+    sleepScore: null,
+    totalSleepMinutes,
+    deepSleepMinutes: null,
+    remSleepMinutes: null,
+    lightSleepMinutes: null,
+    awakeMinutes: null,
+    hrv: null,
+    restingHr: null,
+    maxHr: null,
+    stressScore: null,
+    bodyBatteryStart: null,
+    bodyBatteryEnd: null,
+    steps: null,
+    calories: null,
+    garminTrainingReadiness: null,
+    garminTrainingLoad: null,
+    respirationRate: null,
+    spo2: null,
+    skinTemp: null,
+    sleepDebtMinutes: null,
+  } as DailyMetricInput;
+}
+
+describe("calculateSleepDebt", () => {
+  it("returns zero when every night meets the target", () => {
+    const metrics = Array.from({ length: 7 }, () => metric(480));
+    expect(calculateSleepDebt(metrics, 480)).toBe(0);
+  });
+
+  it("weights recent shortfalls more than older ones (issue #128)", () => {
+    // 60-minute deficit every single night for a week. The naive
+    // 7-day sum would be 420 min (7h); EW-decay should land ~120 min.
+    const metrics = Array.from({ length: 7 }, () => metric(420));
+    const debt = calculateSleepDebt(metrics, 480);
+    expect(debt).toBeGreaterThanOrEqual(100);
+    expect(debt).toBeLessThanOrEqual(140);
+  });
+
+  it("never reproduces the 1047-minute regression", () => {
+    // The regression scenario: user is 150 minutes short every night.
+    // The bug summed to ~1047 minutes; the fix must stay well below it.
+    const metrics = Array.from({ length: 7 }, () => metric(330));
+    const debt = calculateSleepDebt(metrics, 480);
+    expect(debt).toBeLessThan(500);
+  });
+
+  it("today counts roughly double yesterday", () => {
+    const todayOnly = [
+      metric(380),
+      ...Array.from({ length: 6 }, () => metric(480)),
+    ];
+    const yesterdayOnly = [
+      metric(480),
+      metric(380),
+      ...Array.from({ length: 5 }, () => metric(480)),
+    ];
+    expect(calculateSleepDebt(todayOnly, 480)).toBeGreaterThan(
+      calculateSleepDebt(yesterdayOnly, 480),
+    );
+    // Today's deficit ≈ 2× yesterday's contribution under 0.5^i decay.
+    expect(calculateSleepDebt(todayOnly, 480)).toBe(100);
+    expect(calculateSleepDebt(yesterdayOnly, 480)).toBe(50);
+  });
+
+  it("ignores null sleep data", () => {
+    const metrics = [metric(null), metric(360), metric(null)];
+    // i=1 deficit of 120 min × 0.5 = 60 min.
+    expect(calculateSleepDebt(metrics, 480)).toBe(60);
+  });
+});

--- a/packages/engine/src/sleep-coach/index.ts
+++ b/packages/engine/src/sleep-coach/index.ts
@@ -58,27 +58,33 @@ export function calculateSleepNeed(
 }
 
 /**
- * Calculate cumulative sleep debt over a rolling window.
+ * Calculate sleep debt as an exponentially-weighted rolling deficit.
  *
- * Sleep debt = sum of (need - actual) for days where actual < need.
- * Positive number = minutes of accumulated debt.
+ * Older nightly deficits decay so the number stays in a physiologically
+ * believable range. A raw 7-day sum produced ~17h of "debt" for a user
+ * consistently 2h short — far beyond what the literature supports
+ * (Van Dongen et al. 2003: only ~4-6h of accumulated deficit is
+ * measurable; further restriction degrades performance but the
+ * recoverable "debt" plateaus). We weight day i (0 = most recent) by
+ * 0.5^i so the effective window is ≈3 nights and the same chronic
+ * 2h/night shortfall surfaces as ~240 min rather than ~840 min.
  *
- * Ref: Simpson NS et al. (2016) — Sleep debt accumulates and impairs
- * performance even after "recovery" sleep.
+ * Ref: Van Dongen HPA et al. (2003), Simpson NS et al. (2016).
  */
 export function calculateSleepDebt(
   recentMetrics: DailyMetricInput[], // last 7 days, most recent first
   sleepNeedMinutes: number,
 ): number {
   let debt = 0;
-  for (const m of recentMetrics.slice(0, 7)) {
+  recentMetrics.slice(0, 7).forEach((m, i) => {
     if (
       m.totalSleepMinutes !== null &&
       m.totalSleepMinutes < sleepNeedMinutes
     ) {
-      debt += sleepNeedMinutes - m.totalSleepMinutes;
+      const dailyDeficit = sleepNeedMinutes - m.totalSleepMinutes;
+      debt += dailyDeficit * Math.pow(0.5, i);
     }
-  }
+  });
   return Math.round(debt);
 }
 


### PR DESCRIPTION
Six unrelated data-correctness issues surfaced in the latest screenshot QA pass that share a theme — the UI was faithfully rendering numbers the API/engine had no business producing. Each is fixed in its own producer.

### #128 — Sleep debt showed 1047 min (17h)
`calculateSleepDebt` was a 7-day raw sum, so a user consistently 150 min short surfaced as ~1047 min. Switched to exponentially-weighted rolling deficit (weight = 0.5^i, i=0 most recent) so the metric stays in a physiologically believable ~3-night window.

Mirrored the same decay in `analytics.getRecoveryTime` so the recovery gauge and the insights card tell the same story.

New regression test in `sleep-coach.test.ts` locks the bound at < 500 min even under sustained 150-min/night restriction.

### #129 — ACWR drift on insights page
AI insight cards persist in `ai_insight` until dismissed. A new sync mid-day drifted live ACWR but the cached card kept quoting the older value (1.27 AI card vs 1.24 rule card on the same render). `listInsights` now suppresses load-derived types (`injury_risk`, `load_spike`, `overreaching`, `peaking`) whose `createdAt` is older than `MAX(Activity.startedAt)`. Sleep / HRV / readiness insights pass through unchanged.

### #134 — Walk miscategorised as 5K race
A long brisk walk Garmin had labelled `running` was matching the 5K bucket in `raceHistory` (fitness/page.tsx). Added `avgPaceSecPerKm < 480` (<8:00/km) gate so anything slower than a plausible run pace is rejected regardless of sport-type column.

### #138 — Statistically insignificant correlations
Pairs with `p ≥ 0.05` were rendered as findings, including the HRV → Readiness `r = -0.22, p = 0.456` contradiction. Filter on `p < 0.05` before slicing top six; empty-state copy updated.

### #142 — Mobile heatmap right-half truncated
Inner grid had `overflow-x-auto` but parent flex container was free to grow, so nothing scrolled. Pinned flex parent to `min-w-0` and grid child to `min-w-0 flex-1` so overflow engages on narrow viewports.

### #143 — Saturday walk missing from Recent Activities
Garmin auto-detects 1–3 minute incidental walks. Three of those could push a real 3-hour Saturday walk out of the home carousel. `activity.getRecent` over-fetches 15, filters rows where `durationMinutes < 10` AND `distanceMeters < 500`, then returns top 5. Falls back to raw list if every recent row is incidental.

## Verification
- `pnpm --filter @acme/engine test` — 197 tests pass (5 new in `sleep-coach.test.ts`)
- `pnpm --filter @acme/api test` — 73 tests pass
- `pnpm --filter @acme/engine --filter @acme/api typecheck` — clean
- `pnpm --filter @acme/nextjs typecheck` — 10 pre-existing errors in `vitals/page.tsx` and `garmin-training-summary.tsx`, identical to main; no new errors.

Closes #128
Closes #129
Closes #134
Closes #138
Closes #142
Closes #143