### PR TITLE
fix(ui): add pl-12 to Activities subtitle, verify Vitals subtitle commas

### DIFF
--- a/apps/nextjs/src/app/activities/page.tsx
+++ b/apps/nextjs/src/app/activities/page.tsx
@@ -122,7 +122,9 @@ export default function ActivitiesPage() {
       {/* Header */}
       <div>
         <h1 className="pl-12 text-2xl font-bold">Activities</h1>
-        <p className="text-muted-foreground text-sm">Your recent workouts</p>
+        <p className="text-muted-foreground pl-12 text-sm">
+          Your recent workouts
+        </p>
       </div>
 
       {/* Sport Filter */}


### PR DESCRIPTION
Fixes activities-page subtitle clipping found in the 2026-05-19 multi-agent screenshot review.

## Change

Added `pl-12` to the `<p>` subtitle on `/activities` so it clears the hamburger menu icon — same fix class as #167 (validation page). The `<h1>` already had the matching padding.

## Vitals (no change)

The original review report flagged the Vitals page subtitle as missing commas. On inspection the commas were already correct in current code — no change needed. Title kept this verify in the message for traceability; PR body now makes the no-op explicit.

Found in: 2026-05-19 multi-agent screenshot review.