### PR TITLE
feat(api): v0.17.0 W2.3 coach.accept/skip/defer mutations with audit-only side effects

### DIFF
--- a/packages/api/src/router/__tests__/coach-actions.test.ts
+++ b/packages/api/src/router/__tests__/coach-actions.test.ts
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const auditReturning = vi.fn();
+  const auditValues = vi.fn(() => ({ returning: auditReturning }));
+  const auditInsert = vi.fn(() => ({ values: auditValues }));
+
+  return {
+    auditDb: { insert: auditInsert },
+    auditInsert,
+    auditValues,
+    auditReturning,
+  };
+});
+
+vi.mock("@acme/db/client", () => ({
+  db: mocks.auditDb,
+}));
+
+const { appRouter } = await import("../../root");
+
+const TEST_USER_ID = "coach-user-1";
+const OTHER_USER_ID = "coach-user-2";
+const TEST_DATE = "2026-04-10";
+const DEFER_TO_DATE = "2026-04-11";
+const RECOMMENDATION_AUDIT_ID = "00000000-0000-4000-8000-000000000101";
+const WRITTEN_AUDIT_ID = "00000000-0000-4000-8000-000000000202";
+
+type ActionName = "accept" | "skip" | "defer";
+
+function makeSession() {
+  const now = new Date();
+  return {
+    user: {
+      id: TEST_USER_ID,
+      name: "Coach User",
+      email: "coach@example.test",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+    session: {
+      id: "test-session",
+      userId: TEST_USER_ID,
+      token: "test-token",
+      expiresAt: new Date(Date.now() + 86_400_000),
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+function makeRecommendationAudit(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RECOMMENDATION_AUDIT_ID,
+    userId: TEST_USER_ID,
+    date: TEST_DATE,
+    kind: "recommendation",
+    action: "workout",
+    intensity: "moderate",
+    workoutType: "easy",
+    durationMin: 45,
+    confidence: 0.86,
+    hardBlocks: [],
+    ruleTrace: [],
+    llmExplanation: null,
+    relatedActivityIds: null,
+    relatedWorkoutId: null,
+    payload: {},
+    createdAt: new Date(`${TEST_DATE}T08:00:00Z`),
+    ...overrides,
+  };
+}
+
+function makeDb(
+  referencedAudit: Record<string, unknown> | null = makeRecommendationAudit(),
+) {
+  return {
+    query: {
+      RecommendationAudit: {
+        findFirst: vi.fn(async () => referencedAudit),
+      },
+      DailyWorkout: {
+        insert: vi.fn(),
+        update: vi.fn(),
+      },
+      WeeklyPlan: {
+        insert: vi.fn(),
+        update: vi.fn(),
+      },
+    },
+    insert: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+function createCaller(db: ReturnType<typeof makeDb>) {
+  return appRouter.createCaller({
+    authApi: null as never,
+    session: makeSession(),
+    db: db as never,
+  });
+}
+
+function setup(referencedAudit?: Record<string, unknown> | null) {
+  const db = makeDb(
+    referencedAudit === undefined ? makeRecommendationAudit() : referencedAudit,
+  );
+  const caller = createCaller(db);
+  return { caller, db };
+}
+
+function inputFor(action: ActionName, overrides: Record<string, unknown> = {}) {
+  const base = {
+    userId: TEST_USER_ID,
+    date: TEST_DATE,
+    auditId: RECOMMENDATION_AUDIT_ID,
+    note: "coach action note",
+    ...overrides,
+  };
+  if (action === "defer") {
+    return { ...base, deferToDate: DEFER_TO_DATE, ...overrides };
+  }
+  return base;
+}
+
+type BaseActionInput = {
+  userId: string;
+  date: string;
+  auditId: string;
+  note?: string;
+};
+
+type DeferActionInput = BaseActionInput & { deferToDate: string };
+
+async function callAction(
+  caller: ReturnType<typeof createCaller>,
+  action: ActionName,
+  overrides: Record<string, unknown> = {},
+) {
+  if (action === "accept") {
+    return caller.coach.accept(inputFor(action, overrides) as BaseActionInput);
+  }
+  if (action === "skip") {
+    return caller.coach.skip(inputFor(action, overrides) as BaseActionInput);
+  }
+  return caller.coach.defer(inputFor(action, overrides) as DeferActionInput);
+}
+
+function writtenAuditRow() {
+  const calls = mocks.auditValues.mock.calls as unknown as Array<
+    [Record<string, unknown>]
+  >;
+  return calls.at(-1)?.[0];
+}
+
+function expectAuditOnly(db: ReturnType<typeof makeDb>) {
+  expect(db.insert).not.toHaveBeenCalled();
+  expect(db.update).not.toHaveBeenCalled();
+  expect(db.query.DailyWorkout.insert).not.toHaveBeenCalled();
+  expect(db.query.DailyWorkout.update).not.toHaveBeenCalled();
+  expect(db.query.WeeklyPlan.insert).not.toHaveBeenCalled();
+  expect(db.query.WeeklyPlan.update).not.toHaveBeenCalled();
+}
+
+describe("coach recommendation action mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auditReturning.mockResolvedValue([{ id: WRITTEN_AUDIT_ID }]);
+  });
+
+  it("accept writes an intervention_accept audit row", async () => {
+    const { caller, db } = setup();
+
+    await expect(callAction(caller, "accept")).resolves.toEqual({
+      auditId: WRITTEN_AUDIT_ID,
+    });
+
+    expect(mocks.auditValues).toHaveBeenCalledTimes(1);
+    expect(writtenAuditRow()).toMatchObject({
+      userId: TEST_USER_ID,
+      date: TEST_DATE,
+      kind: "intervention_accept",
+      payload: { referencedAuditId: RECOMMENDATION_AUDIT_ID },
+    });
+    expectAuditOnly(db);
+  });
+
+  it("skip writes an intervention_skip audit row", async () => {
+    const { caller, db } = setup();
+
+    await expect(callAction(caller, "skip")).resolves.toEqual({
+      auditId: WRITTEN_AUDIT_ID,
+    });
+
+    expect(writtenAuditRow()).toMatchObject({
+      kind: "intervention_skip",
+      payload: {
+        referencedAuditId: RECOMMENDATION_AUDIT_ID,
+        note: "coach action note",
+      },
+    });
+    expectAuditOnly(db);
+  });
+
+  it("defer writes an intervention_defer audit row for a future date", async () => {
+    const { caller, db } = setup();
+
+    await expect(callAction(caller, "defer")).resolves.toEqual({
+      auditId: WRITTEN_AUDIT_ID,
+    });
+
+    expect(writtenAuditRow()).toMatchObject({
+      kind: "intervention_defer",
+      payload: {
+        referencedAuditId: RECOMMENDATION_AUDIT_ID,
+        deferToDate: DEFER_TO_DATE,
+      },
+    });
+    expectAuditOnly(db);
+  });
+
+  it("rejects same-day defers with BAD_REQUEST", async () => {
+    const { caller } = setup();
+
+    await expect(
+      callAction(caller, "defer", { deferToDate: TEST_DATE }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects past defers with BAD_REQUEST", async () => {
+    const { caller } = setup();
+
+    await expect(
+      callAction(caller, "defer", { deferToDate: "2026-04-09" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects all actions for a different input user with FORBIDDEN", async () => {
+    for (const action of ["accept", "skip", "defer"] as const) {
+      const { caller } = setup();
+      await expect(
+        callAction(caller, action, { userId: OTHER_USER_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    }
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects actions when the referenced audit is not found", async () => {
+    const { caller } = setup(null);
+
+    await expect(callAction(caller, "accept")).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects actions when the referenced audit belongs to another user", async () => {
+    const { caller } = setup(
+      makeRecommendationAudit({ userId: OTHER_USER_ID }),
+    );
+
+    await expect(callAction(caller, "skip")).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects actions when the referenced audit is not a recommendation", async () => {
+    const { caller } = setup(
+      makeRecommendationAudit({ kind: "intervention_skip" }),
+    );
+
+    await expect(callAction(caller, "accept")).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects actions when the referenced audit date mismatches", async () => {
+    const { caller } = setup(makeRecommendationAudit({ date: "2026-04-09" }));
+
+    await expect(callAction(caller, "accept")).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(mocks.auditValues).not.toHaveBeenCalled();
+  });
+
+  it("keeps accept, skip, and defer audit-only", async () => {
+    for (const action of ["accept", "skip", "defer"] as const) {
+      const { caller, db } = setup();
+      await callAction(caller, action);
+      expectAuditOnly(db);
+    }
+    expect(mocks.auditValues).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/api/src/router/coach.ts
+++ b/packages/api/src/router/coach.ts
@@ -5,12 +5,14 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
+import type { db as appDb } from "@acme/db/client";
 import type {
   DailyRecommendationInput,
   Recommendation,
   RecommendationIntensity,
 } from "@acme/engine";
 import { and, desc, eq, gte, lte } from "@acme/db";
+import * as schema from "@acme/db/schema";
 import {
   Activity,
   AdvancedMetric,
@@ -33,6 +35,7 @@ import { shiftIsoDay, todayInTimezone } from "../lib/timezone";
 import { protectedProcedure } from "../trpc";
 
 const LLM_FRAME_TIMEOUT_MS = 5_000;
+type AppDb = typeof appDb;
 type EngineReadinessZone = NonNullable<
   DailyRecommendationInput["readiness"]
 >["zone"];
@@ -43,6 +46,17 @@ const IsoDateSchema = z
   .refine((value) => !Number.isNaN(Date.parse(`${value}T00:00:00Z`)), {
     message: "Expected a valid calendar date",
   });
+
+const RecommendationActionInputSchema = z.object({
+  userId: z.string(),
+  date: IsoDateSchema,
+  auditId: z.string().uuid(),
+  note: z.string().max(500).optional(),
+});
+
+const RecommendationDeferInputSchema = RecommendationActionInputSchema.extend({
+  deferToDate: IsoDateSchema,
+});
 
 function toIsoDay(value: Date | string | null | undefined): string | null {
   if (value == null) return null;
@@ -241,6 +255,53 @@ async function frameReasonWithTimeout(
   }
 }
 
+function enforceOwnUser(inputUserId: string, sessionUserId: string): void {
+  if (inputUserId !== sessionUserId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Cannot act on recommendations for another user",
+    });
+  }
+}
+
+async function loadReferencedRecommendationAudit(
+  db: AppDb,
+  auditId: string,
+  userId: string,
+  expectedDate: string,
+): Promise<typeof schema.RecommendationAudit.$inferSelect> {
+  const audit = await db.query.RecommendationAudit.findFirst({
+    where: eq(schema.RecommendationAudit.id, auditId),
+  });
+
+  if (!audit) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Referenced recommendation audit was not found",
+    });
+  }
+  if (audit.userId !== userId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Referenced recommendation audit belongs to another user",
+    });
+  }
+  if (audit.kind !== "recommendation") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Referenced audit must be a recommendation",
+    });
+  }
+  if (toIsoDay(audit.date) !== expectedDate) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Referenced audit date must match action date",
+    });
+  }
+
+  return audit;
+}
+
 export const coachRouter = {
   getDailyRecommendation: protectedProcedure
     .input(z.object({ userId: z.string(), date: IsoDateSchema.optional() }))
@@ -374,5 +435,87 @@ export const coachRouter = {
           : recommendation,
         auditId: audit.id,
       };
+    }),
+
+  accept: protectedProcedure
+    .input(RecommendationActionInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      enforceOwnUser(input.userId, userId);
+      await loadReferencedRecommendationAudit(
+        ctx.db,
+        input.auditId,
+        userId,
+        input.date,
+      );
+
+      const audit = await recordRecommendationAudit({
+        userId,
+        date: input.date,
+        kind: "intervention_accept",
+        payload: {
+          referencedAuditId: input.auditId,
+          note: input.note,
+        },
+      });
+
+      return { auditId: audit.id };
+    }),
+
+  skip: protectedProcedure
+    .input(RecommendationActionInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      enforceOwnUser(input.userId, userId);
+      await loadReferencedRecommendationAudit(
+        ctx.db,
+        input.auditId,
+        userId,
+        input.date,
+      );
+
+      const audit = await recordRecommendationAudit({
+        userId,
+        date: input.date,
+        kind: "intervention_skip",
+        payload: {
+          referencedAuditId: input.auditId,
+          note: input.note ?? "user skipped recommendation",
+        },
+      });
+
+      return { auditId: audit.id };
+    }),
+
+  defer: protectedProcedure
+    .input(RecommendationDeferInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      enforceOwnUser(input.userId, userId);
+      if (input.deferToDate <= input.date) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "deferToDate must be after date",
+        });
+      }
+      await loadReferencedRecommendationAudit(
+        ctx.db,
+        input.auditId,
+        userId,
+        input.date,
+      );
+
+      const audit = await recordRecommendationAudit({
+        userId,
+        date: input.date,
+        kind: "intervention_defer",
+        payload: {
+          referencedAuditId: input.auditId,
+          deferToDate: input.deferToDate,
+          note: input.note,
+        },
+      });
+
+      return { auditId: audit.id };
     }),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary
