### PR TITLE
fix(zones): wrap legend labels on mobile and fix efficiency subtitle sign

### DIFF
--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -436,7 +436,7 @@ export default function ZoneAnalysisPage() {
                     ? (ZONE_LABELS[value] ?? value)
                     : String(value)
                 }
-                wrapperStyle={{ fontSize: 11 }}
+                wrapperStyle={{ fontSize: 11, flexWrap: "wrap" }}
               />
               {(["z1", "z2", "z3", "z4", "z5"] as const).map((z) => (
                 <Bar
@@ -528,7 +528,7 @@ export default function ZoneAnalysisPage() {
                   return [`${v}%`, n];
                 }}
               />
-              <Legend wrapperStyle={{ fontSize: 11 }} />
+              <Legend wrapperStyle={{ fontSize: 11, flexWrap: "wrap" }} />
               <ReferenceLine
                 yAxisId="pi"
                 y={2.0}
@@ -650,7 +650,7 @@ export default function ZoneAnalysisPage() {
                   const v = String(value);
                   return ZONE_LABELS[v.replace("Pct", "")] ?? v;
                 }}
-                wrapperStyle={{ fontSize: 11 }}
+                wrapperStyle={{ fontSize: 11, flexWrap: "wrap" }}
               />
               {(["z1Pct", "z2Pct", "z3Pct", "z4Pct", "z5Pct"] as const).map(
                 (key) => {
@@ -686,8 +686,8 @@ export default function ZoneAnalysisPage() {
         />
         {efficiencyTrendLine && (
           <p className="text-muted-foreground mb-3 text-[11px]">
-            {efficiencyTrendLine.pctImprovement >= 0 ? "↑" : "↓"}{" "}
-            {Math.abs(efficiencyTrendLine.pctImprovement).toFixed(1)}%{" "}
+            {efficiencyTrendLine.pctImprovement >= 0 ? "+" : ""}
+            {efficiencyTrendLine.pctImprovement.toFixed(1)}%{" "}
             {efficiencyTrendLine.pctImprovement >= 0
               ? "improvement"
               : "decline"}{" "}
@@ -845,7 +845,7 @@ export default function ZoneAnalysisPage() {
                   const v = String(value);
                   return v.charAt(0).toUpperCase() + v.slice(1);
                 }}
-                wrapperStyle={{ fontSize: 11 }}
+                wrapperStyle={{ fontSize: 11, flexWrap: "wrap" }}
               />
               {Object.entries(SPORT_COLORS).map(([key, color]) => (
                 <Bar


### PR DESCRIPTION
## Summary

Closes #133, closes #156

### Issue #133 — Zone 5 legend clipped on mobile

All four Recharts `<Legend>` components in `zones/page.tsx` lacked
`flexWrap` on their `wrapperStyle`, causing the rightmost zone label
(`Zone 5 — VO2max`) to overflow and be clipped on mobile viewports
(~375 px wide). Added `flexWrap: "wrap"` so labels reflow to a
second line when the container is too narrow.

Affected charts:
- Weekly Time In Zones
- Training Polarization (Seiler 80/20 Model)
- Monthly Zone Distribution
- Volume by Sport Type

### Issue #156 — Efficiency subtitle sign contradicts label

Replaced the directional `↑`/`↓` arrow with an explicit `+` prefix
(positive values) and the raw `toFixed(1)` sign (negative values → `-`).
The label word (`improvement` / `decline`) is still derived from the
same `pctImprovement >= 0` check, so sign and word can never contradict:

| Before | After |
|--------|-------|
| `↑ 2.9% improvement over this period` | `+2.9% improvement over this period` |
| `↓ 2.9% decline over this period` | `-2.9% decline over this period` |

## Testing

- All 197 engine unit tests pass
- format, lint, typecheck, test-nextjs all pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>