### PR TITLE
feat(zones): data-driven sport dropdown covers every logged sport

### DIFF
--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -27,7 +27,6 @@ import { SectionHeader } from "../_components/info-button";
 /* ─────────────── constants ─────────────── */
 
 type Period = "90d" | "180d" | "365d";
-type Sport = "all" | "running" | "walking";
 
 const PERIODS: { value: Period; label: string; days: number }[] = [
   { value: "90d", label: "90 D", days: 90 },
@@ -35,11 +34,17 @@ const PERIODS: { value: Period; label: string; days: number }[] = [
   { value: "365d", label: "1 Y", days: 365 },
 ];
 
-const SPORTS: { value: Sport; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "running", label: "Running" },
-  { value: "walking", label: "Walking" },
-];
+// Title-case a raw Garmin sportType string for display:
+//   "strength_training" -> "Strength Training"
+//   "lap_swimming"      -> "Lap Swimming"
+//   "running"           -> "Running"
+function formatSportLabel(sportType: string): string {
+  return sportType
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
 
 const ZONE_COLORS: Record<string, string> = {
   z1: "#94a3b8",
@@ -207,12 +212,28 @@ function CardSkeleton() {
 
 export default function ZoneAnalysisPage() {
   const [period, setPeriod] = useState<Period>("365d");
-  const [sport, setSport] = useState<Sport>("all");
+  // "all" sentinel selects every sportType (no filter applied).
+  // Any other value is the raw Garmin sportType string ("running",
+  // "tennis", "strength_training", "lap_swimming", …) populated
+  // from the listSportTypes query below.
+  const [sport, setSport] = useState<string>("all");
   const periodConfig = PERIODS.find((p) => p.value === period);
   const days = periodConfig?.days ?? 365;
   const sportType = sport === "all" ? undefined : sport;
 
   const trpc = useTRPC();
+
+  // Drive the dropdown from the user's actual activity log over
+  // the selected window — sports they've never done don't appear,
+  // sports they do (tennis, swimming, hiking, …) do.
+  const sportTypes = useQuery(trpc.zones.listSportTypes.queryOptions({ days }));
+  const sportOptions = useMemo(() => {
+    const fromDb = (sportTypes.data ?? []).map((s) => ({
+      value: s.sportType,
+      label: `${formatSportLabel(s.sportType)} (${s.count})`,
+    }));
+    return [{ value: "all", label: "All sports" }, ...fromDb];
+  }, [sportTypes.data]);
 
   /* ── queries ── */
   const weeklyZones = useQuery(
@@ -520,21 +541,22 @@ export default function ZoneAnalysisPage() {
             </button>
           ))}
         </div>
-        <div className="flex gap-1 rounded-lg bg-zinc-800 p-1">
-          {SPORTS.map((s) => (
-            <button
-              key={s.value}
-              onClick={() => setSport(s.value)}
-              className={cn(
-                "rounded-md px-3 py-1 text-xs font-medium transition-colors",
-                sport === s.value
-                  ? "bg-zinc-600 text-white"
-                  : "text-zinc-400 hover:text-zinc-200",
-              )}
-            >
-              {s.label}
-            </button>
-          ))}
+        <div className="rounded-lg bg-zinc-800 p-1">
+          <select
+            value={sport}
+            onChange={(e) => setSport(e.target.value)}
+            className={cn(
+              "appearance-none rounded-md bg-zinc-700 px-3 py-1 text-xs font-medium text-white",
+              "focus:ring-2 focus:ring-zinc-500 focus:outline-none",
+            )}
+            aria-label="Filter by sport"
+          >
+            {sportOptions.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
 

--- a/packages/api/src/router/zones.ts
+++ b/packages/api/src/router/zones.ts
@@ -67,6 +67,37 @@ function normalizeSportType(
 }
 
 export const zonesRouter = {
+  // Distinct sportType strings the user has logged in the window,
+  // each paired with how many activities they've done of that
+  // sport. Powers the Zones page sport dropdown — replaces the
+  // previous hardcoded "all / running / walking" list so users
+  // who do tennis, swimming, strength, hiking, etc see those
+  // sports in the dropdown automatically.
+  listSportTypes: protectedProcedure
+    .input(
+      z
+        .object({
+          days: z.number().min(1).max(730).default(365),
+        })
+        .default({ days: 365 }),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const since = getDateAgo(input.days);
+      const activities = await ctx.db.query.Activity.findMany({
+        where: and(eq(Activity.userId, userId), gte(Activity.startedAt, since)),
+        columns: { sportType: true },
+      });
+      const counts = new Map<string, number>();
+      for (const a of activities) {
+        if (!a.sportType) continue;
+        counts.set(a.sportType, (counts.get(a.sportType) ?? 0) + 1);
+      }
+      return [...counts.entries()]
+        .map(([sportType, count]) => ({ sportType, count }))
+        .sort((a, b) => b.count - a.count);
+    }),
+
   getWeeklyZoneDistribution: protectedProcedure
     .input(
       z.object({


### PR DESCRIPTION
**Why**

User asked on 2026-05-22: 'for the Zone Analysis → HR zone distribution, polarization tracking, and efficiency trends, can i choose the activity like tennis or something else through a drop down? presently there are only three options.'

The page hardcoded `'All' / 'Running' / 'Walking'` even though the underlying tRPC procedures accept any `sportType` string.

**What**

- New `zones.listSportTypes` procedure — returns distinct `sportType` strings the user has logged in the selected window, paired with activity counts, sorted by count desc.
- The pill row is replaced with a `<select>` populated from that query. Sports the user has never done don't appear; sports they do (any Garmin sport — tennis, hiking, swimming, strength_training, cycling, …) appear automatically with counts.
- Behaviour for the polarization/efficiency charts is unchanged — they still fall back to 'running' when 'All sports' is selected (polarization only makes sense for one sport).

**Display formatting:** raw Garmin `sportType` strings are title-cased for display (`strength_training` → `Strength Training`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>