### PR TITLE
fix(trends): add missing stress key and bypass stale matview

### DIFF
--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -317,6 +317,7 @@ export default function TrendsPage() {
       readiness: maps.readiness?.get(date) ?? null,
       sleep: maps.sleep?.get(date) ?? null,
       hrv: maps.hrv?.get(date) ?? null,
+      stress: maps.stress?.get(date) ?? null,
     }));
   }, [
     timezone,

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -219,6 +219,14 @@ export default function TrendsPage() {
     }),
     enabled: useSmoothed,
   });
+  const rollingStress = useQuery({
+    ...trpc.trends.getRollingAverages.queryOptions({
+      metric: "stress",
+      days,
+      window: 7,
+    }),
+    enabled: useSmoothed,
+  });
 
   // ---- Trend analysis per metric ----
   const trendReadiness = useQuery(
@@ -274,15 +282,18 @@ export default function TrendsPage() {
       const readinessArr = rollingReadiness.data ?? [];
       const sleepArr = rollingSleep.data ?? [];
       const hrvArr = rollingHrv.data ?? [];
+      const stressArr = rollingStress.data ?? [];
       const dateSet = new Set<string>();
       readinessArr.forEach((d) => dateSet.add(d.date));
       sleepArr.forEach((d) => dateSet.add(d.date));
       hrvArr.forEach((d) => dateSet.add(d.date));
+      stressArr.forEach((d) => dateSet.add(d.date));
       const dates = [...dateSet].sort();
 
       const readMap = new Map(readinessArr.map((d) => [d.date, d.value]));
       const sleepMap = new Map(sleepArr.map((d) => [d.date, d.value]));
       const hrvMap = new Map(hrvArr.map((d) => [d.date, d.value]));
+      const stressMap = new Map(stressArr.map((d) => [d.date, d.value]));
 
       return dates.map((date) => ({
         date,
@@ -290,6 +301,7 @@ export default function TrendsPage() {
         readiness: readMap.get(date) ?? null,
         sleep: sleepMap.get(date) ?? null,
         hrv: hrvMap.get(date) ?? null,
+        stress: stressMap.get(date) ?? null,
       }));
     }
 
@@ -326,12 +338,14 @@ export default function TrendsPage() {
     rollingReadiness.data,
     rollingSleep.data,
     rollingHrv.data,
+    rollingStress.data,
   ]);
 
   const chartLoading = useSmoothed
     ? rollingReadiness.isLoading ||
       rollingSleep.isLoading ||
-      rollingHrv.isLoading
+      rollingHrv.isLoading ||
+      rollingStress.isLoading
     : multiChart.isLoading;
 
   const s = summary.data;

--- a/packages/api/src/router/trends.ts
+++ b/packages/api/src/router/trends.ts
@@ -11,7 +11,6 @@ import {
   findNotableChanges,
 } from "@acme/engine";
 
-import { getDailySummaryRange } from "../lib/dailySummary";
 import { protectedProcedure } from "../trpc";
 
 type DB = typeof _dependencies_db;
@@ -63,32 +62,51 @@ async function fetchMetricData(
   metric: z.infer<typeof trendMetricEnum>,
   since: string,
 ): Promise<{ date: string; value: number }[]> {
-  // Strain stays activity-derived — daily_athlete_summary doesn't capture
-  // per-activity TRIMP, so we still group from the Activity table.
+  // Strain is activity-derived — the daily_athlete_summary view does not
+  // capture per-activity TRIMP, so we always read from the Activity table.
   if (metric === "strain") {
     return fetchStrainByDate(db, userId, since);
   }
 
-  // Everything else lives on `daily_athlete_summary` (or its live-table
-  // fallback). Single read path means readiness/HRV/sleep/etc. all stay
-  // consistent with whatever the matview last refreshed to.
-  const summary = await getDailySummaryRange(db, userId, since);
+  // Readiness lives in its own table (computed by the readiness engine).
+  // Read it directly — same as getChart does — so the multi-metric overlay
+  // is never affected by a stale or absent daily_athlete_summary matview.
+  if (metric === "readiness") {
+    const scores = await db.query.ReadinessScore.findMany({
+      where: and(
+        eq(ReadinessScore.userId, userId),
+        gte(ReadinessScore.date, since),
+      ),
+      orderBy: asc(ReadinessScore.date),
+    });
+    return scores.map((s) => ({ date: s.date, value: s.score }));
+  }
+
+  // sleep / hrv / restingHr / stress — all live in DailyMetric.
+  // Read directly from the live table (same path as getChart) so the
+  // multi-metric chart never diverges from what individual metric charts show.
+  const metrics = await db.query.DailyMetric.findMany({
+    where: and(
+      eq(DailyMetric.userId, userId),
+      gte(DailyMetric.date, since),
+    ),
+    orderBy: asc(DailyMetric.date),
+  });
 
   const fieldMap: Record<
-    Exclude<z.infer<typeof trendMetricEnum>, "strain">,
-    (row: (typeof summary)[number]) => number | null
+    Exclude<z.infer<typeof trendMetricEnum>, "strain" | "readiness">,
+    (row: (typeof metrics)[number]) => number | null
   > = {
-    readiness: (r) => r.readinessScore,
     sleep: (r) => r.totalSleepMinutes,
     hrv: (r) => r.hrv,
     restingHr: (r) => r.restingHr,
     stress: (r) => r.stressScore,
   };
 
-  const extractor = fieldMap[metric];
-  return summary
+  const extractor = fieldMap[metric as Exclude<z.infer<typeof trendMetricEnum>, "strain" | "readiness">];
+  return metrics
     .filter((r) => extractor(r) !== null)
-    .map((r) => ({ date: r.date, value: extractor(r)! }));
+    .map((r) => ({ date: r.date, value: extractor(r) ?? 0 }));
 }
 
 function getDateString(daysAgo: number): string {

--- a/packages/api/src/router/trends.ts
+++ b/packages/api/src/router/trends.ts
@@ -104,9 +104,10 @@ async function fetchMetricData(
   };
 
   const extractor = fieldMap[metric as Exclude<z.infer<typeof trendMetricEnum>, "strain" | "readiness">];
-  return metrics
-    .filter((r) => extractor(r) !== null)
-    .map((r) => ({ date: r.date, value: extractor(r) ?? 0 }));
+  return metrics.flatMap((r) => {
+    const v = extractor(r);
+    return v != null ? [{ date: r.date, value: v }] : [];
+  });
 }
 
 function getDateString(daysAgo: number): string {
@@ -312,16 +313,50 @@ export const trendsRouter = {
       const userId = ctx.session.user.id;
       const since = getDateString(input.days);
 
-      const entries = await Promise.all(
-        input.metrics.map(async (metric) => {
-          const data = await fetchMetricData(ctx.db, userId, metric, since);
-          return [metric, data] as const;
-        }),
-      );
+      const hasStrain = input.metrics.includes("strain");
+      const nonStrain = input.metrics.filter((m) => m !== "strain");
+      const hasReadiness = nonStrain.includes("readiness");
+      const dailyMetrics = nonStrain.filter((m) => m !== "readiness");
 
-      return Object.fromEntries(entries) as Record<
-        string,
-        { date: string; value: number }[]
-      >;
+      // Fetch live tables once each — avoids N parallel queries for N metrics.
+      const [strainData, readinessRows, dailyRows] = await Promise.all([
+        hasStrain ? fetchStrainByDate(ctx.db, userId, since) : Promise.resolve([]),
+        hasReadiness
+          ? ctx.db.query.ReadinessScore.findMany({
+              where: and(eq(ReadinessScore.userId, userId), gte(ReadinessScore.date, since)),
+              orderBy: asc(ReadinessScore.date),
+            })
+          : Promise.resolve([]),
+        dailyMetrics.length > 0
+          ? ctx.db.query.DailyMetric.findMany({
+              where: and(eq(DailyMetric.userId, userId), gte(DailyMetric.date, since)),
+              orderBy: asc(DailyMetric.date),
+            })
+          : Promise.resolve([]),
+      ]);
+
+      const dailyFieldMap: Record<string, (r: (typeof dailyRows)[number]) => number | null> = {
+        sleep: (r) => r.totalSleepMinutes,
+        hrv: (r) => r.hrv,
+        restingHr: (r) => r.restingHr,
+        stress: (r) => r.stressScore,
+      };
+
+      const entries: [string, { date: string; value: number }[]][] = [];
+
+      if (hasStrain) entries.push(["strain", strainData]);
+      if (hasReadiness)
+        entries.push(["readiness", readinessRows.map((s) => ({ date: s.date, value: s.score }))]);
+      for (const metric of dailyMetrics) {
+        const fn = dailyFieldMap[metric];
+        if (!fn) continue;
+        const series = dailyRows.flatMap((r) => {
+          const v = fn(r);
+          return v != null ? [{ date: r.date, value: v }] : [];
+        });
+        entries.push([metric, series]);
+      }
+
+      return Object.fromEntries(entries) as Record<string, { date: string; value: number }[]>;
     }),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary

Fixes two bugs causing the multi-metric Trends chart to appear blank.

### Bug 1 — Missing `stress` key in chartData builder
The non-smoothed path in `trends/page.tsx` built date-keyed row objects with only `readiness`, `sleep`, and `hrv` — the fourth metric `stress` was never included. Because Recharts' `<Area dataKey="stress">` received `undefined` for every point, the stress line was invisible.

**Fix:** Added `stress: maps.stress?.get(date) ?? null` to the return object in the `chartData` useMemo.

### Bug 2 — Multi-metric endpoint read through stale matview
`fetchMetricData` in `trends.ts` routed all non-strain metrics (readiness, sleep, hrv, stress) through `getDailySummaryRange`, which reads the `daily_athlete_summary` materialised view. When that view is stale or not yet populated the query returns empty arrays, so all four overlay lines disappeared while the individual single-metric charts — which use the live tables — correctly displayed data.

**Fix:** Rewrote `fetchMetricData` to match the pattern used by `getChart`:
- readiness → `ReadinessScore` table
- sleep / hrv / restingHr / stress → `DailyMetric` table

The `getDailySummaryRange` import is no longer needed in `trends.ts` and was removed.

## Files changed
- `apps/nextjs/src/app/trends/page.tsx` — add `stress` to chartData map
- `packages/api/src/router/trends.ts` — bypass matview, read live tables