### PR TITLE
fix(coach,activities,insights,home): screenshot QA bug bash

### DIFF
--- a/apps/nextjs/src/app/_components/quick-stats.tsx
+++ b/apps/nextjs/src/app/_components/quick-stats.tsx
@@ -63,7 +63,7 @@ export function QuickStats({ stats }: { stats: StatItem[] }) {
             )}
             <p className="text-muted-foreground text-xs">{stat.label}</p>
             {stat.zoneLabel && (
-              <p className={`text-[10px] font-medium ${colors.text}`}>
+              <p className="text-[10px] font-medium text-zinc-400">
                 {stat.zoneLabel}
               </p>
             )}

--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -162,9 +162,14 @@ function getAgentConfig(id: AgentType): AgentConfig {
 function renderMarkdown(text: string) {
   const lines = text.split("\n");
   return lines.map((line, li) => {
+    // Strip leading whitespace before matching block-level markers. LLMs
+    // sometimes indent bullets/headers under a parent list which previously
+    // caused the prefix (`*`, `-`, `### `) to render literally (#153).
+    const trimmed = line.replace(/^\s+/, "");
+
     // Horizontal rule (e.g. "---" / "***" / "___"). Render as a divider
     // instead of leaking the literal text into the response body.
-    if (/^\s*[-*_]{3,}\s*$/.test(line))
+    if (/^[-*_]{3,}\s*$/.test(trimmed))
       return (
         <hr
           key={li}
@@ -174,32 +179,32 @@ function renderMarkdown(text: string) {
       );
 
     // Headers
-    if (line.startsWith("### "))
+    if (trimmed.startsWith("### "))
       return (
         <h4 key={li} className="mt-3 mb-1 text-sm font-bold text-zinc-200">
-          {renderInline(line.slice(4))}
+          {renderInline(trimmed.slice(4))}
         </h4>
       );
-    if (line.startsWith("## "))
+    if (trimmed.startsWith("## "))
       return (
         <h3 key={li} className="mt-3 mb-1 text-sm font-bold text-zinc-100">
-          {renderInline(line.slice(3))}
+          {renderInline(trimmed.slice(3))}
         </h3>
       );
 
     // Bullet lists
-    if (/^[-•*] /.test(line))
+    if (/^[-•*] /.test(trimmed))
       return (
         <li key={li} className="ml-4 list-disc text-sm leading-relaxed">
-          {renderInline(line.replace(/^[-•*] /, ""))}
+          {renderInline(trimmed.replace(/^[-•*] /, ""))}
         </li>
       );
 
     // Numbered lists
-    if (/^\d+\. /.test(line))
+    if (/^\d+\. /.test(trimmed))
       return (
         <li key={li} className="ml-4 list-decimal text-sm leading-relaxed">
-          {renderInline(line.replace(/^\d+\. /, ""))}
+          {renderInline(trimmed.replace(/^\d+\. /, ""))}
         </li>
       );
 
@@ -216,15 +221,21 @@ function renderMarkdown(text: string) {
 }
 
 function renderInline(text: string) {
-  // Bold **text** and _italic_
-  return text.split(/(\*\*[^*]+\*\*|_[^_]+_)/).map((seg, i) => {
+  // Bold **text**, italic _text_ or *text*. LLMs often emit single-asterisk
+  // italics which previously rendered as literal asterisks (#153).
+  // Order matters: try **bold** first so single-asterisk italic doesn't
+  // greedily eat the inner content.
+  return text.split(/(\*\*[^*]+\*\*|\*[^*\n]+\*|_[^_\n]+_)/).map((seg, i) => {
     if (seg.startsWith("**") && seg.endsWith("**"))
       return (
         <strong key={i} className="font-semibold">
           {seg.slice(2, -2)}
         </strong>
       );
-    if (seg.startsWith("_") && seg.endsWith("_"))
+    if (
+      (seg.startsWith("_") && seg.endsWith("_") && seg.length > 2) ||
+      (seg.startsWith("*") && seg.endsWith("*") && seg.length > 2)
+    )
       return (
         <em key={i} className="italic">
           {seg.slice(1, -1)}

--- a/packages/api/src/lib/data-context.ts
+++ b/packages/api/src/lib/data-context.ts
@@ -322,7 +322,7 @@ export async function buildDataContext(
         profile.goals.length > 0
       )
         lines.push(
-          `- Goals: ${profile.goals.map((g) => `${g.sport} ${g.goalType}${g.target ? ` (${g.target})` : ""}`).join("; ")}`,
+          `- Goals: ${profile.goals.map((g) => `${prettySport(g.sport)} ${g.goalType}${g.target ? ` (${g.target})` : ""}`).join("; ")}`,
         );
     }
     if (latestVo2) {
@@ -332,7 +332,7 @@ export async function buildDataContext(
         profile?.sex,
       );
       lines.push(
-        `- VO2max: ${latestVo2.value.toFixed(1)} ml/kg/min (${classification}) [${latestVo2.sport}]`,
+        `- VO2max: ${latestVo2.value.toFixed(1)} ml/kg/min (${classification}) [${prettySport(latestVo2.sport)}]`,
       );
     } else if (profile?.vo2maxRunning) {
       const classification = classifyVO2max(

--- a/packages/api/src/router/activity.ts
+++ b/packages/api/src/router/activity.ts
@@ -82,7 +82,12 @@ export const activityRouter = {
         },
       });
 
-      return activities;
+      // Hide tiny incidental activities (< 10 min AND < 500 m). Garmin's
+      // auto-detected "phantom walks" otherwise dominate the list and
+      // bury real workouts (#158). Same filter as `getRecent` above.
+      return activities.filter(
+        (a) => (a.durationMinutes ?? 0) >= 10 || (a.distanceMeters ?? 0) >= 500,
+      );
     }),
 
   getDetail: protectedProcedure

--- a/packages/api/src/router/trends.ts
+++ b/packages/api/src/router/trends.ts
@@ -103,7 +103,11 @@ export const trendsRouter = {
     .query(async ({ ctx, input }) => {
       const days = input.period === "7d" ? 7 : 28;
       const userId = ctx.session.user.id;
-      const since = getDateString(days);
+      // `gte(date, since)` is inclusive on both ends, so we need to subtract
+      // one day to get exactly `days` calendar dates including today.
+      // Previously: 7d window returned 8 distinct days (#157 — Insights
+      // "This Week" showed "8 days tracked").
+      const since = getDateString(days - 1);
 
       const readinessScores = await ctx.db.query.ReadinessScore.findMany({
         where: and(


### PR DESCRIPTION
Closes #153, #155, #157, #158, #161.

Batched fixes from the 2026-05-18 screenshot QA review.

### Changes
- **Coach markdown (#153)**: `renderMarkdown` now trims leading
  whitespace before testing for headers/lists, so indented bullets no
  longer render their prefix literally. `renderInline` also accepts
  single-asterisk italics (`*foo*`) which LLMs emit more often than
  the underscore form.
- **AI coach context (#155)**: `data-context.ts` now routes sport
  codes from the VO2max source and profile goals through
  `prettySport()`, so internal ids like `Tennis_v2` are humanized
  to `Tennis` before reaching the system prompt.
- **Insights "This Week" (#157)**: `trends.getSummary` uses
  `gte(date, since)` which is inclusive on both ends; for `7d` it
  produced 8 distinct dates. Subtract one day before building the
  bound. Now reports exactly 7.
- **Activities list (#158)**: applied the same <10 min / <500 m
  phantom-walk filter that `activity.getRecent` already uses, so
  Garmin's auto-detected micro-walks stop dominating the page.
- **Home QuickStats (#161)**: dimmed the per-card status sub-label
  ("High Load", "Optimal", etc.) to `text-zinc-400` so the
  metric value stays the primary visual element. Matches the #148
  insights polish.

### Not addressed in this PR
- #154 (VO2max coach vs fitness contradiction) — needs a shared
  `pickBestVO2maxEstimate` helper; will follow in a separate PR.
- #156 (pace/HR `+2.9% decline` sign mismatch) — current zones-page
  code is logically consistent; cannot reproduce, will re-check
  against a fresh capture.
- #159 (activity row "Mon" for Saturday) — likely stale data from
  pre-v0.16.22 sync; needs a one-time backfill rather than a code fix.
- #160 (zone heatmap mobile clipping regression) — needs DOM
  inspection at 360 px; will tackle separately.

### Verification
- `pnpm --filter @acme/api test` → 73 passed.
- `pnpm --filter @acme/nextjs typecheck` → only the 10 known
  pre-existing errors in `vitals/page.tsx` and
  `garmin-training-summary.tsx` (unrelated, baseline).
- `pnpm format --write` → clean.