### PR TITLE
fix(trends): use red for stress line in multi-metric chart

### DIFF
--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -41,7 +41,7 @@ const METRIC_COLORS: Record<string, string> = {
   hrv: "#a855f7",
   strain: "#ef4444",
   restingHr: "#f59e0b",
-  stress: "#3b82f6",
+  stress: "#f43f5e",
 };
 
 const METRIC_LABELS: Record<string, string> = {


### PR DESCRIPTION
Stress and sleep both used `#3b82f6` (blue), making them indistinguishable when overlaid in the Multi-metric Trend chart on the Trends page.

Switch stress to rose-500 (`#f43f5e`) — clearly red while staying distinct from strain's `#ef4444` so charts that overlay both stay readable.

Closes nothing (drive-by polish requested in screenshot review batch 2026-05-21).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>