### PR TITLE
fix(sleep): propagate null stage durations instead of coercing to zero

### DIFF
--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -40,7 +40,8 @@ function fmtDuration(minutes: number | null | undefined): string {
 }
 
 /** Convert minutes to decimal hours for chart Y-axis */
-function minToHours(min: number): number {
+function minToHours(min: number | null | undefined): number | null {
+  if (min == null) return null;
   return +(min / 60).toFixed(2);
 }
 
@@ -185,11 +186,11 @@ export default function SleepDashboard() {
     const raw = stages.data as
       | {
           date: string;
-          deepMinutes: number;
-          remMinutes: number;
-          lightMinutes: number;
-          awakeMinutes: number;
-          sleepNeedMinutes?: number;
+          deepMinutes: number | null;
+          remMinutes: number | null;
+          lightMinutes: number | null;
+          awakeMinutes: number | null;
+          sleepNeedMinutes?: number | null;
         }[]
       | undefined;
     if (!raw) return [];
@@ -210,7 +211,7 @@ export default function SleepDashboard() {
     () =>
       stagesChartData.length > 0 &&
       stagesChartData.every(
-        (d) => !(d.deep > 0) && !(d.rem > 0) && !(d.light > 0),
+        (d) => !(d.deep != null && d.deep > 0) && !(d.rem != null && d.rem > 0) && !(d.light != null && d.light > 0),
       ),
     [stagesChartData],
   );
@@ -528,7 +529,7 @@ export default function SleepDashboard() {
               />
               {stagesChartData.some((d) => d.need != null) && (
                 <ReferenceLine
-                  y={stagesChartData.find((d) => d.need != null)?.need}
+                  y={stagesChartData.find((d) => d.need != null)?.need ?? undefined}
                   stroke="#eab308"
                   strokeDasharray="6 3"
                   label={{


### PR DESCRIPTION
## Summary

When a device does not record sleep stages, `deepSleepMinutes` etc. are NULL in the DB. The API returns `deepMinutes: null` but the type cast in `stagesChartData` declared them as `number` (hiding the null). `minToHours(null)` then computed `null / 60 = 0` in JavaScript — making all sleep stage bars render at zero height, which looks like an empty/broken chart.

## Changes

- **`minToHours`** — signature extended to `(number | null | undefined) → number | null` so Recharts receives `null` for missing values and renders data-gap segments instead of zero-height bars
- **`stagesChartData` type cast** — stage fields are now typed as `number | null` to surface the real API shape
- **`hasNoSleepStages`** — null-guarded comparisons (`d.deep != null && d.deep > 0`) so the "device not supported" message fires correctly when values are genuinely null vs genuinely zero
- **`ReferenceLine y`** — passes `undefined` instead of `null` when no need value is found (TypeScript `y` prop accepts `number | undefined`, not `number | null`)