### PR TITLE
fix(validation): replace sleeping-face emoji with bed emoji for Sleep Lab

### DIFF
--- a/apps/nextjs/src/app/validation/page.tsx
+++ b/apps/nextjs/src/app/validation/page.tsx
@@ -19,7 +19,7 @@ const MEASUREMENT_TYPES = [
   { key: "body_composition", emoji: "⚖️", label: "Body Composition" },
   { key: "chest_strap_hr", emoji: "❤️", label: "Chest Strap HR" },
   { key: "ecg_hrv", emoji: "📊", label: "ECG HRV" },
-  { key: "sleep_lab", emoji: "😴", label: "Sleep Lab" },
+  { key: "sleep_lab", emoji: "🛏️", label: "Sleep Lab" },
 ] as const;
 
 type MeasurementTypeKey = (typeof MEASUREMENT_TYPES)[number]["key"];


### PR DESCRIPTION
## Summary

The Sleep Lab measurement type used the 😴 sleeping-face emoji while all other validation types use science/medical domain icons (🔬🩸⚖️❤️📊). The casual sleeping-face emoji looked inconsistent in a clinical data entry context.

**Fix:** Replace `😴` with `🛏️` (bed), which better represents a formal sleep study while maintaining the same emoji-based approach used across all measurement types.