### PR TITLE
fix(vitals): clarify SpO2 Low/Critical badge uses absolute threshold

### DIFF
--- a/apps/nextjs/src/app/vitals/page.tsx
+++ b/apps/nextjs/src/app/vitals/page.tsx
@@ -41,13 +41,13 @@ const SPO2_STATUS: StatusConfig = {
     icon: "⚠️",
     label: "Low",
     cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
-    desc: "SpO2 is 90-94%. May indicate altitude, mild illness, or overtraining.",
+    desc: "SpO2 is 90–94% by absolute clinical threshold — this is independent of your personal baseline. May indicate altitude, mild illness, or overtraining.",
   },
   critical: {
     icon: "🚨",
     label: "Critical",
     cls: "bg-red-500/20 text-red-400 border-red-500/30",
-    desc: "SpO2 below 90%. Seek medical attention if persistent.",
+    desc: "SpO2 below 90% by absolute clinical threshold. Seek medical attention if persistent.",
   },
   no_data: {
     icon: "📊",


### PR DESCRIPTION
## Summary

When a user's SpO2 is in the 90–94% range (triggering the **Low** badge) but their deviation vs personal baseline is positive (e.g. `+1.3% above baseline`), the UI appeared contradictory.

The confusion: SpO2 status is evaluated against **absolute clinical thresholds** (Low = 90–94%), while the deviation card is relative to the user's 30-day **personal baseline**.

**Fix:** Update the `low` and `critical` description strings to explicitly state *"by absolute clinical threshold — this is independent of your personal baseline"*.