- Adds protected `coach.accept`, `coach.skip`, and `coach.defer` tRPC mutations.
- Enforces session `userId` ownership and validates the referenced audit row exists, belongs to the user, and is `kind="recommendation"`.
- Writes audit-only `RecommendationAudit` intervention rows; no `DailyWorkout`, `WeeklyPlan`, readiness, or other state tables are mutated.
- Adds 10 API tests covering happy paths, forbidden/not-found/bad-request failures, defer date validation, and audit-only invariants.

## UI coordination
The sibling home-card PR was not merged on `main` when this branch was created (no PR found for `home-recommendation`), so this PR intentionally does **not** touch the card UI.

### API surface for card wiring
```ts
api.coach.accept.useMutation();
api.coach.skip.useMutation();
api.coach.defer.useMutation();
```

Inputs:
```ts
await accept.mutateAsync({
  userId,
  date,              // YYYY-MM-DD recommendation date
  auditId,           // originating recommendation audit UUID
  note,              // optional, max 500 chars
});

await skip.mutateAsync({ userId, date, auditId, note });

await defer.mutateAsync({
  userId,
  date,
  auditId,
  deferToDate,       // YYYY-MM-DD and must be > date
  note,
});
```

Suggested card handler pattern:
```ts
const utils = api.useUtils();
const accept = api.coach.accept.useMutation({
  onSuccess: async () => {
    toast.success("Recommendation accepted");
    await utils.coach.getDailyRecommendation.invalidate();
  },
  onError: (error) => toast.error(error.message),
});
```

Use the same success/error/invalidate pattern for `skip` and `defer`; `defer` should collect a future `deferToDate` before calling the mutation.

## Verification
- `pnpm --filter @acme/api exec vitest run --reporter=dot` → 91 passed, 10 skipped
- `pnpm typecheck` → passed
- `pnpm --filter @acme/api lint` → passed
- `pnpm format` → passed
- `pre-commit run --all-files` → passed after hooks autofixed pre-existing whitespace in generated workflow lock files; those workflow changes were reverted to honor the no-workflow-modification guardrail
