### PR TITLE
fix(coach): always show persona tab labels on mobile

### DIFF
--- a/apps/nextjs/src/app/coach/page.tsx
+++ b/apps/nextjs/src/app/coach/page.tsx
@@ -405,7 +405,7 @@ export default function CoachPage() {
             )}
           >
             <span aria-hidden="true">{agent.icon}</span>
-            <span className="ml-1 max-[400px]:hidden">{agent.label}</span>
+            <span className="ml-1">{agent.label}</span>
           </button>
         ))}
       </div>


### PR DESCRIPTION
Summary: Always show coach persona tab text labels on mobile so users can identify each tab.

Closes: N/A

Found in: 2026-05-19 multi-agent screenshot review

Root cause: the persona tab label span used max-[400px]:hidden, which hid labels on viewports ≤400px. Many modern phones use CSS widths in the 360-393px range, leaving only emoji visible. The tab bar already has overflow-x-auto, so wider labeled tabs can scroll without breaking layout.

Screenshot refs: coach-mobile.png