### PR TITLE
fix(sleep): widen Sleep Debt YAxis so 3-digit ticks render fully (#166)

### DIFF
--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -750,7 +750,7 @@ export default function SleepDashboard() {
                   tick={{ fill: "#a1a1aa", fontSize: 11 }}
                   tickLine={false}
                   axisLine={false}
-                  width={35}
+                  width={40}
                   label={{
                     value: "min",
                     angle: -90,


### PR DESCRIPTION
## Root Cause

Recharts' `<YAxis>` allocates a fixed pixel column for tick labels equal to the `width` prop. The Sleep Debt chart had `width={35}`. At `fontSize 11` each digit is roughly 7 px wide, so a 3-digit label like `100` or `150` needs ~21 px of glyph space plus inter-character spacing and axis-line overhead. With width={35} the SVG clip region trimmed the leading digit, rendering `100` as `00`.

## Fix

Increased `width` from `35` to `40` on the Sleep Debt LineChart's `<YAxis>`. This matches the `width={40}` already used for the main sleep-duration AreaChart on the same page.

Only the Sleep Debt chart's YAxis was changed; the other charts on the sleep page were already adequately sized or deal with 2-digit values only.

Closes #166

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>