### PR TITLE
fix(fitness,coach,zones): unify VO2max picker + fix heatmap mobile clipping

### DIFF
--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -975,26 +975,10 @@ function CalendarHeatmap({ data }: { data: CalendarDay[] }) {
   const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
   return (
-    <div className="relative">
-      {/* Month labels */}
-      <div className="mb-1 flex pl-8" style={{ gap: 0 }}>
-        {monthLabels.map((m, i) => (
-          <div
-            key={i}
-            className="text-[10px] text-zinc-500"
-            style={{
-              position: "absolute",
-              left: `${m.col * 14 + 32}px`,
-            }}
-          >
-            {m.label}
-          </div>
-        ))}
-      </div>
-
-      <div className="mt-4 flex min-w-0 gap-0.5">
-        {/* Day labels */}
-        <div className="flex shrink-0 flex-col gap-0.5 pr-1">
+    <div className="relative overflow-x-clip">
+      <div className="flex gap-0.5">
+        {/* Day labels (sticky on the left) */}
+        <div className="flex shrink-0 flex-col gap-0.5 pt-4 pr-1">
           {DAYS.map((d, i) => (
             <div
               key={d}
@@ -1005,39 +989,61 @@ function CalendarHeatmap({ data }: { data: CalendarDay[] }) {
           ))}
         </div>
 
-        {/* Grid */}
-        <div className="flex min-w-0 flex-1 gap-0.5 overflow-x-auto">
-          {weeks.map((week, wIdx) => (
-            <div key={wIdx} className="flex flex-col gap-0.5">
-              {Array.from({ length: 7 }, (_, dIdx) => {
-                const dateStr = week[dIdx];
-                if (!dateStr) {
-                  return <div key={dIdx} className="h-[12px] w-[12px]" />;
-                }
-                const day = dayMap.get(dateStr);
-                const mins = day?.totalMinutes ?? 0;
-                return (
-                  <div
-                    key={dIdx}
-                    className={cn(
-                      "h-[12px] w-[12px] rounded-[2px] transition-colors",
-                      heatColor(mins),
-                    )}
-                    onMouseEnter={(e) => {
-                      const rect = e.currentTarget.getBoundingClientRect();
-                      setTooltip({
-                        x: rect.left + rect.width / 2,
-                        y: rect.top - 4,
-                        day: day ?? null,
-                        date: dateStr,
-                      });
-                    }}
-                    onMouseLeave={() => setTooltip(null)}
-                  />
-                );
-              })}
-            </div>
-          ))}
+        {/* Scrolling region: month labels + grid scroll together so they
+            stay aligned. Previously month labels were absolute-positioned
+            in the outer container and bled past the mobile viewport,
+            causing horizontal page scroll (#160 regression of #142). */}
+        <div className="min-w-0 flex-1 overflow-x-auto">
+          {/* Month labels row */}
+          <div
+            className="relative h-3 text-[10px] text-zinc-500"
+            style={{ width: `${weeks.length * 14}px` }}
+          >
+            {monthLabels.map((m, i) => (
+              <div
+                key={i}
+                className="absolute"
+                style={{ left: `${m.col * 14}px`, top: 0 }}
+              >
+                {m.label}
+              </div>
+            ))}
+          </div>
+
+          {/* Grid */}
+          <div className="mt-1 flex gap-0.5">
+            {weeks.map((week, wIdx) => (
+              <div key={wIdx} className="flex flex-col gap-0.5">
+                {Array.from({ length: 7 }, (_, dIdx) => {
+                  const dateStr = week[dIdx];
+                  if (!dateStr) {
+                    return <div key={dIdx} className="h-[12px] w-[12px]" />;
+                  }
+                  const day = dayMap.get(dateStr);
+                  const mins = day?.totalMinutes ?? 0;
+                  return (
+                    <div
+                      key={dIdx}
+                      className={cn(
+                        "h-[12px] w-[12px] rounded-[2px] transition-colors",
+                        heatColor(mins),
+                      )}
+                      onMouseEnter={(e) => {
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        setTooltip({
+                          x: rect.left + rect.width / 2,
+                          y: rect.top - 4,
+                          day: day ?? null,
+                          date: dateStr,
+                        });
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/packages/api/src/lib/data-context.ts
+++ b/packages/api/src/lib/data-context.ts
@@ -21,6 +21,8 @@ import {
   countConsecutiveHardDays,
 } from "@acme/engine";
 
+import { pickBestVO2maxEstimate } from "./vo2max";
+
 // Drizzle db type — keep generic to avoid coupling to the concrete client
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DB = any;
@@ -204,30 +206,10 @@ export async function buildDataContext(
   ]);
 
   // Pick the best VO2max estimate using the same source priority as the UI
-  // hero card (Garmin Firstbeat > pace+HR > Cooper > UTH). This keeps the AI
-  // agent narrative aligned with the dashboard's "Current VO2max" number.
-  const VO2_SOURCE_PRIORITY: Record<string, number> = {
-    garmin_official: 0,
-    running_pace_hr: 1,
-    cooper: 2,
-    uth_method: 4,
-    uth_ratio: 4,
-  };
-  const latestVo2 =
-    vo2Estimates.length === 0
-      ? undefined
-      : vo2Estimates.reduce((best, e) => {
-          const bp = VO2_SOURCE_PRIORITY[best.source] ?? 3;
-          const ep = VO2_SOURCE_PRIORITY[e.source] ?? 3;
-          if (ep < bp) return e;
-          if (
-            ep === bp &&
-            new Date(e.date).getTime() > new Date(best.date).getTime()
-          ) {
-            return e;
-          }
-          return best;
-        }, vo2Estimates[0]!);
+  // hero card (Garmin Firstbeat > pace+HR > Cooper > UTH). The picker lives
+  // in `./vo2max.ts` so the AI coach narrative stays aligned with the
+  // /fitness dashboard's "Current VO2max" number (#154).
+  const latestVo2 = pickBestVO2maxEstimate(vo2Estimates);
 
   // Early exit if no data at all
   if (!profile && metrics14.length === 0 && activities10.length === 0) {

--- a/packages/api/src/lib/vo2max.ts
+++ b/packages/api/src/lib/vo2max.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared VO2max source-priority logic.
+ *
+ * The DB stores multiple VO2max estimates per user — some from Garmin's
+ * Firstbeat algorithm (synced from Garmin Connect, high accuracy), some
+ * derived from pace+HR data on running activities (good), some from the
+ * Cooper test (okay), and some from the Uth ratio formula (15.3 ×
+ * HRmax/HRrest — overestimates for age > 35, ±5 ml/kg/min, PMC8443998).
+ *
+ * Without a shared helper, the AI coach context (data-context.ts) and
+ * the /fitness "Current VO2max" hero card drifted in priority defaults
+ * and produced contradictory numbers in the same session (#154).
+ */
+
+/** Lower number = higher priority. Defaults to 3 for unknown sources. */
+export const VO2_SOURCE_PRIORITY: Record<string, number> = {
+  garmin_official: 0,
+  running_pace_hr: 1,
+  cooper: 2,
+  uth_method: 4,
+  uth_ratio: 4,
+};
+
+/** Priority for a source string. Unknown sources sort below cooper. */
+export function vo2SourcePriority(source: string | null | undefined): number {
+  if (!source) return 3;
+  return VO2_SOURCE_PRIORITY[source] ?? 3;
+}
+
+interface Vo2Like {
+  date: string;
+  source: string;
+}
+
+/**
+ * Pick the single best estimate from a list using source priority,
+ * breaking ties on newest date. Returns undefined for empty input so
+ * callers can short-circuit on "no data".
+ */
+export function pickBestVO2maxEstimate<T extends Vo2Like>(
+  estimates: readonly T[],
+): T | undefined {
+  if (estimates.length === 0) return undefined;
+  return estimates.reduce((best, e) => {
+    const bp = vo2SourcePriority(best.source);
+    const ep = vo2SourcePriority(e.source);
+    if (ep < bp) return e;
+    if (
+      ep === bp &&
+      new Date(e.date).getTime() > new Date(best.date).getTime()
+    ) {
+      return e;
+    }
+    return best;
+  }, estimates[0]!);
+}

--- a/packages/api/src/router/analytics.ts
+++ b/packages/api/src/router/analytics.ts
@@ -25,6 +25,7 @@ import {
 } from "@acme/engine";
 
 import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
+import { vo2SourcePriority } from "../lib/vo2max";
 import { protectedProcedure } from "../trpc";
 
 function getDateString(daysAgo: number): string {
@@ -221,25 +222,19 @@ export const analyticsRouter = {
       });
 
       // Deduplicate: keep the highest-priority source per date.
-      // Priority: garmin_official > running_pace_hr > cooper > uth_method
-      // Garmin's Firstbeat algorithm (pace+HR during runs) is far more accurate
-      // than the Uth ratio method (±5 ml/kg/min, overestimates for age >35).
-      // Ref: Uth et al. 2004, PMC8443998 (2021 age-correction study)
-      const SOURCE_PRIORITY: Record<string, number> = {
-        garmin_official: 0,
-        running_pace_hr: 1,
-        cooper: 2,
-        uth_method: 3,
-        uth_ratio: 3,
-      };
+      // Priority: garmin_official > running_pace_hr > cooper > UTH.
+      // Garmin's Firstbeat algorithm (pace+HR during runs) is far more
+      // accurate than the Uth ratio method (±5 ml/kg/min, overestimates
+      // for age >35). Ref: Uth et al. 2004, PMC8443998 (2021 study).
+      // Picker logic lives in `lib/vo2max.ts` so the /fitness hero card,
+      // the AI coach data-context, and this list view all agree (#154).
       const bestByDate = new Map<string, (typeof allEstimates)[number]>();
       for (const e of allEstimates) {
         const existing = bestByDate.get(e.date);
-        const ePriority = SOURCE_PRIORITY[e.source] ?? 2;
-        const existingPriority = existing
-          ? (SOURCE_PRIORITY[existing.source] ?? 2)
-          : Infinity;
-        if (ePriority < existingPriority) {
+        if (
+          !existing ||
+          vo2SourcePriority(e.source) < vo2SourcePriority(existing.source)
+        ) {
           bestByDate.set(e.date, e);
         }
       }


### PR DESCRIPTION
Round 2 of the screenshot QA bug bash (follow-up to #162).

Closes #154, #160.

### #154 — VO2max coach narrative vs /fitness hero contradicted each other

The AI coach context and the `analytics.getVO2maxHistory` deduplicator
each had their own copy of the source-priority table with different
defaults:

| | garmin_official | running_pace_hr | cooper | uth_* | unknown |
| --- | --- | --- | --- | --- | --- |
| analytics (old) | 0 | 1 | 2 | 3 | 2 |
| data-context (old) | 0 | 1 | 2 | 4 | 3 |

For a user with a fresh `uth_ratio` row and a slightly older
`garmin_official` row, the two paths could disagree on which estimate
was "best", producing the screenshot bug where the coach said 28.7
while the fitness card said 32.2.

Extracted both into `packages/api/src/lib/vo2max.ts`
(`pickBestVO2maxEstimate`, `vo2SourcePriority`) and wired both
call-sites to it. /fitness's local picker already used the canonical
priorities (uth=4, unknown=3) so no change was needed there.

### #160 — Activity calendar heatmap clipped on mobile (regression of #142)

`#142` added `min-w-0` to the heatmap so the 52-week grid would
scroll horizontally inside its card. That part still worked. But the
month-label row used `position: absolute; left: ${col*14 + 32}px`
in the **outer** `relative` container — so labels for late-year
columns sat ~700 px out, bled past the 360 px viewport, and caused
horizontal **page** scroll on mobile.

Restructured so the month-label row and the day-grid live inside the
same `overflow-x-auto` scroll container. They now scroll together
(better alignment) and never overflow the card. Added
`overflow-x-clip` on the outer wrapper as a regression guard.

### Verification
- `pnpm --filter @acme/api test` → 73 passed.
- `pnpm --filter @acme/nextjs typecheck` → 10 known baseline errors
  only (vitals/page.tsx, garmin-training-summary.tsx — unrelated).
- `pnpm format --write` → clean.