### PR TITLE
fix(journal,power,insights): canonical unique-indexes, sex-aware cycle UI, power empty-state, color polish

### DIFF
--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -631,7 +631,7 @@ export default function InsightsPage() {
                   <p className="text-xl font-bold text-blue-400">
                     {summaryData.totalDays as number}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-300">
+                  <p className="mt-0.5 text-[11px] text-zinc-400">
                     Days tracked
                   </p>
                 </div>
@@ -641,7 +641,7 @@ export default function InsightsPage() {
                   <p className="text-xl font-bold text-green-400">
                     {Math.round(summaryData.avgReadiness as number)}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-300">
+                  <p className="mt-0.5 text-[11px] text-zinc-400">
                     Avg readiness
                   </p>
                 </div>
@@ -651,7 +651,7 @@ export default function InsightsPage() {
                   <p className="text-xl font-bold text-purple-400">
                     {((summaryData.avgSleepMinutes as number) / 60).toFixed(1)}h
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-300">Avg sleep</p>
+                  <p className="mt-0.5 text-[11px] text-zinc-400">Avg sleep</p>
                 </div>
               )}
               {summaryData.avgHrv != null && (
@@ -659,7 +659,7 @@ export default function InsightsPage() {
                   <p className="text-xl font-bold text-pink-400">
                     {Math.round(summaryData.avgHrv as number)}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-300">Avg HRV</p>
+                  <p className="mt-0.5 text-[11px] text-zinc-400">Avg HRV</p>
                 </div>
               )}
             </div>

--- a/apps/nextjs/src/app/journal/page.tsx
+++ b/apps/nextjs/src/app/journal/page.tsx
@@ -215,6 +215,11 @@ export default function JournalPage() {
     trpc.analytics.getCorrelations.queryOptions({ period: "30d" }),
   );
 
+  const profileQuery = useQuery(trpc.profile.get.queryOptions());
+  // Hide cycle tracking UI for male profiles. Female / other / unspecified
+  // users keep the (collapsed-by-default) section visible.
+  const showCycleTracking = profileQuery.data?.sex !== "male";
+
   // Sync form when entry data changes
   const loadedDate = entryQuery.data?.date;
   const [syncedDate, setSyncedDate] = useState<string | null>(null);
@@ -341,7 +346,9 @@ export default function JournalPage() {
       alcoholDrinks: alcoholDrinks ?? undefined,
       napMinutes: napMinutes ?? undefined,
       medications: medications.length ? medications : undefined,
-      menstrualPhase: menstrualPhase ?? undefined,
+      menstrualPhase: showCycleTracking
+        ? (menstrualPhase ?? undefined)
+        : undefined,
     });
   }
 
