### PR TITLE
fix(sleep): replace hollow bar with dashed line for sleep Need series

### DIFF
--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -6,6 +6,7 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  ComposedChart,
   Legend,
   Line,
   LineChart,
@@ -655,7 +656,7 @@ export default function SleepDashboard() {
             </p>
           ) : (
             <ResponsiveContainer width="100%" height={220}>
-              <BarChart
+              <ComposedChart
                 data={vsNeedChartData}
                 margin={{ top: 5, right: 5, left: -10, bottom: 0 }}
               >
@@ -704,16 +705,16 @@ export default function SleepDashboard() {
                   radius={[4, 4, 0, 0]}
                   name="actual"
                 />
-                <Bar
+                <Line
+                  type="monotone"
                   dataKey="need"
-                  fill="none"
                   stroke="#eab308"
                   strokeWidth={2}
                   strokeDasharray="4 2"
-                  radius={[4, 4, 0, 0]}
+                  dot={false}
                   name="need"
                 />
-              </BarChart>
+              </ComposedChart>
             </ResponsiveContainer>
           )}
         </div>


### PR DESCRIPTION
## Summary

The **Actual vs Need** chart used a `<BarChart>` with two `<Bar>` components. The Need bar had `fill='none'` and a dashed stroke — a valid SVG trick on desktop, but on mobile viewports the thin dashed outline is invisible, making it appear as if the Need series is missing.

## Change

Replace the `<BarChart>` with a `<ComposedChart>` and split into:
- **Actual sleep** — `<Bar fill='#60a5fa'>` (unchanged)  
- **Sleep need** — `<Line type='monotone' strokeDasharray='4 2' stroke='#eab308'>`

A dashed line is semantically correct (the need is a *target*, not a bar measurement) and is consistently visible on all screen sizes.