### PR TITLE
fix(readiness): prevent confidence label from wrapping inside ring

### DIFF
--- a/apps/nextjs/src/app/_components/readiness-card.tsx
+++ b/apps/nextjs/src/app/_components/readiness-card.tsx
@@ -185,7 +185,7 @@ export function ReadinessCard({
               {score}
             </span>
             {confidencePct != null && (
-              <span className="text-muted-foreground mt-0.5 text-[9px] tabular-nums">
+              <span className="text-muted-foreground mt-0.5 text-[9px] tabular-nums whitespace-nowrap">
                 {confidencePct}% confidence
               </span>
             )}


### PR DESCRIPTION
## Summary

The `X% confidence` label inside the readiness ring (`h-28 w-28` = 112 px) used no text-wrapping constraint. At narrow viewports the browser could hyphenate or break "confidence" across two lines, which looks broken inside the circular layout.

**Fix:** Added `whitespace-nowrap` to the span so the label always renders on a single line.