@@ -609,47 +616,49 @@ export default function JournalPage() {
         </div>
       </div>
 
-      {/* ---- Cycle Section ---- */}
-      <div className="bg-card rounded-2xl border p-4">
-        <button
-          onClick={() => setShowCycle((v) => !v)}
-          className="flex w-full items-center justify-between text-sm font-medium"
-        >
-          <span>🩸 Track cycle</span>
-          <span className="text-muted-foreground text-xs">
-            {showCycle ? "▲ Hide" : "▼ Show"}
-          </span>
-        </button>
+      {/* ---- Cycle Section (hidden for male profiles) ---- */}
+      {showCycleTracking && (
+        <div className="bg-card rounded-2xl border p-4">
+          <button
+            onClick={() => setShowCycle((v) => !v)}
+            className="flex w-full items-center justify-between text-sm font-medium"
+          >
+            <span>🩸 Track cycle</span>
+            <span className="text-muted-foreground text-xs">
+              {showCycle ? "▲ Hide" : "▼ Show"}
+            </span>
+          </button>
 
-        {showCycle && (
-          <div className="mt-4 space-y-3">
-            <p className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-              Menstrual Phase
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {MENSTRUAL_PHASES.map((phase) => (
-                <button
-                  key={phase.key}
-                  onClick={() =>
-                    setMenstrualPhase(
-                      menstrualPhase === phase.key ? null : phase.key,
-                    )
-                  }
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs transition-all",
-                    menstrualPhase === phase.key
-                      ? "border-pink-500/50 bg-pink-500/20 text-pink-400"
-                      : "bg-secondary/50 text-muted-foreground hover:bg-secondary border-transparent",
-                  )}
-                >
-                  <span>{phase.emoji}</span>
-                  <span className="font-medium">{phase.label}</span>
-                </button>
-              ))}
+          {showCycle && (
+            <div className="mt-4 space-y-3">
+              <p className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+                Menstrual Phase
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {MENSTRUAL_PHASES.map((phase) => (
+                  <button
+                    key={phase.key}
+                    onClick={() =>
+                      setMenstrualPhase(
+                        menstrualPhase === phase.key ? null : phase.key,
+                      )
+                    }
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs transition-all",
+                      menstrualPhase === phase.key
+                        ? "border-pink-500/50 bg-pink-500/20 text-pink-400"
+                        : "bg-secondary/50 text-muted-foreground hover:bg-secondary border-transparent",
+                    )}
+                  >
+                    <span>{phase.emoji}</span>
+                    <span className="font-medium">{phase.label}</span>
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
       {/* ---- Save ---- */}
       <Button

--- a/apps/nextjs/src/app/journal/page.tsx
+++ b/apps/nextjs/src/app/journal/page.tsx
@@ -217,8 +217,12 @@ export default function JournalPage() {
 
   const profileQuery = useQuery(trpc.profile.get.queryOptions());
   // Hide cycle tracking UI for male profiles. Female / other / unspecified
-  // users keep the (collapsed-by-default) section visible.
-  const showCycleTracking = profileQuery.data?.sex !== "male";
+  // users keep the (collapsed-by-default) section visible. Wait until the
+  // profile query has resolved so the section doesn't briefly render for
+  // male profiles on initial mount (and so a quick save before profile
+  // arrives can't accidentally persist menstrualPhase data).
+  const showCycleTracking =
+    profileQuery.isSuccess && profileQuery.data?.sex !== "male";
 
   // Sync form when entry data changes
   const loadedDate = entryQuery.data?.date;

--- a/apps/nextjs/src/app/power/page.tsx
+++ b/apps/nextjs/src/app/power/page.tsx
@@ -121,6 +121,15 @@ export default function PowerPage() {
 
   const hasCpData = cp != null && wPrime != null;
 
+  // No power meter detected: every query returned without any power-bearing
+  // data. Render a single explainer rather than three empty-state cards.
+  const hasAnyPowerData =
+    hasCpData ||
+    powerActivities.length > 0 ||
+    pdCurveData.some((d) => d.power != null);
+  const queriesReady = !latest.isLoading && !activities.isLoading;
+  const showNoPowerMeterHero = queriesReady && !hasAnyPowerData;
+
   return (
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">
       {/* ── Header ── */}
@@ -131,246 +140,280 @@ export default function PowerPage() {
         </p>
       </div>
 
-      {/* ── CP Summary ── */}
-      <div className="bg-card rounded-2xl border p-4">
-        <SectionHeader
-          title="Critical Power Summary"
-          info="Critical Power (CP) is the highest sustainable power output. W' (W-prime) is the anaerobic work capacity above CP in kJ. mFTP ≈ 95% CP. Method: 3-parameter CP model from multi-duration best efforts."
-          className="mb-3"
-        />
-        {latest.isLoading ? (
-          <div className="grid grid-cols-3 gap-3">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-muted h-16 animate-pulse rounded-xl" />
-            ))}
-          </div>
-        ) : hasCpData ? (
-          <div className="grid grid-cols-3 gap-3">
-            <div className="bg-secondary/40 rounded-xl p-3 text-center">
-              <p className="text-xl font-bold text-blue-400">
-                {Math.round(cp)}W
-              </p>
-              <p className="text-muted-foreground mt-0.5 text-xs">
-                Critical Power
-              </p>
-            </div>
-            <div className="bg-secondary/40 rounded-xl p-3 text-center">
-              <p className="text-xl font-bold text-purple-400">
-                {wPrime.toFixed(1)}kJ
-              </p>
-              <p className="text-muted-foreground mt-0.5 text-xs">W&apos;</p>
-            </div>
-            <div className="bg-secondary/40 rounded-xl p-3 text-center">
-              <p className="text-xl font-bold text-green-400">
-                {mFtp != null
-                  ? `${Math.round(mFtp)}W`
-                  : `${Math.round(cp * 0.95)}W`}
-              </p>
-              <p className="text-muted-foreground mt-0.5 text-xs">mFTP</p>
-            </div>
-          </div>
-        ) : (
-          <p className="text-muted-foreground py-4 text-center text-sm">
-            Insufficient power data — complete 3+ workouts with a power meter
+      {/* ── No power-meter hero (single explainer, replaces empty sections) ── */}
+      {showNoPowerMeterHero ? (
+        <div className="bg-card rounded-2xl border p-6 text-center">
+          <div className="mb-3 text-4xl">⚡</div>
+          <h2 className="mb-2 text-lg font-semibold">Power meter required</h2>
+          <p className="text-muted-foreground mx-auto max-w-sm text-sm">
+            Power &amp; CP analytics estimate Critical Power, W&apos; and the
+            power-duration curve from workouts captured with a power-meter
+            capable device.
           </p>
-        )}
-      </div>
-
-      {/* ── Power-Duration Curve ── */}
-      <div className="bg-card rounded-2xl border p-4">
-        <SectionHeader
-          title="Power-Duration Curve"
-          info="Best power output at each duration from last 90 days. Uses Normalized Power when available. Each point is the highest power from activities matching that duration ±20%."
-          className="mb-3"
-        />
-        {activities.isLoading ? (
-          <div className="bg-muted h-48 animate-pulse rounded-lg" />
-        ) : pdCurveData.some((d) => d.power != null) ? (
-          <ResponsiveContainer width="100%" height={200}>
-            <LineChart
-              data={pdCurveData}
-              margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" stroke="#333" />
-              <XAxis dataKey="label" tick={{ fill: "#888", fontSize: 10 }} />
-              <YAxis
-                tick={{ fill: "#888", fontSize: 10 }}
-                width={40}
-                unit="W"
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "#18181b",
-                  border: "1px solid #333",
-                  borderRadius: 8,
-                  fontSize: 12,
-                }}
-                formatter={(v: unknown) => `${Math.round(Number(v))} W`}
-              />
-              <Line
-                type="monotone"
-                dataKey="power"
-                stroke="#f97316"
-                strokeWidth={2}
-                dot={{ fill: "#f97316", r: 4 }}
-                connectNulls
-                name="Best Power"
-              />
-              {cp != null && (
-                <Line
-                  type="monotone"
-                  dataKey="cp"
-                  stroke="#3b82f6"
-                  strokeWidth={1.5}
-                  strokeDasharray="6 3"
-                  dot={false}
-                  name="CP"
-                />
-              )}
-            </LineChart>
-          </ResponsiveContainer>
-        ) : (
-          <p className="text-muted-foreground py-8 text-center text-sm">
-            No power data yet — complete rides/runs with a power meter.
+          <p className="text-muted-foreground mx-auto mt-3 max-w-sm text-xs">
+            Compatible sources include cycling power meters (Garmin Rally,
+            Stages, Favero), smart trainers, and running-power pods (Stryd,
+            COROS POD 2, Garmin HRM-Pro). Pair one with your Garmin and complete
+            a few rides or runs &mdash; this page will fill in automatically.
           </p>
-        )}
-      </div>
-
-      {/* ── W' Depletion Chart ── */}
-      {hasCpData && wPrimeData.length > 0 && (
-        <div className="bg-card rounded-2xl border p-4">
-          <SectionHeader
-            title="W′ Depletion Model"
-            info="How quickly W' depletes above CP at various intensities. Formula: t_lim = W' / (Power − CP). At 150% CP, W' depletes in seconds. Use to pace intervals. Citation: Monod & Scherrer (1965), Morton (1996)."
-            className="mb-3"
-          />
-          <ResponsiveContainer width="100%" height={200}>
-            <LineChart margin={{ top: 5, right: 5, left: -5, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#333" />
-              <XAxis
-                type="number"
-                dataKey="t"
-                name="Time"
-                unit="s"
-                tick={{ fill: "#888", fontSize: 10 }}
-                allowDuplicatedCategory={false}
-              />
-              <YAxis
-                tick={{ fill: "#888", fontSize: 10 }}
-                width={36}
-                unit="kJ"
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "#18181b",
-                  border: "1px solid #333",
-                  borderRadius: 8,
-                  fontSize: 12,
-                }}
-                formatter={(v: unknown) => `${Number(v).toFixed(1)} kJ`}
-                labelFormatter={(label) => `Time: ${label}s`}
-              />
-              {wPrimeData.map((series) => (
-                <Line
-                  key={series.key}
-                  data={series.points}
-                  type="monotone"
-                  dataKey="remaining"
-                  stroke={series.color}
-                  strokeWidth={2}
-                  dot={false}
-                  name={series.label}
-                />
-              ))}
-            </LineChart>
-          </ResponsiveContainer>
-          <div className="mt-2 flex flex-wrap gap-3 text-[10px]">
-            {wPrimeData.map((s) => (
-              <span key={s.key} className="flex items-center gap-1">
-                <span
-                  className="inline-block h-0.5 w-5 rounded"
-                  style={{ background: s.color }}
-                />
-                <span className="text-muted-foreground">{s.label}</span>
-              </span>
-            ))}
-          </div>
         </div>
-      )}
-
-      {/* ── Recent Power Activities ── */}
-      <div className="bg-card rounded-2xl border p-4">
-        <SectionHeader
-          title="Recent Power Activities"
-          info="Last 10 activities with power data. Intensity Factor (IF) = NP/FTP. TSS estimate = duration × NP × IF / (FTP × 3600) × 100."
-          className="mb-3"
-        />
-        {activities.isLoading ? (
-          <div className="space-y-2">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-muted h-12 animate-pulse rounded-xl" />
-            ))}
-          </div>
-        ) : powerActivities.length > 0 ? (
-          <div className="space-y-2">
-            {powerActivities.map((act) => {
-              const ftp = mFtp ?? (cp != null ? cp * 0.95 : null);
-              const np = act.normalizedPower ?? act.avgPower ?? 0;
-              const IF = ftp && ftp > 0 ? np / ftp : null;
-              const tssEst =
-                ftp && IF != null && act.durationMinutes
-                  ? Math.round(
-                      ((act.durationMinutes * 60 * np * IF) / (ftp * 3600)) *
-                        100,
-                    )
-                  : null;
-              const intensity =
-                IF == null
-                  ? "text-muted-foreground"
-                  : IF < 0.75
-                    ? "text-blue-400"
-                    : IF < 0.9
-                      ? "text-green-400"
-                      : IF < 1.05
-                        ? "text-yellow-400"
-                        : "text-red-400";
-
-              return (
-                <div
-                  key={act.id}
-                  className="bg-secondary/40 flex items-center justify-between rounded-xl px-3 py-2.5"
-                >
-                  <div>
-                    <p className="text-sm font-medium capitalize">
-                      {act.sportType?.replace(/_/g, " ") ?? "Activity"}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {act.durationMinutes != null
-                        ? fmtDuration(Math.round(act.durationMinutes))
-                        : "—"}
-                      {tssEst != null && ` · TSS ~${tssEst}`}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className={cn("font-bold", intensity)}>
-                      {Math.round(np)} W
-                    </p>
-                    {IF != null && (
-                      <p className="text-muted-foreground text-xs">
-                        IF {IF.toFixed(2)}
-                      </p>
-                    )}
-                  </div>
+      ) : (
+        <>
+          {/* ── CP Summary ── */}
+          <div className="bg-card rounded-2xl border p-4">
+            <SectionHeader
+              title="Critical Power Summary"
+              info="Critical Power (CP) is the highest sustainable power output. W' (W-prime) is the anaerobic work capacity above CP in kJ. mFTP ≈ 95% CP. Method: 3-parameter CP model from multi-duration best efforts."
+              className="mb-3"
+            />
+            {latest.isLoading ? (
+              <div className="grid grid-cols-3 gap-3">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="bg-muted h-16 animate-pulse rounded-xl"
+                  />
+                ))}
+              </div>
+            ) : hasCpData ? (
+              <div className="grid grid-cols-3 gap-3">
+                <div className="bg-secondary/40 rounded-xl p-3 text-center">
+                  <p className="text-xl font-bold text-blue-400">
+                    {Math.round(cp)}W
+                  </p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    Critical Power
+                  </p>
                 </div>
-              );
-            })}
+                <div className="bg-secondary/40 rounded-xl p-3 text-center">
+                  <p className="text-xl font-bold text-purple-400">
+                    {wPrime.toFixed(1)}kJ
+                  </p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    W&apos;
+                  </p>
+                </div>
+                <div className="bg-secondary/40 rounded-xl p-3 text-center">
+                  <p className="text-xl font-bold text-green-400">
+                    {mFtp != null
+                      ? `${Math.round(mFtp)}W`
+                      : `${Math.round(cp * 0.95)}W`}
+                  </p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">mFTP</p>
+                </div>
+              </div>
+            ) : (
+              <p className="text-muted-foreground py-4 text-center text-sm">
+                Insufficient power data — complete 3+ workouts with a power
+                meter
+              </p>
+            )}
           </div>
-        ) : (
-          <p className="text-muted-foreground py-4 text-center text-sm">
-            No power activities found in the last 90 days.
-          </p>
-        )}
-      </div>
+
+          {/* ── Power-Duration Curve ── */}
+          <div className="bg-card rounded-2xl border p-4">
+            <SectionHeader
+              title="Power-Duration Curve"
+              info="Best power output at each duration from last 90 days. Uses Normalized Power when available. Each point is the highest power from activities matching that duration ±20%."
+              className="mb-3"
+            />
+            {activities.isLoading ? (
+              <div className="bg-muted h-48 animate-pulse rounded-lg" />
+            ) : pdCurveData.some((d) => d.power != null) ? (
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart
+                  data={pdCurveData}
+                  margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fill: "#888", fontSize: 10 }}
+                  />
+                  <YAxis
+                    tick={{ fill: "#888", fontSize: 10 }}
+                    width={40}
+                    unit="W"
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#18181b",
+                      border: "1px solid #333",
+                      borderRadius: 8,
+                      fontSize: 12,
+                    }}
+                    formatter={(v: unknown) => `${Math.round(Number(v))} W`}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="power"
+                    stroke="#f97316"
+                    strokeWidth={2}
+                    dot={{ fill: "#f97316", r: 4 }}
+                    connectNulls
+                    name="Best Power"
+                  />
+                  {cp != null && (
+                    <Line
+                      type="monotone"
+                      dataKey="cp"
+                      stroke="#3b82f6"
+                      strokeWidth={1.5}
+                      strokeDasharray="6 3"
+                      dot={false}
+                      name="CP"
+                    />
+                  )}
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-muted-foreground py-8 text-center text-sm">
+                No power data yet — complete rides/runs with a power meter.
+              </p>
+            )}
+          </div>
+
+          {/* ── W' Depletion Chart ── */}
+          {hasCpData && wPrimeData.length > 0 && (
+            <div className="bg-card rounded-2xl border p-4">
+              <SectionHeader
+                title="W′ Depletion Model"
+                info="How quickly W' depletes above CP at various intensities. Formula: t_lim = W' / (Power − CP). At 150% CP, W' depletes in seconds. Use to pace intervals. Citation: Monod & Scherrer (1965), Morton (1996)."
+                className="mb-3"
+              />
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart margin={{ top: 5, right: 5, left: -5, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                  <XAxis
+                    type="number"
+                    dataKey="t"
+                    name="Time"
+                    unit="s"
+                    tick={{ fill: "#888", fontSize: 10 }}
+                    allowDuplicatedCategory={false}
+                  />
+                  <YAxis
+                    tick={{ fill: "#888", fontSize: 10 }}
+                    width={36}
+                    unit="kJ"
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#18181b",
+                      border: "1px solid #333",
+                      borderRadius: 8,
+                      fontSize: 12,
+                    }}
+                    formatter={(v: unknown) => `${Number(v).toFixed(1)} kJ`}
+                    labelFormatter={(label) => `Time: ${label}s`}
+                  />
+                  {wPrimeData.map((series) => (
+                    <Line
+                      key={series.key}
+                      data={series.points}
+                      type="monotone"
+                      dataKey="remaining"
+                      stroke={series.color}
+                      strokeWidth={2}
+                      dot={false}
+                      name={series.label}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+              <div className="mt-2 flex flex-wrap gap-3 text-[10px]">
+                {wPrimeData.map((s) => (
+                  <span key={s.key} className="flex items-center gap-1">
+                    <span
+                      className="inline-block h-0.5 w-5 rounded"
+                      style={{ background: s.color }}
+                    />
+                    <span className="text-muted-foreground">{s.label}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* ── Recent Power Activities ── */}
+          <div className="bg-card rounded-2xl border p-4">
+            <SectionHeader
+              title="Recent Power Activities"
+              info="Last 10 activities with power data. Intensity Factor (IF) = NP/FTP. TSS estimate = duration × NP × IF / (FTP × 3600) × 100."
+              className="mb-3"
+            />
+            {activities.isLoading ? (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="bg-muted h-12 animate-pulse rounded-xl"
+                  />
+                ))}
+              </div>
+            ) : powerActivities.length > 0 ? (
+              <div className="space-y-2">
+                {powerActivities.map((act) => {
+                  const ftp = mFtp ?? (cp != null ? cp * 0.95 : null);
+                  const np = act.normalizedPower ?? act.avgPower ?? 0;
+                  const IF = ftp && ftp > 0 ? np / ftp : null;
+                  const tssEst =
+                    ftp && IF != null && act.durationMinutes
+                      ? Math.round(
+                          ((act.durationMinutes * 60 * np * IF) /
+                            (ftp * 3600)) *
+                            100,
+                        )
+                      : null;
+                  const intensity =
+                    IF == null
+                      ? "text-muted-foreground"
+                      : IF < 0.75
+                        ? "text-blue-400"
+                        : IF < 0.9
+                          ? "text-green-400"
+                          : IF < 1.05
+                            ? "text-yellow-400"
+                            : "text-red-400";
+
+                  return (
+                    <div
+                      key={act.id}
+                      className="bg-secondary/40 flex items-center justify-between rounded-xl px-3 py-2.5"
+                    >
+                      <div>
+                        <p className="text-sm font-medium capitalize">
+                          {act.sportType?.replace(/_/g, " ") ?? "Activity"}
+                        </p>
+                        <p className="text-muted-foreground text-xs">
+                          {act.durationMinutes != null
+                            ? fmtDuration(Math.round(act.durationMinutes))
+                            : "—"}
+                          {tssEst != null && ` · TSS ~${tssEst}`}
+                        </p>
+                      </div>
+                      <div className="text-right">
+                        <p className={cn("font-bold", intensity)}>
+                          {Math.round(np)} W
+                        </p>
+                        {IF != null && (
+                          <p className="text-muted-foreground text-xs">
+                            IF {IF.toFixed(2)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="text-muted-foreground py-4 text-center text-sm">
+                No power activities found in the last 90 days.
+              </p>
+            )}
+          </div>
+        </>
+      )}
 
       <BottomNav />
     </main>

--- a/apps/nextjs/src/app/power/page.tsx
+++ b/apps/nextjs/src/app/power/page.tsx
@@ -121,14 +121,22 @@ export default function PowerPage() {
 
   const hasCpData = cp != null && wPrime != null;
 
-  // No power meter detected: every query returned without any power-bearing
-  // data. Render a single explainer rather than three empty-state cards.
+  // No power meter detected: every query returned successfully without any
+  // power-bearing data. Render a single explainer rather than three empty-
+  // state cards. We require both queries to have resolved successfully —
+  // an error from either should not be silently re-labelled as "no power
+  // meter". On error we fall through to the original sections which have
+  // their own loading / error rendering.
   const hasAnyPowerData =
     hasCpData ||
     powerActivities.length > 0 ||
     pdCurveData.some((d) => d.power != null);
-  const queriesReady = !latest.isLoading && !activities.isLoading;
-  const showNoPowerMeterHero = queriesReady && !hasAnyPowerData;
+  const queriesSettledOk =
+    latest.isSuccess &&
+    activities.isSuccess &&
+    !latest.isError &&
+    !activities.isError;
+  const showNoPowerMeterHero = queriesSettledOk && !hasAnyPowerData;
 
   return (
     <main className="mx-auto max-w-lg space-y-4 px-4 pt-6 pb-24">

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -77,6 +77,8 @@ export const activityRouter = {
           calories: true,
           aerobicTE: true,
           anaerobicTE: true,
+          avgPower: true,
+          normalizedPower: true,
         },
       });
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { pgTable } from "drizzle-orm/pg-core";
+import { pgTable, uniqueIndex } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod/v4";
 
@@ -112,11 +112,7 @@ export const DailyMetric = pgTable(
     rawDataHash: t.varchar({ length: 64 }),
   }),
   (table) => [
-    {
-      name: "daily_metric_user_date_unique",
-      columns: [table.userId, table.date],
-      unique: true,
-    },
+    uniqueIndex("daily_metric_user_date_unique").on(table.userId, table.date),
   ],
 );
 
@@ -212,11 +208,10 @@ export const ReadinessScore = pgTable(
     computedAt: t.timestamp().defaultNow().notNull(),
   }),
   (table) => [
-    {
-      name: "readiness_score_user_date_unique",
-      columns: [table.userId, table.date],
-      unique: true,
-    },
+    uniqueIndex("readiness_score_user_date_unique").on(
+      table.userId,
+      table.date,
+    ),
   ],
 );
 
@@ -308,11 +303,10 @@ export const TrainingStatus = pgTable(
     createdAt: t.timestamp().defaultNow().notNull(),
   }),
   (table) => [
-    {
-      name: "training_status_user_date_unique",
-      columns: [table.userId, table.date],
-      unique: true,
-    },
+    uniqueIndex("training_status_user_date_unique").on(
+      table.userId,
+      table.date,
+    ),
   ],
 );
 
@@ -351,11 +345,7 @@ export const JournalEntry = pgTable(
       .$onUpdateFn(() => new Date()),
   }),
   (table) => [
-    {
-      name: "journal_entry_user_date_unique",
-      columns: [table.userId, table.date],
-      unique: true,
-    },
+    uniqueIndex("journal_entry_user_date_unique").on(table.userId, table.date),
   ],
 );
 
@@ -399,11 +389,10 @@ export const SessionReport = pgTable(
       .$onUpdateFn(() => new Date()),
   }),
   (table) => [
-    {
-      name: "session_report_activity_user_unique",
-      columns: [table.activityId, table.userId],
-      unique: true,
-    },
+    uniqueIndex("session_report_activity_user_unique").on(
+      table.activityId,
+      table.userId,
+    ),
   ],
 );
 
