### PR TITLE
fix(vitals): remove duplicate 'Baseline' word in skin-temp subtext

### DIFF
--- a/apps/nextjs/src/app/vitals/page.tsx
+++ b/apps/nextjs/src/app/vitals/page.tsx
@@ -266,7 +266,7 @@ function deviationClass(
 
 function baselineSubtext(metric: VitalMetric): string | undefined {
   if (metric.baseline !== null || metric.baselineDays >= 30) return undefined;
-  return `Baseline still warming up (${metric.baselineDays} days)`;
+  return `Still warming up (${metric.baselineDays} days)`;
 }
 
 function Unit({ unit, className }: { unit: string; className: string }) {


### PR DESCRIPTION
## Summary

The skin-temperature `StatCard` uses `label="Baseline"` and passes a `subtext` from `baselineSubtext()` that also started with the word "Baseline", producing the redundant label:

> **Baseline** — Baseline still warming up (X days)

**Fix:** Changed the subtext to `Still warming up (X days)` so there is no word repetition.