### PR TITLE
fix(workout): regenerate recommendation when readiness zone changes

### DIFF
--- a/apps/nextjs/src/app/_components/readiness-card.tsx
+++ b/apps/nextjs/src/app/_components/readiness-card.tsx
@@ -185,7 +185,7 @@ export function ReadinessCard({
               {score}
             </span>
             {confidencePct != null && (
-              <span className="text-muted-foreground mt-0.5 text-[9px] tabular-nums whitespace-nowrap">
+              <span className="text-muted-foreground mt-0.5 text-[9px] whitespace-nowrap tabular-nums">
                 {confidencePct}% confidence
               </span>
             )}

--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -619,7 +619,7 @@ export default function InsightsPage() {
             </div>
           </div>
         ) : summaryData ? (
-          <div className="bg-zinc-900 rounded-2xl border border-zinc-800 p-4">
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4">
             <SectionHeader
               title="This Week"
               info="Weekly summary comparing key metrics against your 30-day personal baselines. Green = better than average, red = below. Method: Current week's mean vs 30-day EMA baseline for each metric (sleep, activity, RHR, stress, HRV). Threshold: >0.5 SD difference flagged. Citation: Individual monitoring using z-scores (Buchheit 2014)."

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -212,7 +212,10 @@ export default function SleepDashboard() {
     () =>
       stagesChartData.length > 0 &&
       stagesChartData.every(
-        (d) => !(d.deep != null && d.deep > 0) && !(d.rem != null && d.rem > 0) && !(d.light != null && d.light > 0),
+        (d) =>
+          !(d.deep != null && d.deep > 0) &&
+          !(d.rem != null && d.rem > 0) &&
+          !(d.light != null && d.light > 0),
       ),
     [stagesChartData],
   );
@@ -530,7 +533,10 @@ export default function SleepDashboard() {
               />
               {stagesChartData.some((d) => d.need != null) && (
                 <ReferenceLine
-                  y={stagesChartData.find((d) => d.need != null)?.need ?? undefined}
+                  y={
+                    stagesChartData.find((d) => d.need != null)?.need ??
+                    undefined
+                  }
                   stroke="#eab308"
                   strokeDasharray="6 3"
                   label={{

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -305,7 +305,7 @@ export default function TrainingLoadPage() {
         {/* Legend */}
         <div className="mt-2 flex flex-wrap gap-3 text-[10px]">
           {[
-          { color: "#60a5fa", label: "CTL (Fitness)" },
+            { color: "#60a5fa", label: "CTL (Fitness)" },
             { color: "#c084fc", label: "ATL (Fatigue)" },
             { color: "#4ade80", label: "TSB (Form)" },
             { color: "#fb923c", label: "ACWR (right)" },

--- a/packages/api/src/router/trends.ts
+++ b/packages/api/src/router/trends.ts
@@ -86,10 +86,7 @@ async function fetchMetricData(
   // Read directly from the live table (same path as getChart) so the
   // multi-metric chart never diverges from what individual metric charts show.
   const metrics = await db.query.DailyMetric.findMany({
-    where: and(
-      eq(DailyMetric.userId, userId),
-      gte(DailyMetric.date, since),
-    ),
+    where: and(eq(DailyMetric.userId, userId), gte(DailyMetric.date, since)),
     orderBy: asc(DailyMetric.date),
   });
 
@@ -103,7 +100,10 @@ async function fetchMetricData(
     stress: (r) => r.stressScore,
   };
 
-  const extractor = fieldMap[metric as Exclude<z.infer<typeof trendMetricEnum>, "strain" | "readiness">];
+  const extractor =
+    fieldMap[
+      metric as Exclude<z.infer<typeof trendMetricEnum>, "strain" | "readiness">
+    ];
   return metrics.flatMap((r) => {
     const v = extractor(r);
     return v != null ? [{ date: r.date, value: v }] : [];
@@ -320,22 +320,33 @@ export const trendsRouter = {
 
       // Fetch live tables once each — avoids N parallel queries for N metrics.
       const [strainData, readinessRows, dailyRows] = await Promise.all([
-        hasStrain ? fetchStrainByDate(ctx.db, userId, since) : Promise.resolve([]),
+        hasStrain
+          ? fetchStrainByDate(ctx.db, userId, since)
+          : Promise.resolve([]),
         hasReadiness
           ? ctx.db.query.ReadinessScore.findMany({
-              where: and(eq(ReadinessScore.userId, userId), gte(ReadinessScore.date, since)),
+              where: and(
+                eq(ReadinessScore.userId, userId),
+                gte(ReadinessScore.date, since),
+              ),
               orderBy: asc(ReadinessScore.date),
             })
           : Promise.resolve([]),
         dailyMetrics.length > 0
           ? ctx.db.query.DailyMetric.findMany({
-              where: and(eq(DailyMetric.userId, userId), gte(DailyMetric.date, since)),
+              where: and(
+                eq(DailyMetric.userId, userId),
+                gte(DailyMetric.date, since),
+              ),
               orderBy: asc(DailyMetric.date),
             })
           : Promise.resolve([]),
       ]);
 
-      const dailyFieldMap: Record<string, (r: (typeof dailyRows)[number]) => number | null> = {
+      const dailyFieldMap: Record<
+        string,
+        (r: (typeof dailyRows)[number]) => number | null
+      > = {
         sleep: (r) => r.totalSleepMinutes,
         hrv: (r) => r.hrv,
         restingHr: (r) => r.restingHr,
@@ -346,7 +357,10 @@ export const trendsRouter = {
 
       if (hasStrain) entries.push(["strain", strainData]);
       if (hasReadiness)
-        entries.push(["readiness", readinessRows.map((s) => ({ date: s.date, value: s.score }))]);
+        entries.push([
+          "readiness",
+          readinessRows.map((s) => ({ date: s.date, value: s.score })),
+        ]);
       for (const metric of dailyMetrics) {
         const fn = dailyFieldMap[metric];
         if (!fn) continue;
@@ -357,6 +371,9 @@ export const trendsRouter = {
         entries.push([metric, series]);
       }
 
-      return Object.fromEntries(entries) as Record<string, { date: string; value: number }[]>;
+      return Object.fromEntries(entries) as Record<
+        string,
+        { date: string; value: number }[]
+      >;
     }),
 } satisfies TRPCRouterRecord;

--- a/packages/api/src/router/workout.ts
+++ b/packages/api/src/router/workout.ts
@@ -37,27 +37,43 @@ export const workoutRouter = {
     const userId = ctx.session.user.id;
     const today = getDateString(0);
 
-    // Check if already generated
-    const existing = await ctx.db.query.DailyWorkout.findFirst({
-      where: and(eq(DailyWorkout.userId, userId), eq(DailyWorkout.date, today)),
-    });
-    if (existing) return existing;
-
-    // Get profile + readiness
-    const profile = await ctx.db.query.Profile.findFirst({
-      where: eq(Profile.userId, userId),
-    });
+    // Get current readiness first — needed to detect stale cache
+    const [existing, profile, readiness] = await Promise.all([
+      ctx.db.query.DailyWorkout.findFirst({
+        where: and(
+          eq(DailyWorkout.userId, userId),
+          eq(DailyWorkout.date, today),
+        ),
+      }),
+      ctx.db.query.Profile.findFirst({
+        where: eq(Profile.userId, userId),
+      }),
+      ctx.db.query.ReadinessScore.findFirst({
+        where: and(
+          eq(ReadinessScore.userId, userId),
+          eq(ReadinessScore.date, today),
+        ),
+      }),
+    ]);
     if (!profile) return null;
-
-    const readiness = await ctx.db.query.ReadinessScore.findFirst({
-      where: and(
-        eq(ReadinessScore.userId, userId),
-        eq(ReadinessScore.date, today),
-      ),
-    });
 
     const zone: ReadinessZone =
       (readiness?.zone as ReadinessZone) ?? "moderate";
+
+    // Return cached row only when the readiness zone it was built with still matches.
+    // Garmin sync can update ReadinessScore after the first load of the day, which
+    // previously caused the home page to show e.g. "High readiness" (ring) alongside
+    // a stale "Moderate / -10% volume" workout built from an earlier lower score.
+    if (existing?.readinessZoneUsed === zone) return existing;
+
+    // Stale or missing — delete the old row (if any) then regenerate below.
+    if (existing) {
+      await ctx.db
+        .delete(DailyWorkout)
+        .where(
+          and(eq(DailyWorkout.userId, userId), eq(DailyWorkout.date, today)),
+        );
+    }
 
     // Get recent strain for hard day stacking check
     const recentActivities = await ctx.db.query.Activity.findMany({


### PR DESCRIPTION
## Bug 10 — Home readiness contradiction

### Problem
After a Garmin sync mid-day, `ReadinessScore.zone` can shift (e.g. `moderate` → `high`).  
The home page readiness ring re-reads `ReadinessScore` fresh, so it shows the updated zone (e.g. **High**).  
But `workout.getToday` returned the first `DailyWorkout` row that was inserted that morning — built against the old zone — so the workout tile still showed **"Moderate / -10% volume"**.

### Root cause
`getToday` cached the first row for the day unconditionally (`if (existing) return existing`), ignoring subsequent changes to readiness.

### Fix
- Fetch `DailyWorkout`, `Profile`, and `ReadinessScore` in parallel (no extra round-trip).
- Compare `existing.readinessZoneUsed` against the current zone.
- Return the cached row only when the zones match.
- Otherwise delete the stale row and regenerate, so the explanation always reflects the displayed zone.

### Testing
- `pnpm -F @acme/api lint` — 0 errors.
- Manual: insert a `DailyWorkout` with `readinessZoneUsed = 'moderate'` then update `ReadinessScore.zone` to `'high'` — `getToday` now returns a freshly generated high-readiness workout.