### PR TITLE
fix(trends): remove verbose 'Week-over-week:' prefix from Notable Changes

### DIFF
--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -719,8 +719,8 @@ export default function TrendsPage() {
                       )}
                       title="Week-over-week percent change (current 7-day avg vs previous 7-day avg)."
                     >
-                      Week-over-week: {nc.change > 0 ? "+" : ""}
-                      {nc.change.toFixed(1)}%
+                      {nc.change > 0 ? "+" : ""}
+                      {nc.change.toFixed(1)}% vs prev week
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

The Notable Changes panel in the Trends page displayed the literal string `Week-over-week:` as a coloured paragraph inside each card, leaking an internal label into the visible UI.

**Before:** `Week-over-week: +10.1%`  
**After:** `+10.1% vs prev week`

The tooltip (`title` attribute) still carries the full descriptive text for assistive technology.