### PR TITLE
fix(validation): pad page title past fixed menu button (#167)

### DIFF
--- a/apps/nextjs/src/app/validation/page.tsx
+++ b/apps/nextjs/src/app/validation/page.tsx
@@ -157,7 +157,7 @@ export default function ValidationPage() {
         <h1 className="text-foreground pl-12 text-xl font-bold">
           Data Validation
         </h1>
-        <p className="text-muted-foreground mt-0.5 text-sm">
+        <p className="text-muted-foreground mt-0.5 pl-12 text-sm">
           Compare Garmin estimates against reference measurements
         </p>
       </div>

--- a/apps/nextjs/src/app/validation/page.tsx
+++ b/apps/nextjs/src/app/validation/page.tsx
@@ -154,7 +154,9 @@ export default function ValidationPage() {
     <div className="bg-background text-foreground min-h-screen pb-20">
       {/* Header */}
       <div className="bg-card sticky top-0 z-10 border-b px-4 py-4 shadow-sm">
-        <h1 className="text-foreground text-xl font-bold">Data Validation</h1>
+        <h1 className="text-foreground pl-12 text-xl font-bold">
+          Data Validation
+        </h1>
         <p className="text-muted-foreground mt-0.5 text-sm">
           Compare Garmin estimates against reference measurements
         </p>


### PR DESCRIPTION
## Root Cause

The `/validation` page header `<h1>` had no explicit left padding. The hamburger menu button is fixed-positioned at `top-3 left-3` (12 px from the viewport left edge) with dimensions `h-10 w-10` (40 px). This means the button covers viewport x = 12–52 px.

The sticky header container only applies `px-4` (16 px), so the `<h1>` content began at 16 px – well inside the button's footprint. The first ~36 px of the title text was occluded, displaying as `≡ a Validation`.

## Fix

Added `pl-12` (48 px) to the `<h1>` class, placing the text at 16 + 48 = 64 px from the left edge, safely past the 52 px button boundary.

This pattern is already established across the codebase – all other page titles with the shared hamburger menu (sleep, fitness, hrv, training, trends, activities, power, zones, export, settings, etc.) already use `pl-12 text-2xl font-bold`.

## Other pages checked

After grepping for page `<h1>` elements without `pl-12`, `/validation` was the only affected page. All other pages already carry the correct padding.

Closes #167

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
