### PR TITLE
fix(insights): use theme colors for week summary

### DIFF
--- a/apps/nextjs/src/app/insights/page.tsx
+++ b/apps/nextjs/src/app/insights/page.tsx
@@ -619,7 +619,7 @@ export default function InsightsPage() {
             </div>
           </div>
         ) : summaryData ? (
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-4">
+          <div className="bg-card rounded-2xl border p-4">
             <SectionHeader
               title="This Week"
               info="Weekly summary comparing key metrics against your 30-day personal baselines. Green = better than average, red = below. Method: Current week's mean vs 30-day EMA baseline for each metric (sleep, activity, RHR, stress, HRV). Threshold: >0.5 SD difference flagged. Citation: Individual monitoring using z-scores (Buchheit 2014)."
@@ -627,39 +627,43 @@ export default function InsightsPage() {
             />
             <div className="grid grid-cols-3 gap-3">
               {summaryData.totalDays != null && (
-                <div className="rounded-xl bg-zinc-800/60 p-3 text-center">
+                <div className="bg-muted/60 rounded-xl p-3 text-center">
                   <p className="text-xl font-bold text-blue-400">
                     {summaryData.totalDays as number}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-400">
+                  <p className="text-foreground/80 mt-0.5 text-[11px]">
                     Days tracked
                   </p>
                 </div>
               )}
               {summaryData.avgReadiness != null && (
-                <div className="rounded-xl bg-zinc-800/60 p-3 text-center">
+                <div className="bg-muted/60 rounded-xl p-3 text-center">
                   <p className="text-xl font-bold text-green-400">
                     {Math.round(summaryData.avgReadiness as number)}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-400">
+                  <p className="text-foreground/80 mt-0.5 text-[11px]">
                     Avg readiness
                   </p>
                 </div>
               )}
               {summaryData.avgSleepMinutes != null && (
-                <div className="rounded-xl bg-zinc-800/60 p-3 text-center">
+                <div className="bg-muted/60 rounded-xl p-3 text-center">
                   <p className="text-xl font-bold text-purple-400">
                     {((summaryData.avgSleepMinutes as number) / 60).toFixed(1)}h
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-400">Avg sleep</p>
+                  <p className="text-foreground/80 mt-0.5 text-[11px]">
+                    Avg sleep
+                  </p>
                 </div>
               )}
               {summaryData.avgHrv != null && (
-                <div className="rounded-xl bg-zinc-800/60 p-3 text-center">
+                <div className="bg-muted/60 rounded-xl p-3 text-center">
                   <p className="text-xl font-bold text-pink-400">
                     {Math.round(summaryData.avgHrv as number)}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-zinc-400">Avg HRV</p>
+                  <p className="text-foreground/80 mt-0.5 text-[11px]">
+                    Avg HRV
+                  </p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- replace hardcoded zinc surfaces in the This Week card with bg-card, border, and bg-muted/60
- keep intentional colored metric values
- raise labels to theme-aware foreground text for better small-text contrast in dark and light themes

## Validation
- pnpm typecheck
- pnpm --filter @acme/nextjs lint
- pnpm lint currently fails before completion because @acme/engine and @acme/garmin cannot find eslint in this checkout