@@ -439,11 +428,11 @@ export const Intervention = pgTable(
       .$onUpdateFn(() => new Date()),
   }),
   (table) => [
-    {
-      name: "intervention_user_date_type_unique",
-      columns: [table.userId, table.date, table.type],
-      unique: true,
-    },
+    uniqueIndex("intervention_user_date_type_unique").on(
+      table.userId,
+      table.date,
+      table.type,
+    ),
   ],
 );
 
@@ -476,11 +465,10 @@ export const AdvancedMetric = pgTable(
     computedAt: t.timestamp().defaultNow().notNull(),
   }),
   (table) => [
-    {
-      name: "advanced_metric_user_date_unique",
-      columns: [table.userId, table.date],
-      unique: true,
-    },
+    uniqueIndex("advanced_metric_user_date_unique").on(
+      table.userId,
+      table.date,
+    ),
   ],
 );
 
@@ -567,11 +555,10 @@ export const AthleteBaseline = pgTable(
     computedAt: t.timestamp().defaultNow().notNull(),
   }),
   (table) => [
-    {
-      name: "athlete_baseline_user_metric_unique",
-      columns: [table.userId, table.metricName],
-      unique: true,
-    },
+    uniqueIndex("athlete_baseline_user_metric_unique").on(
+      table.userId,
+      table.metricName,
+    ),
   ],
 );
 export const CreateAthleteBaselineSchema = createInsertSchema(
@@ -668,11 +655,11 @@ export const AiInsight = pgTable(
       .$onUpdateFn(() => new Date()),
   }),
   (table) => [
-    {
-      name: "ai_insight_user_date_type_unique",
-      columns: [table.userId, table.date, table.insightType],
-      unique: true,
-    },
+    uniqueIndex("ai_insight_user_date_type_unique").on(
+      table.userId,
+      table.date,
+      table.insightType,
+    ),
   ],
 );
 


