### PR TITLE
fix(training): graceful empty states for Load Focus + 42d charts, fix mobile pill overlap

### DIFF
--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -150,7 +150,7 @@ export default function TrainingLoadPage() {
 
       {/* ── PMC — Performance Management Chart ── */}
       <div className="bg-card rounded-2xl border p-4">
-        <div className="mb-3 flex items-center justify-between">
+        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <SectionHeader
             title="Performance Management Chart"
             info="CTL (Chronic Training Load) = fitness built over 42 days. ATL (Acute Training Load) = fatigue over 7 days. TSB (Training Stress Balance) = CTL - ATL = form. ACWR (Acute:Chronic Workload Ratio) = optimal 0.8–1.3. Citation: Banister (1991), Hulin et al. (2016)."
@@ -371,12 +371,14 @@ export default function TrainingLoadPage() {
         />
         {strainChart.isLoading ? (
           <div className="bg-muted h-48 animate-pulse rounded-lg" />
-        ) : strainChart.data && strainChart.data.length > 0 ? (
+        ) : strainChart.data &&
+          strainChart.data.length > 0 &&
+          strainChart.data.some((d) => (d.value ?? 0) > 0) ? (
           <ResponsiveContainer width="100%" height={200}>
             <AreaChart
               data={strainChart.data.map((d) => ({
                 date: d.date.slice(5),
-                value: d.value ?? 0,
+                value: d.value ?? null,
               }))}
             >
               <defs>
@@ -431,12 +433,14 @@ export default function TrainingLoadPage() {
         />
         {stressChart.isLoading ? (
           <div className="bg-muted h-48 animate-pulse rounded-lg" />
-        ) : stressChart.data && stressChart.data.length > 0 ? (
+        ) : stressChart.data &&
+          stressChart.data.length > 0 &&
+          stressChart.data.some((d) => (d.value ?? 0) > 0) ? (
           <ResponsiveContainer width="100%" height={200}>
             <AreaChart
               data={stressChart.data.map((d) => ({
                 date: d.date.slice(5),
-                value: d.value ?? 0,
+                value: d.value ?? null,
               }))}
             >
               <defs>
@@ -844,7 +848,7 @@ function LoadFocusChart({ focus }: { focus: string }) {
   const focusData = getFocusPieData(focus);
 
   return (
-    <div className="flex flex-col items-center gap-3">
+    <div className="flex w-full flex-col items-center gap-3">
       <ResponsiveContainer width="100%" height={140}>
         <PieChart>
           <Pie


### PR DESCRIPTION
## Summary

Three related rendering bugs on the Training page fixed in a single commit.

**Closes:** N/A
**Found in:** 2026-05-19 multi-agent screenshot review

---

### 2a — Load Focus PieChart renders invisible

The `LoadFocusChart` component wraps its `<ResponsiveContainer width="100%">` inside a `flex flex-col items-center` div. In a Flexbox column with `align-items: center` the flex child has no explicit width anchor, so `width="100%"` resolved to 0px and the Recharts PieChart rendered with zero size — visible only as the label badge at the bottom.

**Fix:** Added `w-full` to the wrapper `<div>` so the `ResponsiveContainer` receives a valid pixel width.

### 2b — Training Strain and Body Stress 42-day charts show axes but no data line

Both AreaCharts render when `data.length > 0` is true, but the data contains entries with `null` values (no HR-based activities → strain=null; no Garmin stress score → stressScore=null). The previous code mapped `null → 0` via `?? 0`, producing an invisible flat line sitting on top of the x-axis.

**Fix:** Added a `.some((d) => (d.value ?? 0) > 0)` guard so the chart only renders when at least one value is non-zero. Values are kept as `null` (not coerced to 0) so Recharts creates clean gaps rather than deceptive zero points. The existing empty-state message is shown when all values are zero/null.

### 2c — PMC time-range pills overlap section header on mobile

The Performance Management Chart header container used `flex items-center justify-between` at all viewport widths. On narrow phones (≤640px) the three pills (42d/90d/180d) pressed against the section title text, causing visual overlap.

**Fix:** Changed the container to `flex-col gap-2` by default with `sm:flex-row sm:items-center sm:justify-between` for wider viewports, so pills stack cleanly below the title on mobile.

---

### Screenshot references
- `tools/screenshots/screenshots/2026-05-19/training-desktop.png`
- `tools/screenshots/screenshots/2026-05-19/training-mobile.png`

### Files changed
- `apps/nextjs/src/app/training/page.tsx` (10 insertions, 6 deletions)