### PR TITLE
feat(engine): add daily-recommendation rules-first module

### DIFF
--- a/packages/engine/src/daily-recommendation/__tests__/daily-recommendation.test.ts
+++ b/packages/engine/src/daily-recommendation/__tests__/daily-recommendation.test.ts
@@ -256,7 +256,7 @@ const fixtures: Array<{
       intensity: "easy",
       workoutType: "steady_run",
       hardBlocks: [],
-      firedRules: ["intervention-recent-respects", "plan-honored-when-safe"],
+      firedRules: ["intervention-recent-respects"],
     },
   },
   {
@@ -269,7 +269,7 @@ const fixtures: Array<{
       intensity: "moderate",
       workoutType: "tempo",
       hardBlocks: [],
-      firedRules: ["intervention-recent-respects", "plan-honored-when-safe"],
+      firedRules: ["intervention-recent-respects"],
     },
   },
   {
@@ -446,5 +446,53 @@ describe("recommendDay", () => {
         severity: "block",
       }),
     );
+  });
+
+  // Regression: PR #206 Copilot review — race-week-protects-taper fires on
+  // race day (raceDateDaysAway === 0) and previously downgraded the planned
+  // race itself from hard to moderate, defeating the race-day branch.
+  it("race day with planned race workout keeps hard intensity", () => {
+    const result = recommendDay(
+      makeInput({
+        raceDateDaysAway: 0,
+        weeklyPlan: {
+          plannedToday: {
+            workoutType: "race",
+            intensity: "hard",
+            durationMin: 90,
+          },
+          sessionsThisWeek: 3,
+          plannedThisWeek: 5,
+        },
+      }),
+    );
+
+    expect(result.action).toBe("workout");
+    expect(result.workoutType).toBe("race");
+    expect(result.intensity).toBe("hard");
+  });
+
+  // Regression: PR #206 Copilot review — plan-honored-when-safe must not fire
+  // when warning rules will subsequently downgrade the planned intensity,
+  // otherwise the audit trace contradicts the actual recommendation.
+  it("plan-honored-when-safe does not fire when warns will downgrade plan", () => {
+    const result = recommendDay(
+      makeInput({
+        recentInterventions: [{ type: "physio", date: "2026-04-09" }],
+      }),
+    );
+
+    const planHonored = result.rules.find(
+      (rule) => rule.ruleId === "plan-honored-when-safe",
+    );
+    expect(planHonored).toBeDefined();
+    expect(planHonored?.fired).toBe(false);
+
+    // And the intensity should actually be downgraded by the intervention rule.
+    const interventionRule = result.rules.find(
+      (rule) => rule.ruleId === "intervention-recent-respects",
+    );
+    expect(interventionRule?.fired).toBe(true);
+    expect(result.intensity).not.toBe("hard");
   });
 });

