### PR TITLE
fix(insights): use explicit dark background for 'This Week' card

### DIFF
--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -619,7 +619,7 @@ export default function InsightsPage() {
             </div>
           </div>
         ) : summaryData ? (
-          <div className="bg-card rounded-2xl border p-4">
+          <div className="bg-zinc-900 rounded-2xl border border-zinc-800 p-4">
             <SectionHeader
               title="This Week"
               info="Weekly summary comparing key metrics against your 30-day personal baselines. Green = better than average, red = below. Method: Current week's mean vs 30-day EMA baseline for each metric (sleep, activity, RHR, stress, HRV). Threshold: >0.5 SD difference flagged. Citation: Individual monitoring using z-scores (Buchheit 2014)."


### PR DESCRIPTION
## Summary

The **This Week** summary card used `bg-card` which resolves to the `--card` CSS custom property. In some mobile browser / PWA contexts this property defaults to the light-theme value (white), rendering a bright white card against the dark `zinc-950` page background.

**Fix:** Replace `bg-card` with the explicit `bg-zinc-900` used everywhere else on the page, and add a `border-zinc-800` border for visual consistency with sibling cards.