### PR DESCRIPTION
## Why

Four bugs reported in screenshot-QA:

1. **#150** Journal save fails with 'there is no unique or exclusion constraint matching the ON CONFLICT specification' (42P10). Root cause: nine schema tables declared their table-level uniqueness via a plain '{ name, columns, unique: true }' object literal — a form drizzle-kit silently drops. The addon was already working around this for DailyMetric with a runtime 'ADD CONSTRAINT' in garmin-sync.py; the rest of the tables had no guard.
2. **#151** 🩸 Track cycle accordion shown to male profiles on /journal.
3. **#149** /power renders three identical 'No power data' cards for users without a power meter — useless screen.
4. **#148** Insights → 'This Week' tile sub-labels are too bright ('text-zinc-300') and outshine the bold metric values they describe.

## What

- 'packages/db/src/schema.ts': convert all 9 plain-object table-level
  unique entries to the canonical 'uniqueIndex(name).on(...)' form
  (DailyMetric, ReadinessScore, TrainingStatus, JournalEntry,
  SessionReport, Intervention, AdvancedMetric, AthleteBaseline,
  AiInsight). 'drizzle-kit push --force' (run by the addon at every
  startup) will create the missing indexes on existing installs.
- 'apps/nextjs/src/app/journal/page.tsx': add 'trpc.profile.get'
  query, expose 'showCycleTracking = profile.sex !== "male"',
  conditionally render the cycle section, and scrub 'menstrualPhase'
  from the upsert payload when hidden.
- 'apps/nextjs/src/app/power/page.tsx': add 'showNoPowerMeterHero'
  guard (no CP row + zero power activities + every PD bucket null);
  wrap the three sections in a fragment and replace with a single
  explainer hero.
- 'apps/nextjs/src/app/insights/page.tsx': dim the four sub-labels in
  the 'This Week' card from 'text-zinc-300' to 'text-zinc-400'.

## Verification

- '@acme/db typecheck' ✅
- '@acme/api test' — 73 passed / 10 skipped ✅
- '@acme/engine test' — 197 passed ✅
- '@acme/nextjs typecheck' — same 10 pre-existing errors as 'main'
  (vitals/page.tsx + garmin-training-summary.tsx), no new errors.
- 'pnpm format --write' applied.

## Closes

- Closes #148
- Closes #149
- Closes #150
- Closes #151