--- a/packages/engine/src/daily-recommendation/__tests__/daily-recommendation.test.ts
+++ b/packages/engine/src/daily-recommendation/__tests__/daily-recommendation.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it } from "vitest";
+
+import type { DailyRecommendationInput } from "..";
+import { recommendDay } from "..";
+
+type InputOverrides = Partial<
+  Omit<DailyRecommendationInput, "readiness" | "load" | "weeklyPlan">
+> & {
+  readiness?: DailyRecommendationInput["readiness"];
+  load?: Partial<DailyRecommendationInput["load"]>;
+  weeklyPlan?: DailyRecommendationInput["weeklyPlan"];
+};
+
+type ExpectedRecommendation = {
+  action: DailyRecommendationInput["weeklyPlan"] extends infer _Plan
+    ? ReturnType<typeof recommendDay>["action"]
+    : never;
+  intensity?: ReturnType<typeof recommendDay>["intensity"];
+  workoutType?: string;
+  hardBlocks: string[];
+  firedRules: string[];
+  maxConfidence?: number;
+  reasonIncludes?: string;
+};
+
+function makeInput(overrides: InputOverrides = {}): DailyRecommendationInput {
+  const base: DailyRecommendationInput = {
+    date: "2026-04-10",
+    readiness: {
+      score: 82,
+      zone: "optimal",
+      hrvDeviation: 0.4,
+      sleepDebtMin: 0,
+    },
+    load: {
+      acwr: 1.0,
+      tsb: 5,
+      consecutiveHardDays: 0,
+    },
+    weeklyPlan: {
+      plannedToday: {
+        workoutType: "tempo",
+        intensity: "hard",
+        durationMin: 50,
+      },
+      sessionsThisWeek: 2,
+      plannedThisWeek: 5,
+    },
+    recentInterventions: [],
+    raceDateDaysAway: null,
+    baseline: { restDaysPerWeek: 2 },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    readiness:
+      overrides.readiness === undefined ? base.readiness : overrides.readiness,
+    load: { ...base.load, ...overrides.load },
+    weeklyPlan:
+      overrides.weeklyPlan === undefined
+        ? base.weeklyPlan
+        : overrides.weeklyPlan,
+  };
+}
+
+function firedRuleIds(input: DailyRecommendationInput): string[] {
+  return recommendDay(input)
+    .rules.filter((rule) => rule.fired)
+    .map((rule) => rule.ruleId);
+}
+
+const fixtures: Array<{
+  name: string;
+  input: DailyRecommendationInput;
+  expected: ExpectedRecommendation;
+}> = [
+  {
+    name: "optimal day honors the hard plan",
+    input: makeInput(),
+    expected: {
+      action: "workout",
+      intensity: "hard",
+      workoutType: "tempo",
+      hardBlocks: [],
+      firedRules: ["plan-honored-when-safe"],
+    },
+  },
+  {
+    name: "low readiness alone downgrades hard plan to easy",
+    input: makeInput({
+      readiness: {
+        score: 49,
+        zone: "balanced",
+        hrvDeviation: 0,
+        sleepDebtMin: 0,
+      },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "tempo",
+      hardBlocks: ["low-readiness-blocks-hard"],
+      firedRules: ["low-readiness-blocks-hard"],
+    },
+  },
+  {
+    name: "compromised readiness downgrades moderate plan to easy",
+    input: makeInput({
+      readiness: {
+        score: 60,
+        zone: "compromised",
+        hrvDeviation: 0,
+        sleepDebtMin: 0,
+      },
+      weeklyPlan: {
+        plannedToday: {
+          workoutType: "steady_run",
+          intensity: "moderate",
+          durationMin: 45,
+        },
+        sessionsThisWeek: 2,
+        plannedThisWeek: 5,
+      },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "steady_run",
+      hardBlocks: ["low-readiness-blocks-hard"],
+      firedRules: ["low-readiness-blocks-hard"],
+    },
+  },
+  {
+    name: "HRV suppression and ACWR spike force active recovery",
+    input: makeInput({
+      readiness: {
+        score: 70,
+        zone: "balanced",
+        hrvDeviation: -1.6,
+        sleepDebtMin: 0,
+      },
+      load: { acwr: 1.6 },
+    }),
+    expected: {
+      action: "active_recovery",
+      intensity: "easy",
+      workoutType: "yoga",
+      hardBlocks: ["hrv-suppressed-blocks-hard", "acwr-spike-blocks-hard"],
+      firedRules: ["hrv-suppressed-blocks-hard", "acwr-spike-blocks-hard"],
+    },
+  },
+  {
+    name: "race day without a plan rests",
+    input: makeInput({ raceDateDaysAway: 0, weeklyPlan: null }),
+    expected: {
+      action: "rest",
+      workoutType: "rest",
+      hardBlocks: ["race-week-protects-taper", "race-day-rest"],
+      firedRules: ["race-week-protects-taper", "race-day-rest"],
+    },
+  },
+  {
+    name: "race week hard plan downgrades to easy",
+    input: makeInput({ raceDateDaysAway: 5 }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "easy_run",
+      hardBlocks: ["race-week-protects-taper"],
+      firedRules: ["race-week-protects-taper"],
+    },
+  },
+  {
+    name: "race week easy plan remains easy",
+    input: makeInput({
+      raceDateDaysAway: 5,
+      weeklyPlan: {
+        plannedToday: {
+          workoutType: "easy_run",
+          intensity: "easy",
+          durationMin: 30,
+        },
+        sessionsThisWeek: 2,
+        plannedThisWeek: 5,
+      },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "easy_run",
+      hardBlocks: ["race-week-protects-taper"],
+      firedRules: ["race-week-protects-taper"],
+    },
+  },
+  {
+    name: "sparse data stays conservative with low confidence",
+    input: makeInput({
+      readiness: null,
+      load: { acwr: null, tsb: null, consecutiveHardDays: 0 },
+      weeklyPlan: null,
+    }),
+    expected: {
+      action: "rest",
+      workoutType: "rest",
+      hardBlocks: [],
+      firedRules: ["sparse-data-low-confidence"],
+      maxConfidence: 0.2,
+      reasonIncludes: "sparse",
+    },
+  },
+  {
+    name: "three consecutive hard days suggest active recovery",
+    input: makeInput({ weeklyPlan: null, load: { consecutiveHardDays: 3 } }),
+    expected: {
+      action: "active_recovery",
+      intensity: "easy",
+      workoutType: "yoga",
+      hardBlocks: [],
+      firedRules: ["consecutive-hard-suggests-recovery"],
+    },
+  },
+  {
+    name: "TSB below minus 30 with four hard days deloads",
+    input: makeInput({
+      weeklyPlan: null,
+      load: { tsb: -40, consecutiveHardDays: 4 },
+    }),
+    expected: {
+      action: "deload",
+      intensity: "easy",
+      workoutType: "easy_run",
+      hardBlocks: [],
+      firedRules: [
+        "tsb-overreaching-suggests-deload",
+        "consecutive-hard-suggests-recovery",
+      ],
+    },
+  },
+  {
+    name: "recent physio downgrades a moderate plan one step",
+    input: makeInput({
+      weeklyPlan: {
+        plannedToday: {
+          workoutType: "steady_run",
+          intensity: "moderate",
+          durationMin: 45,
+        },
+        sessionsThisWeek: 2,
+        plannedThisWeek: 5,
+      },
+      recentInterventions: [{ type: "physio", date: "2026-04-09" }],
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "steady_run",
+      hardBlocks: [],
+      firedRules: ["intervention-recent-respects", "plan-honored-when-safe"],
+    },
+  },
+  {
+    name: "recent massage downgrades a hard plan one step",
+    input: makeInput({
+      recentInterventions: [{ type: "massage", date: "2026-04-10" }],
+    }),
+    expected: {
+      action: "workout",
+      intensity: "moderate",
+      workoutType: "tempo",
+      hardBlocks: [],
+      firedRules: ["intervention-recent-respects", "plan-honored-when-safe"],
+    },
+  },
+  {
+    name: "weekly quota met with no plan rests",
+    input: makeInput({
+      weeklyPlan: {
+        plannedToday: null,
+        sessionsThisWeek: 5,
+        plannedThisWeek: 5,
+      },
+    }),
+    expected: {
+      action: "rest",
+      workoutType: "rest",
+      hardBlocks: [],
+      firedRules: ["weekly-quota-met-suggests-rest"],
+    },
+  },
+  {
+    name: "easy plan and low readiness keeps easy",
+    input: makeInput({
+      readiness: {
+        score: 45,
+        zone: "balanced",
+        hrvDeviation: 0,
+        sleepDebtMin: 0,
+      },
+      weeklyPlan: {
+        plannedToday: {
+          workoutType: "easy_run",
+          intensity: "easy",
+          durationMin: 30,
+        },
+        sessionsThisWeek: 2,
+        plannedThisWeek: 5,
+      },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "easy_run",
+      hardBlocks: ["low-readiness-blocks-hard"],
+      firedRules: ["low-readiness-blocks-hard"],
+    },
+  },
+  {
+    name: "hard plan with ACWR spike becomes moderate",
+    input: makeInput({ load: { acwr: 1.6 } }),
+    expected: {
+      action: "workout",
+      intensity: "moderate",
+      workoutType: "tempo",
+      hardBlocks: ["acwr-spike-blocks-hard"],
+      firedRules: ["acwr-spike-blocks-hard"],
+    },
+  },
+  {
+    name: "hard plan with ACWR spike and low readiness becomes easy",
+    input: makeInput({
+      readiness: {
+        score: 45,
+        zone: "balanced",
+        hrvDeviation: 0,
+        sleepDebtMin: 0,
+      },
+      load: { acwr: 1.6 },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "tempo",
+      hardBlocks: ["low-readiness-blocks-hard", "acwr-spike-blocks-hard"],
+      firedRules: ["low-readiness-blocks-hard", "acwr-spike-blocks-hard"],
+    },
+  },
+  {
+    name: "very low ACWR alone suggests an easy build",
+    input: makeInput({ weeklyPlan: null, load: { acwr: 0.7 } }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "easy_run",
+      hardBlocks: [],
+      firedRules: ["acwr-very-low-suggests-light-build"],
+    },
+  },
+  {
+    name: "sleep debt blocks hard plan and downgrades to easy",
+    input: makeInput({
+      readiness: {
+        score: 75,
+        zone: "balanced",
+        hrvDeviation: 0,
+        sleepDebtMin: 180,
+      },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "easy",
+      workoutType: "tempo",
+      hardBlocks: ["sleep-debt-blocks-hard"],
+      firedRules: ["sleep-debt-blocks-hard"],
+    },
+  },
+  {
+    name: "no plan and no signals defaults to moderate workout",
+    input: makeInput({ weeklyPlan: null }),
+    expected: {
+      action: "workout",
+      intensity: "moderate",
+      workoutType: "steady_run",
+      hardBlocks: [],
+      firedRules: [],
+    },
+  },
+  {
+    name: "balanced moderate plan is honored",
+    input: makeInput({
+      weeklyPlan: {
+        plannedToday: {
+          workoutType: "steady_run",
+          intensity: "moderate",
+          durationMin: 45,
+        },
+        sessionsThisWeek: 1,
+        plannedThisWeek: 4,
+      },
+    }),
+    expected: {
+      action: "workout",
+      intensity: "moderate",
+      workoutType: "steady_run",
+      hardBlocks: [],
+      firedRules: ["plan-honored-when-safe"],
+    },
+  },
+];
+
+describe("recommendDay", () => {
+  it.each(fixtures)("$name", ({ input, expected }) => {
+    const result = recommendDay(input);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        action: expected.action,
+        hardBlocks: expected.hardBlocks,
+        workoutType: expected.workoutType,
+      }),
+    );
+
+    if (expected.intensity !== undefined) {
+      expect(result.intensity).toBe(expected.intensity);
+    }
+
+    expect(firedRuleIds(input)).toEqual(expected.firedRules);
+
+    if (expected.maxConfidence !== undefined) {
+      expect(result.confidence).toBeLessThanOrEqual(expected.maxConfidence);
+    }
+
+    if (expected.reasonIncludes !== undefined) {
+      expect(result.reason.toLowerCase()).toContain(expected.reasonIncludes);
+    }
+  });
+
+  it("returns every rule trace for replay", () => {
+    const result = recommendDay(makeInput());
+
+    expect(result.rules).toHaveLength(13);
+    expect(result.rules[0]).toEqual(
+      expect.objectContaining({
+        ruleId: "low-readiness-blocks-hard",
+        fired: false,
+        severity: "block",
+      }),
+    );
+  });
+});

--- a/packages/engine/src/daily-recommendation/__tests__/rules.test.ts
+++ b/packages/engine/src/daily-recommendation/__tests__/rules.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from "vitest";
+
+import type { DailyRecommendationInput } from "..";
+import {
+  acwrSpikeBlocksHard,
+  acwrVeryLowSuggestsLightBuild,
+  consecutiveHardSuggestsRecovery,
+  hrvSuppressedBlocksHard,
+  interventionRecentRespects,
+  lowReadinessBlocksHard,
+  planHonoredWhenSafe,
+  raceDayRest,
+  raceWeekProtectsTaper,
+  sleepDebtBlocksHard,
+  sparseDataLowConfidence,
+  tsbOverreachingSuggestsDeload,
+  weeklyQuotaMetSuggestsRest,
+} from "..";
+
+type InputOverrides = Partial<
+  Omit<DailyRecommendationInput, "readiness" | "load" | "weeklyPlan">
+> & {
+  readiness?: DailyRecommendationInput["readiness"];
+  load?: Partial<DailyRecommendationInput["load"]>;
+  weeklyPlan?: DailyRecommendationInput["weeklyPlan"];
+};
+
+function makeInput(overrides: InputOverrides = {}): DailyRecommendationInput {
+  const base: DailyRecommendationInput = {
+    date: "2026-04-10",
+    readiness: {
+      score: 80,
+      zone: "optimal",
+      hrvDeviation: 0,
+      sleepDebtMin: 0,
+    },
+    load: {
+      acwr: 1,
+      tsb: 0,
+      consecutiveHardDays: 0,
+    },
+    weeklyPlan: {
+      plannedToday: {
+        workoutType: "tempo",
+        intensity: "hard",
+        durationMin: 50,
+      },
+      sessionsThisWeek: 1,
+      plannedThisWeek: 4,
+    },
+    recentInterventions: [],
+    raceDateDaysAway: null,
+    baseline: { restDaysPerWeek: 2 },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    readiness:
+      overrides.readiness === undefined ? base.readiness : overrides.readiness,
+    load: { ...base.load, ...overrides.load },
+    weeklyPlan:
+      overrides.weeklyPlan === undefined
+        ? base.weeklyPlan
+        : overrides.weeklyPlan,
+  };
+}
+
+describe("daily recommendation rules", () => {
+  it("fires low readiness below 50 but not at 50", () => {
+    expect(
+      lowReadinessBlocksHard(
+        makeInput({
+          readiness: {
+            score: 49,
+            zone: "balanced",
+            hrvDeviation: 0,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(
+      lowReadinessBlocksHard(
+        makeInput({
+          readiness: {
+            score: 50,
+            zone: "balanced",
+            hrvDeviation: 0,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(false);
+  });
+
+  it("fires low readiness for stressed and compromised zones", () => {
+    expect(
+      lowReadinessBlocksHard(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "stressed",
+            hrvDeviation: 0,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(
+      lowReadinessBlocksHard(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "compromised",
+            hrvDeviation: 0,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(true);
+  });
+
+  it("is null-safe for missing readiness", () => {
+    expect(lowReadinessBlocksHard(makeInput({ readiness: null })).fired).toBe(
+      false,
+    );
+    expect(hrvSuppressedBlocksHard(makeInput({ readiness: null })).fired).toBe(
+      false,
+    );
+    expect(sleepDebtBlocksHard(makeInput({ readiness: null })).fired).toBe(
+      false,
+    );
+  });
+
+  it("fires HRV suppression at -1.5 but not above", () => {
+    expect(
+      hrvSuppressedBlocksHard(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "optimal",
+            hrvDeviation: -1.5,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(
+      hrvSuppressedBlocksHard(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "optimal",
+            hrvDeviation: -1.49,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(false);
+  });
+
+  it("fires ACWR spike above 1.5 but not at 1.5", () => {
+    expect(acwrSpikeBlocksHard(makeInput({ load: { acwr: 1.51 } })).fired).toBe(
+      true,
+    );
+    expect(acwrSpikeBlocksHard(makeInput({ load: { acwr: 1.5 } })).fired).toBe(
+      false,
+    );
+    expect(acwrSpikeBlocksHard(makeInput({ load: { acwr: null } })).fired).toBe(
+      false,
+    );
+  });
+
+  it("fires low ACWR below 0.8 but not at 0.8", () => {
+    expect(
+      acwrVeryLowSuggestsLightBuild(makeInput({ load: { acwr: 0.79 } })).fired,
+    ).toBe(true);
+    expect(
+      acwrVeryLowSuggestsLightBuild(makeInput({ load: { acwr: 0.8 } })).fired,
+    ).toBe(false);
+    expect(
+      acwrVeryLowSuggestsLightBuild(makeInput({ load: { acwr: null } })).fired,
+    ).toBe(false);
+  });
+
+  it("fires TSB overreaching below -30 but not at -30", () => {
+    expect(
+      tsbOverreachingSuggestsDeload(makeInput({ load: { tsb: -31 } })).fired,
+    ).toBe(true);
+    expect(
+      tsbOverreachingSuggestsDeload(makeInput({ load: { tsb: -30 } })).fired,
+    ).toBe(false);
+    expect(
+      tsbOverreachingSuggestsDeload(makeInput({ load: { tsb: null } })).fired,
+    ).toBe(false);
+  });
+
+  it("fires consecutive hard recovery at 3 but not 2", () => {
+    expect(
+      consecutiveHardSuggestsRecovery(
+        makeInput({ load: { consecutiveHardDays: 3 } }),
+      ).fired,
+    ).toBe(true);
+    expect(
+      consecutiveHardSuggestsRecovery(
+        makeInput({ load: { consecutiveHardDays: 2 } }),
+      ).fired,
+    ).toBe(false);
+  });
+
+  it("fires race taper protection at 7 days but not 8", () => {
+    expect(
+      raceWeekProtectsTaper(makeInput({ raceDateDaysAway: 7 })).fired,
+    ).toBe(true);
+    expect(
+      raceWeekProtectsTaper(makeInput({ raceDateDaysAway: 8 })).fired,
+    ).toBe(false);
+    expect(
+      raceWeekProtectsTaper(makeInput({ raceDateDaysAway: null })).fired,
+    ).toBe(false);
+  });
+
+  it("fires race-day rest only on day zero", () => {
+    expect(raceDayRest(makeInput({ raceDateDaysAway: 0 })).fired).toBe(true);
+    expect(raceDayRest(makeInput({ raceDateDaysAway: 1 })).fired).toBe(false);
+    expect(raceDayRest(makeInput({ raceDateDaysAway: null })).fired).toBe(
+      false,
+    );
+  });
+
+  it("fires recent intervention for recovery bodywork in last two days", () => {
+    expect(
+      interventionRecentRespects(
+        makeInput({
+          recentInterventions: [{ type: "ice_bath", date: "2026-04-08" }],
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(
+      interventionRecentRespects(
+        makeInput({
+          recentInterventions: [{ type: "ice_bath", date: "2026-04-07" }],
+        }),
+      ).fired,
+    ).toBe(false);
+    expect(
+      interventionRecentRespects(
+        makeInput({
+          recentInterventions: [{ type: "stretch", date: "2026-04-09" }],
+        }),
+      ).fired,
+    ).toBe(false);
+  });
+
+  it("fires sleep debt at 180 minutes but not below", () => {
+    expect(
+      sleepDebtBlocksHard(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "optimal",
+            hrvDeviation: 0,
+            sleepDebtMin: 180,
+          },
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(
+      sleepDebtBlocksHard(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "optimal",
+            hrvDeviation: 0,
+            sleepDebtMin: 179,
+          },
+        }),
+      ).fired,
+    ).toBe(false);
+  });
+
+  it("honors plan only when hard blocks are absent", () => {
+    expect(planHonoredWhenSafe(makeInput()).fired).toBe(true);
+    expect(
+      planHonoredWhenSafe(
+        makeInput({
+          readiness: {
+            score: 49,
+            zone: "balanced",
+            hrvDeviation: 0,
+            sleepDebtMin: 0,
+          },
+        }),
+      ).fired,
+    ).toBe(false);
+    expect(planHonoredWhenSafe(makeInput({ weeklyPlan: null })).fired).toBe(
+      false,
+    );
+  });
+
+  it("fires weekly quota only when no plan exists today", () => {
+    expect(
+      weeklyQuotaMetSuggestsRest(
+        makeInput({
+          weeklyPlan: {
+            plannedToday: null,
+            sessionsThisWeek: 4,
+            plannedThisWeek: 4,
+          },
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(weeklyQuotaMetSuggestsRest(makeInput()).fired).toBe(false);
+  });
+
+  it("fires sparse data for no readiness or all load signal nulls", () => {
+    expect(sparseDataLowConfidence(makeInput({ readiness: null })).fired).toBe(
+      true,
+    );
+    expect(
+      sparseDataLowConfidence(
+        makeInput({
+          readiness: {
+            score: 80,
+            zone: "optimal",
+            hrvDeviation: null,
+            sleepDebtMin: 0,
+          },
+          load: { acwr: null, tsb: null },
+        }),
+      ).fired,
+    ).toBe(true);
+    expect(sparseDataLowConfidence(makeInput()).fired).toBe(false);
+  });
+});

--- a/packages/engine/src/daily-recommendation/index.ts
+++ b/packages/engine/src/daily-recommendation/index.ts
@@ -225,7 +225,12 @@ function enforceHardBlocks(
     (hasFired(rules, "hrv-suppressed-blocks-hard") ||
       hasFired(rules, "acwr-spike-blocks-hard") ||
       hasFired(rules, "race-week-protects-taper")) &&
-    next.intensity === "hard"
+    next.intensity === "hard" &&
+    // Race-day exemption: when the user is racing today and the plan is the
+    // actual race workout, the taper rule must not downgrade it. The race-day
+    // branch in computeDesiredRecommendation returns the planned race; we
+    // honor that here too. See PR #206 Copilot review (race-week double-fire).
+    next.workoutType !== "race"
   ) {
     next = applyIntensity(next, "moderate");
   }

--- a/packages/engine/src/daily-recommendation/index.ts
+++ b/packages/engine/src/daily-recommendation/index.ts
@@ -1,0 +1,308 @@
+import type {
+  DailyRecommendationInput,
+  Recommendation,
+  RecommendationAction,
+  RecommendationIntensity,
+  RuleTrace,
+} from "./rules";
+import { dailyRecommendationRules } from "./rules";
+
+export type {
+  DailyRecommendationInput,
+  Recommendation,
+  RecommendationAction,
+  RecommendationIntensity,
+  RuleTrace,
+} from "./rules";
+
+export {
+  acwrSpikeBlocksHard,
+  acwrVeryLowSuggestsLightBuild,
+  consecutiveHardSuggestsRecovery,
+  dailyRecommendationRules,
+  hrvSuppressedBlocksHard,
+  interventionRecentRespects,
+  lowReadinessBlocksHard,
+  planHonoredWhenSafe,
+  raceDayRest,
+  raceWeekProtectsTaper,
+  sleepDebtBlocksHard,
+  sparseDataLowConfidence,
+  tsbOverreachingSuggestsDeload,
+  weeklyQuotaMetSuggestsRest,
+} from "./rules";
+
+type MutableRecommendation = Omit<
+  Recommendation,
+  "reason" | "confidence" | "rules" | "hardBlocks" | "raceProximityDays"
+>;
+
+const RECOVERY_WORKOUT_TYPE = "yoga";
+
+function hasFired(rules: RuleTrace[], ruleId: string): boolean {
+  return rules.some((rule) => rule.ruleId === ruleId && rule.fired);
+}
+
+function downgradeIntensity(
+  intensity: RecommendationIntensity,
+): RecommendationIntensity {
+  if (intensity === "hard") return "moderate";
+  if (intensity === "moderate") return "easy";
+  return "easy";
+}
+
+function applyIntensity(
+  recommendation: MutableRecommendation,
+  intensity: RecommendationIntensity,
+): MutableRecommendation {
+  if (recommendation.action === "rest") return recommendation;
+
+  return {
+    ...recommendation,
+    intensity,
+    workoutType:
+      recommendation.workoutType ?? (intensity === "easy" ? "easy_run" : "run"),
+    durationMin: recommendation.durationMin ?? (intensity === "easy" ? 30 : 45),
+  };
+}
+
+function fromPlan(
+  input: DailyRecommendationInput,
+): MutableRecommendation | null {
+  const plannedToday = input.weeklyPlan?.plannedToday;
+  if (!plannedToday) return null;
+
+  return {
+    action: plannedToday.workoutType === "rest" ? "rest" : "workout",
+    workoutType: plannedToday.workoutType,
+    durationMin: plannedToday.durationMin,
+    intensity: plannedToday.intensity,
+  };
+}
+
+function defaultWorkout(
+  intensity: RecommendationIntensity,
+): MutableRecommendation {
+  return {
+    action: "workout",
+    workoutType: intensity === "easy" ? "easy_run" : "steady_run",
+    durationMin: intensity === "easy" ? 30 : 45,
+    intensity,
+  };
+}
+
+function recoveryRecommendation(): MutableRecommendation {
+  return {
+    action: "active_recovery",
+    workoutType: RECOVERY_WORKOUT_TYPE,
+    durationMin: 30,
+    intensity: "easy",
+  };
+}
+
+function deloadRecommendation(): MutableRecommendation {
+  return {
+    action: "deload",
+    workoutType: "easy_run",
+    durationMin: 30,
+    intensity: "easy",
+  };
+}
+
+function restRecommendation(): MutableRecommendation {
+  return { action: "rest", workoutType: "rest" };
+}
+
+function computeDesiredRecommendation(
+  input: DailyRecommendationInput,
+  rules: RuleTrace[],
+): MutableRecommendation {
+  const plannedToday = input.weeklyPlan?.plannedToday;
+  const raceDayFired = hasFired(rules, "race-day-rest");
+
+  if (raceDayFired) {
+    if (plannedToday?.workoutType === "race")
+      return fromPlan(input) ?? defaultWorkout("hard");
+    return restRecommendation();
+  }
+
+  if (hasFired(rules, "race-week-protects-taper")) {
+    if (plannedToday?.intensity === "easy")
+      return fromPlan(input) ?? defaultWorkout("easy");
+    return defaultWorkout("easy");
+  }
+
+  const planned = fromPlan(input);
+  if (planned) return planned;
+
+  if (
+    hasFired(rules, "sparse-data-low-confidence") &&
+    input.readiness === null &&
+    input.load.acwr === null &&
+    input.load.tsb === null
+  ) {
+    return restRecommendation();
+  }
+
+  if (
+    hasFired(rules, "tsb-overreaching-suggests-deload") &&
+    input.load.consecutiveHardDays >= 4
+  ) {
+    return deloadRecommendation();
+  }
+
+  if (hasFired(rules, "consecutive-hard-suggests-recovery")) {
+    return recoveryRecommendation();
+  }
+
+  if (hasFired(rules, "weekly-quota-met-suggests-rest")) {
+    return restRecommendation();
+  }
+
+  if (hasFired(rules, "acwr-very-low-suggests-light-build")) {
+    return defaultWorkout("easy");
+  }
+
+  return defaultWorkout("moderate");
+}
+
+function applyWarnDowngrades(
+  recommendation: MutableRecommendation,
+  rules: RuleTrace[],
+): MutableRecommendation {
+  let next = recommendation;
+
+  if (
+    hasFired(rules, "intervention-recent-respects") &&
+    next.intensity !== undefined
+  ) {
+    next = applyIntensity(next, downgradeIntensity(next.intensity));
+  }
+
+  if (
+    hasFired(rules, "acwr-very-low-suggests-light-build") &&
+    next.intensity !== undefined &&
+    next.intensity !== "easy"
+  ) {
+    next = applyIntensity(next, "easy");
+  }
+
+  return next;
+}
+
+function enforceHardBlocks(
+  recommendation: MutableRecommendation,
+  rules: RuleTrace[],
+): MutableRecommendation {
+  const hardBlocks = rules.filter(
+    (rule) => rule.fired && rule.severity === "block",
+  );
+  if (hardBlocks.length === 0 || recommendation.intensity === undefined) {
+    return recommendation;
+  }
+
+  if (
+    hasFired(rules, "hrv-suppressed-blocks-hard") &&
+    hasFired(rules, "acwr-spike-blocks-hard") &&
+    recommendation.intensity !== "easy"
+  ) {
+    return recoveryRecommendation();
+  }
+
+  let next = recommendation;
+
+  if (hasFired(rules, "low-readiness-blocks-hard")) {
+    if (next.intensity === "hard") next = applyIntensity(next, "moderate");
+    if (next.intensity === "moderate") next = applyIntensity(next, "easy");
+  }
+
+  if (hasFired(rules, "sleep-debt-blocks-hard")) {
+    if (next.intensity === "hard") next = applyIntensity(next, "moderate");
+    if (next.intensity === "moderate") next = applyIntensity(next, "easy");
+  }
+
+  if (
+    (hasFired(rules, "hrv-suppressed-blocks-hard") ||
+      hasFired(rules, "acwr-spike-blocks-hard") ||
+      hasFired(rules, "race-week-protects-taper")) &&
+    next.intensity === "hard"
+  ) {
+    next = applyIntensity(next, "moderate");
+  }
+
+  return next;
+}
+
+function nullReadinessFieldCount(input: DailyRecommendationInput): number {
+  if (input.readiness === null) return 4;
+
+  return [
+    input.readiness.score,
+    input.readiness.zone,
+    input.readiness.hrvDeviation,
+    input.readiness.sleepDebtMin,
+  ].filter((value) => value === null).length;
+}
+
+function computeConfidence(
+  input: DailyRecommendationInput,
+  rules: RuleTrace[],
+): number {
+  const sparsePenalty = hasFired(rules, "sparse-data-low-confidence") ? 0.4 : 0;
+  const nullPenalty = nullReadinessFieldCount(input) * 0.2;
+  const rawConfidence = 1 - sparsePenalty - nullPenalty;
+
+  return Math.max(0.1, Math.min(1, Math.round(rawConfidence * 100) / 100));
+}
+
+function buildReason(rules: RuleTrace[]): string {
+  const firedNonInfo = rules.filter(
+    (rule) => rule.fired && rule.severity !== "info",
+  );
+
+  if (firedNonInfo.length === 0) {
+    const sparseData = rules.find(
+      (rule) => rule.ruleId === "sparse-data-low-confidence" && rule.fired,
+    );
+    return (
+      sparseData?.message ??
+      "Plan day — no signals against your scheduled workout."
+    );
+  }
+
+  return firedNonInfo
+    .slice(0, 2)
+    .map((rule) => rule.message)
+    .join(" ");
+}
+
+/**
+ * DAILY RECOMMENDATION ENGINE — deterministic, rules-first coaching.
+ *
+ * Uses transparent guardrails before selecting a single day recommendation.
+ * - ACWR >1.5 follows the high-risk spike threshold described by Blanch &
+ *   Gabbett and Gabbett's training-injury prevention paradox (2016).
+ * - TSB < -30 is treated as overreaching, consistent with Coggan's PMC
+ *   interpretation of strongly negative training stress balance.
+ * - Race-week hard work is blocked to protect tapering, following Mujika &
+ *   Padilla's taper review (2003).
+ */
+export function recommendDay(input: DailyRecommendationInput): Recommendation {
+  const rules = dailyRecommendationRules.map((rule) => rule(input));
+  const hardBlocks = rules
+    .filter((rule) => rule.fired && rule.severity === "block")
+    .map((rule) => rule.ruleId);
+
+  const desired = computeDesiredRecommendation(input, rules);
+  const warned = applyWarnDowngrades(desired, rules);
+  const finalRecommendation = enforceHardBlocks(warned, rules);
+
+  return {
+    ...finalRecommendation,
+    reason: buildReason(rules),
+    confidence: computeConfidence(input, rules),
+    rules,
+    hardBlocks,
+    raceProximityDays: input.raceDateDaysAway,
+  };
+}

--- a/packages/engine/src/daily-recommendation/rules.ts
+++ b/packages/engine/src/daily-recommendation/rules.ts
@@ -1,0 +1,348 @@
+export type RecommendationAction =
+  | "workout"
+  | "rest"
+  | "active_recovery"
+  | "deload";
+export type RecommendationIntensity = "easy" | "moderate" | "hard";
+
+export interface RuleTrace {
+  ruleId: string;
+  fired: boolean;
+  severity: "info" | "warn" | "block";
+  message: string;
+  inputs: Record<string, unknown>;
+}
+
+export interface Recommendation {
+  action: RecommendationAction;
+  workoutType?: string;
+  durationMin?: number;
+  intensity?: RecommendationIntensity;
+  reason: string;
+  confidence: number;
+  rules: RuleTrace[];
+  hardBlocks: string[];
+  raceProximityDays: number | null;
+}
+
+export interface DailyRecommendationInput {
+  date: string;
+  readiness: {
+    score: number | null;
+    zone: "optimal" | "balanced" | "compromised" | "stressed" | null;
+    hrvDeviation: number | null;
+    sleepDebtMin: number | null;
+  } | null;
+  load: {
+    acwr: number | null;
+    tsb: number | null;
+    consecutiveHardDays: number;
+  };
+  weeklyPlan: {
+    plannedToday: {
+      workoutType: string;
+      intensity: RecommendationIntensity;
+      durationMin: number;
+    } | null;
+    sessionsThisWeek: number;
+    plannedThisWeek: number;
+  } | null;
+  recentInterventions: Array<{ type: string; date: string }>;
+  raceDateDaysAway: number | null;
+  baseline: { restDaysPerWeek: number } | null;
+}
+
+type RuleDefinition = {
+  ruleId: string;
+  severity: RuleTrace["severity"];
+  message: string;
+  inputs: Record<string, unknown>;
+  predicate: (input: DailyRecommendationInput) => boolean;
+};
+
+function traceRule(
+  input: DailyRecommendationInput,
+  definition: RuleDefinition,
+): RuleTrace {
+  return {
+    ruleId: definition.ruleId,
+    fired: definition.predicate(input),
+    severity: definition.severity,
+    message: definition.message,
+    inputs: definition.inputs,
+  };
+}
+
+function daysBetween(fromDate: string, toDate: string): number | null {
+  const fromTime = Date.parse(`${fromDate}T00:00:00Z`);
+  const toTime = Date.parse(`${toDate}T00:00:00Z`);
+
+  if (!Number.isFinite(fromTime) || !Number.isFinite(toTime)) return null;
+
+  return Math.floor((fromTime - toTime) / 86_400_000);
+}
+
+function hasRecentRecoveryIntervention(
+  input: DailyRecommendationInput,
+): boolean {
+  const recoveryTypes = new Set(["physio", "ice_bath", "massage"]);
+
+  return input.recentInterventions.some((intervention) => {
+    if (!recoveryTypes.has(intervention.type)) return false;
+
+    const ageDays = daysBetween(input.date, intervention.date);
+    return ageDays !== null && ageDays >= 0 && ageDays <= 2;
+  });
+}
+
+function isSparseData(input: DailyRecommendationInput): boolean {
+  return (
+    input.readiness === null ||
+    (input.load.acwr === null &&
+      input.load.tsb === null &&
+      (input.readiness?.hrvDeviation ?? null) === null)
+  );
+}
+
+function hasHardBlockSignal(input: DailyRecommendationInput): boolean {
+  const readiness = input.readiness;
+  const lowReadiness =
+    (readiness?.score !== null &&
+      readiness?.score !== undefined &&
+      readiness.score < 50) ||
+    readiness?.zone === "stressed" ||
+    readiness?.zone === "compromised";
+  const hrvSuppressed =
+    (readiness?.hrvDeviation ?? null) !== null &&
+    (readiness?.hrvDeviation ?? 0) <= -1.5;
+  const acwrSpike = input.load.acwr !== null && input.load.acwr > 1.5;
+  const raceWeek =
+    input.raceDateDaysAway !== null && input.raceDateDaysAway <= 7;
+  const raceDay = input.raceDateDaysAway === 0;
+  const sleepDebt =
+    (readiness?.sleepDebtMin ?? null) !== null &&
+    (readiness?.sleepDebtMin ?? 0) >= 180;
+
+  return (
+    lowReadiness ||
+    hrvSuppressed ||
+    acwrSpike ||
+    raceWeek ||
+    raceDay ||
+    sleepDebt
+  );
+}
+
+export function lowReadinessBlocksHard(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "low-readiness-blocks-hard",
+    severity: "block",
+    message: "Readiness is low, so intensity should be reduced today.",
+    inputs: {
+      score: input.readiness?.score ?? null,
+      zone: input.readiness?.zone ?? null,
+    },
+    predicate: (candidate) => {
+      const readiness = candidate.readiness;
+      return (
+        (readiness?.score !== null &&
+          readiness?.score !== undefined &&
+          readiness.score < 50) ||
+        readiness?.zone === "stressed" ||
+        readiness?.zone === "compromised"
+      );
+    },
+  });
+}
+
+export function hrvSuppressedBlocksHard(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "hrv-suppressed-blocks-hard",
+    severity: "block",
+    message: "HRV is suppressed, so hard training is blocked.",
+    inputs: { hrvDeviation: input.readiness?.hrvDeviation ?? null },
+    predicate: (candidate) =>
+      (candidate.readiness?.hrvDeviation ?? null) !== null &&
+      (candidate.readiness?.hrvDeviation ?? 0) <= -1.5,
+  });
+}
+
+export function acwrSpikeBlocksHard(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "acwr-spike-blocks-hard",
+    severity: "block",
+    message: "Recent load spiked above the safe ACWR range.",
+    inputs: { acwr: input.load.acwr },
+    predicate: (candidate) =>
+      candidate.load.acwr !== null && candidate.load.acwr > 1.5,
+  });
+}
+
+export function acwrVeryLowSuggestsLightBuild(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "acwr-very-low-suggests-light-build",
+    severity: "warn",
+    message: "Training load is low; use an easy build today.",
+    inputs: { acwr: input.load.acwr },
+    predicate: (candidate) =>
+      candidate.load.acwr !== null && candidate.load.acwr < 0.8,
+  });
+}
+
+export function tsbOverreachingSuggestsDeload(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "tsb-overreaching-suggests-deload",
+    severity: "warn",
+    message: "Training stress balance suggests overreaching.",
+    inputs: {
+      tsb: input.load.tsb,
+      consecutiveHardDays: input.load.consecutiveHardDays,
+    },
+    predicate: (candidate) =>
+      candidate.load.tsb !== null && candidate.load.tsb < -30,
+  });
+}
+
+export function consecutiveHardSuggestsRecovery(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "consecutive-hard-suggests-recovery",
+    severity: "warn",
+    message: "Three or more hard days call for recovery.",
+    inputs: { consecutiveHardDays: input.load.consecutiveHardDays },
+    predicate: (candidate) => candidate.load.consecutiveHardDays >= 3,
+  });
+}
+
+export function raceWeekProtectsTaper(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "race-week-protects-taper",
+    severity: "block",
+    message: "Race week favors tapering over hard training.",
+    inputs: {
+      raceDateDaysAway: input.raceDateDaysAway,
+      plannedIntensity: input.weeklyPlan?.plannedToday?.intensity ?? null,
+    },
+    predicate: (candidate) =>
+      candidate.raceDateDaysAway !== null && candidate.raceDateDaysAway <= 7,
+  });
+}
+
+export function raceDayRest(input: DailyRecommendationInput): RuleTrace {
+  return traceRule(input, {
+    ruleId: "race-day-rest",
+    severity: "block",
+    message: "Race day is protected for racing or rest.",
+    inputs: {
+      raceDateDaysAway: input.raceDateDaysAway,
+      plannedWorkoutType: input.weeklyPlan?.plannedToday?.workoutType ?? null,
+    },
+    predicate: (candidate) => candidate.raceDateDaysAway === 0,
+  });
+}
+
+export function interventionRecentRespects(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "intervention-recent-respects",
+    severity: "warn",
+    message: "Recent bodywork suggests easing back one step.",
+    inputs: { recentInterventions: input.recentInterventions },
+    predicate: hasRecentRecoveryIntervention,
+  });
+}
+
+export function sleepDebtBlocksHard(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "sleep-debt-blocks-hard",
+    severity: "block",
+    message: "Sleep debt is high, so hard training is blocked.",
+    inputs: { sleepDebtMin: input.readiness?.sleepDebtMin ?? null },
+    predicate: (candidate) =>
+      (candidate.readiness?.sleepDebtMin ?? null) !== null &&
+      (candidate.readiness?.sleepDebtMin ?? 0) >= 180,
+  });
+}
+
+export function planHonoredWhenSafe(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "plan-honored-when-safe",
+    severity: "info",
+    message: "Plan day — no signals against your scheduled workout.",
+    inputs: { plannedToday: input.weeklyPlan?.plannedToday ?? null },
+    predicate: (candidate) =>
+      candidate.weeklyPlan?.plannedToday != null &&
+      !hasHardBlockSignal(candidate),
+  });
+}
+
+export function weeklyQuotaMetSuggestsRest(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "weekly-quota-met-suggests-rest",
+    severity: "info",
+    message: "Weekly workout quota is already met.",
+    inputs: {
+      sessionsThisWeek: input.weeklyPlan?.sessionsThisWeek ?? null,
+      plannedThisWeek: input.weeklyPlan?.plannedThisWeek ?? null,
+      plannedToday: input.weeklyPlan?.plannedToday ?? null,
+    },
+    predicate: (candidate) =>
+      candidate.weeklyPlan !== null &&
+      candidate.weeklyPlan.plannedToday === null &&
+      candidate.weeklyPlan.sessionsThisWeek >=
+        candidate.weeklyPlan.plannedThisWeek,
+  });
+}
+
+export function sparseDataLowConfidence(
+  input: DailyRecommendationInput,
+): RuleTrace {
+  return traceRule(input, {
+    ruleId: "sparse-data-low-confidence",
+    severity: "info",
+    message: "Data is sparse, so this recommendation is conservative.",
+    inputs: {
+      readiness: input.readiness,
+      acwr: input.load.acwr,
+      tsb: input.load.tsb,
+      hrvDeviation: input.readiness?.hrvDeviation ?? null,
+    },
+    predicate: isSparseData,
+  });
+}
+
+export const dailyRecommendationRules = [
+  lowReadinessBlocksHard,
+  hrvSuppressedBlocksHard,
+  acwrSpikeBlocksHard,
+  acwrVeryLowSuggestsLightBuild,
+  tsbOverreachingSuggestsDeload,
+  consecutiveHardSuggestsRecovery,
+  raceWeekProtectsTaper,
+  raceDayRest,
+  interventionRecentRespects,
+  sleepDebtBlocksHard,
+  planHonoredWhenSafe,
+  weeklyQuotaMetSuggestsRest,
+  sparseDataLowConfidence,
+];

--- a/packages/engine/src/daily-recommendation/rules.ts
+++ b/packages/engine/src/daily-recommendation/rules.ts
@@ -104,6 +104,21 @@ function isSparseData(input: DailyRecommendationInput): boolean {
   );
 }
 
+function hasWarnDowngradeSignal(input: DailyRecommendationInput): boolean {
+  // Signals that, while not hard-blocking, will downgrade a planned workout's
+  // intensity during the enforcement phase. The plan-honored-when-safe trace
+  // should NOT fire when these are present — otherwise the audit reads "no
+  // signals against your plan" while the recommendation has already been
+  // softened. Kept in sync with applyWarnDowngrades() in ./index.ts.
+  const recentDowngradingIntervention =
+    Array.isArray(input.recentInterventions) &&
+    input.recentInterventions.some((intervention) =>
+      ["physio", "ice_bath", "massage"].includes(intervention.type),
+    );
+  const acwrVeryLow = input.load.acwr !== null && input.load.acwr < 0.8;
+  return recentDowngradingIntervention || acwrVeryLow;
+}
+
 function hasHardBlockSignal(input: DailyRecommendationInput): boolean {
   const readiness = input.readiness;
   const lowReadiness =
@@ -290,7 +305,8 @@ export function planHonoredWhenSafe(
     inputs: { plannedToday: input.weeklyPlan?.plannedToday ?? null },
     predicate: (candidate) =>
       candidate.weeklyPlan?.plannedToday != null &&
-      !hasHardBlockSignal(candidate),
+      !hasHardBlockSignal(candidate) &&
+      !hasWarnDowngradeSignal(candidate),
   });
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -111,3 +111,12 @@ export {
 } from "./correlations";
 
 export { analyzeRunningForm } from "./running-form";
+
+export {
+  recommendDay,
+  type Recommendation,
+  type RecommendationAction,
+  type RecommendationIntensity,
+  type RuleTrace,
+  type DailyRecommendationInput,
+} from "./daily-recommendation";


### PR DESCRIPTION
## Summary

- Adds W1.1 of the v0.17.0 AI-native release: a pure, deterministic daily recommendation engine.
- Produces one Recommendation with rule traces, hard blocks, race proximity, confidence, and user-facing reasons.
- Exports the new module from @acme/engine without modifying existing exports.

## Rule catalogue table

| Rule | Severity | Purpose |
| --- | --- | --- |
| low-readiness-blocks-hard | block | Downgrades intensity on low readiness or stressed/compromised zone. |
| hrv-suppressed-blocks-hard | block | Blocks hard work when HRV z-score is suppressed. |
| acwr-spike-blocks-hard | block | Blocks hard work when ACWR exceeds 1.5. |
| acwr-very-low-suggests-light-build | warn | Suggests an easy build when ACWR is below 0.8. |
| tsb-overreaching-suggests-deload | warn | Suggests deloading when TSB is below -30. |
| consecutive-hard-suggests-recovery | warn | Suggests recovery after 3+ hard days. |
| race-week-protects-taper | block | Protects race-week tapering. |
| race-day-rest | block | Forces rest unless the plan is a race. |
| intervention-recent-respects | warn | Downgrades after recent physio, ice bath, or massage. |
| sleep-debt-blocks-hard | block | Blocks hard work with 3+ hours sleep debt. |
| plan-honored-when-safe | info | Honors the plan when no block fires. |
| weekly-quota-met-suggests-rest | info | Rests when the weekly quota is met and no plan exists. |
| sparse-data-low-confidence | info | Lowers confidence when data is sparse. |

## Test coverage

- Added golden table-driven tests covering 20 daily recommendation scenarios.
- Added per-rule boundary and null-safety tests.
- Local checks passed: pnpm --filter @acme/engine test, typecheck, lint; pnpm format; pre-commit on staged task files.

## v0.17.0 context

Implements W1.1 of v0.17.0 AI-native release.