### PR TITLE
feat(api): add reconciliation and adherence trend

### DIFF
--- a/.github/workflows/garmin-app-daily-health.lock.yml
+++ b/.github/workflows/garmin-app-daily-health.lock.yml
@@ -1,11 +1,11 @@
-#    ___                   _   _      
-#   / _ \                 | | (_)     
-#  | |_| | __ _  ___ _ __ | |_ _  ___ 
+#    ___                   _   _
+#   / _ \                 | | (_)
+#  | |_| | __ _  ___ _ __ | |_ _  ___
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__ 
+#  | | | | (_| |  __/ | | | |_| | (__
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/ 
+#  _    _ |___/
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -156,7 +156,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-          
+
           GH_AW_PROMPT_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
@@ -192,9 +192,9 @@ jobs:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
-            
+
             const substitutePlaceholders = require('${{ runner.temp }}/gh-aw/actions/substitute_placeholders.cjs');
-            
+
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -437,17 +437,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-          
+
           PORT=3001
-          
+
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-          
+
           echo "Safe Outputs MCP server will run on port ${PORT}"
-          
+
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -465,9 +465,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-          
+
           bash ${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh
-          
+
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -480,7 +480,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
-          
+
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="80"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -491,10 +491,10 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-          
+
           export GH_AW_ENGINE="copilot"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.20'
-          
+
           mkdir -p /home/runner/.copilot
           cat << GH_AW_MCP_CONFIG_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
@@ -603,7 +603,7 @@ jobs:
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
           LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
-          
+
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
@@ -1011,4 +1011,3 @@ jobs:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl
           if-no-files-found: ignore
-

--- a/.github/workflows/garmin-app-review.lock.yml
+++ b/.github/workflows/garmin-app-review.lock.yml
@@ -1,11 +1,11 @@
-#    ___                   _   _      
-#   / _ \                 | | (_)     
-#  | |_| | __ _  ___ _ __ | |_ _  ___ 
+#    ___                   _   _
+#   / _ \                 | | (_)
+#  | |_| | __ _  ___ _ __ | |_ _  ___
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__ 
+#  | | | | (_| |  __/ | | | |_| | (__
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/ 
+#  _    _ |___/
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -173,7 +173,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-          
+
           GH_AW_PROMPT_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
@@ -210,9 +210,9 @@ jobs:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
-            
+
             const substitutePlaceholders = require('${{ runner.temp }}/gh-aw/actions/substitute_placeholders.cjs');
-            
+
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -438,17 +438,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-          
+
           PORT=3001
-          
+
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-          
+
           echo "Safe Outputs MCP server will run on port ${PORT}"
-          
+
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -466,9 +466,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-          
+
           bash ${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh
-          
+
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -481,7 +481,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
-          
+
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="80"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -492,10 +492,10 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-          
+
           export GH_AW_ENGINE="copilot"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.20'
-          
+
           mkdir -p /home/runner/.copilot
           cat << GH_AW_MCP_CONFIG_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
@@ -604,7 +604,7 @@ jobs:
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
           LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
-          
+
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
@@ -1040,4 +1040,3 @@ jobs:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl
           if-no-files-found: ignore
-

--- a/packages/api/src/router/__tests__/coach-reconcile.test.ts
+++ b/packages/api/src/router/__tests__/coach-reconcile.test.ts
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReconcileResult } from "@acme/engine";
+
+const mocks = vi.hoisted(() => {
+  const auditReturning = vi.fn();
+  const auditValues = vi.fn(() => ({ returning: auditReturning }));
+  const auditInsert = vi.fn(() => ({ values: auditValues }));
+
+  return {
+    auditDb: { insert: auditInsert },
+    auditInsert,
+    auditValues,
+    auditReturning,
+    reconcilePlanVsActual: vi.fn(),
+  };
+});
+
+vi.mock("@acme/db/client", () => ({
+  db: mocks.auditDb,
+}));
+
+vi.mock("@acme/engine", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@acme/engine")>();
+  return {
+    ...actual,
+    reconcilePlanVsActual: mocks.reconcilePlanVsActual,
+  };
+});
+
+const { appRouter } = await import("../../root");
+
+const TEST_USER_ID = "coach-user-1";
+const TEST_DATE = "2026-04-10";
+
+function makeSession(userId = TEST_USER_ID) {
+  const now = new Date();
+  return {
+    user: {
+      id: userId,
+      name: "Coach User",
+      email: "coach@example.test",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+    session: {
+      id: "test-session",
+      userId,
+      token: "test-token",
+      expiresAt: new Date(Date.now() + 86_400_000),
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+function makePlanned(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    userId: TEST_USER_ID,
+    date: TEST_DATE,
+    sportType: "running",
+    workoutType: "tempo",
+    title: "Tempo Run",
+    targetDurationMin: 50,
+    targetDurationMax: 55,
+    targetHrZoneHigh: 4,
+    targetStrainHigh: 12,
+    status: "planned",
+    ...overrides,
+  };
+}
+
+function makeActivity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "10000000-0000-4000-8000-000000000001",
+    userId: TEST_USER_ID,
+    sportType: "running",
+    startedAt: new Date(`${TEST_DATE}T12:00:00Z`),
+    durationMinutes: 50,
+    avgHr: 150,
+    maxHr: 176,
+    ...overrides,
+  };
+}
+
+function makeReconcile(
+  overrides: Partial<ReconcileResult> = {},
+): ReconcileResult {
+  return {
+    date: TEST_DATE,
+    status: "completed",
+    matchedActivityIds: ["10000000-0000-4000-8000-000000000001"],
+    deviation: {
+      durationMinDelta: 0,
+      durationPctDelta: 0,
+      intensityShift: 0,
+      sportTypeMatch: true,
+    },
+    notes: ["matched by sportType+duration"],
+    confidence: 0.94,
+    ...overrides,
+  };
+}
+
+function makeDb(
+  args: {
+    planned?: ReturnType<typeof makePlanned> | null;
+    activities?: ReturnType<typeof makeActivity>[];
+    audits?: unknown[];
+  } = {},
+) {
+  const updateWhere = vi.fn(async () => undefined);
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  return {
+    update,
+    updateSet,
+    updateWhere,
+    query: {
+      Profile: {
+        findFirst: vi.fn(async () => ({
+          userId: TEST_USER_ID,
+          timezone: "UTC",
+          maxHr: 176,
+        })),
+      },
+      DailyWorkout: {
+        findFirst: vi.fn(async () =>
+          Object.hasOwn(args, "planned") ? args.planned : makePlanned(),
+        ),
+      },
+      Activity: {
+        findMany: vi.fn(async () => args.activities ?? [makeActivity()]),
+      },
+      RecommendationAudit: {
+        findMany: vi.fn(async () => args.audits ?? []),
+      },
+    },
+  };
+}
+
+function createCaller(db: ReturnType<typeof makeDb>, userId = TEST_USER_ID) {
+  return appRouter.createCaller({
+    authApi: null as never,
+    session: makeSession(userId),
+    db: db as never,
+  });
+}
+
+function setup(args: Parameters<typeof makeDb>[0] = {}) {
+  const db = makeDb(args);
+  return { caller: createCaller(db), db };
+}
+
+function auditRow() {
+  const calls = mocks.auditValues.mock.calls as unknown as Array<[unknown]>;
+  return calls.at(-1)![0] as {
+    kind: string;
+    payload: {
+      reconcile: ReconcileResult;
+      plannedId: string | null;
+      actualIds: string[];
+    };
+  };
+}
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function shiftIsoDay(isoDay: string, deltaDays: number) {
+  const date = new Date(`${isoDay}T12:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + deltaDays);
+  return date.toISOString().slice(0, 10);
+}
+
+function makeAudit(
+  date: string,
+  status: ReconcileResult["status"],
+  overrides: Record<string, unknown> = {},
+) {
+  const actualIds = status === "missed" ? [] : [`activity-${date}`];
+  return {
+    id: `audit-${date}`,
+    userId: TEST_USER_ID,
+    date,
+    kind: status === "missed" ? "workout_missed" : "workout_complete",
+    confidence: 0.9,
+    relatedActivityIds: actualIds,
+    payload: {
+      reconcile: makeReconcile({ date, status, matchedActivityIds: actualIds }),
+      plannedId: `planned-${date}`,
+      actualIds,
+      plannedDurationMin: 50,
+      actualDurationMin: status === "missed" ? 0 : 50,
+    },
+    ...overrides,
+  };
+}
+
+describe("coach reconciliation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auditReturning.mockResolvedValue([{ id: "audit-1" }]);
+    mocks.reconcilePlanVsActual.mockReturnValue(makeReconcile());
+  });
+
+  it("records completed reconciliation and updates DailyWorkout.status", async () => {
+    const { caller, db } = setup();
+
+    const result = await caller.coach.reconcile({
+      userId: TEST_USER_ID,
+      date: TEST_DATE,
+    });
+
+    expect(mocks.reconcilePlanVsActual).toHaveBeenCalledWith(
+      expect.objectContaining({
+        date: TEST_DATE,
+        planned: expect.objectContaining({ durationMin: 50 }),
+        actuals: [expect.objectContaining({ durationMin: 50 })],
+      }),
+    );
+    expect(result.auditId).toBe("audit-1");
+    expect(db.updateSet).toHaveBeenCalledWith({ status: "completed" });
+    expect(auditRow().kind).toBe("workout_complete");
+  });
+
+  it("records missed reconciliation and updates DailyWorkout.status", async () => {
+    mocks.reconcilePlanVsActual.mockReturnValue(
+      makeReconcile({
+        status: "missed",
+        matchedActivityIds: [],
+        confidence: 1,
+      }),
+    );
+    const { caller, db } = setup({ activities: [] });
+
+    await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
+
+    expect(auditRow().kind).toBe("workout_missed");
+    expect(db.updateSet).toHaveBeenCalledWith({ status: "missed" });
+  });
+
+  it("counts rest-day extras as completed adherence", async () => {
+    mocks.reconcilePlanVsActual.mockReturnValue(
+      makeReconcile({ status: "extra", confidence: 1 }),
+    );
+    const { caller, db } = setup({
+      planned: makePlanned({ workoutType: "rest", targetDurationMin: 0 }),
+    });
+
+    await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
+
+    expect(auditRow().kind).toBe("workout_complete");
+    expect(db.updateSet).toHaveBeenCalledWith({ status: "extra" });
+  });
+
+  it("records no-plan activity as override without touching DailyWorkout", async () => {
+    mocks.reconcilePlanVsActual.mockReturnValue(
+      makeReconcile({ status: "no-plan", confidence: 1 }),
+    );
+    const { caller, db } = setup({ planned: null });
+
+    await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
+
+    expect(auditRow().kind).toBe("override");
+    expect(auditRow().payload.plannedId).toBeNull();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("echoes engine confidence into the audit payload", async () => {
+    mocks.reconcilePlanVsActual.mockReturnValue(
+      makeReconcile({ confidence: 0.37 }),
+    );
+    const { caller } = setup();
+
+    await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
+
+    expect(auditRow().payload.reconcile.confidence).toBe(0.37);
+  });
+
+  it("rejects userId mismatch", async () => {
+    const { caller } = setup();
+
+    await expect(
+      caller.coach.reconcile({ userId: "other-user", date: TEST_DATE }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("propagates audit failure before mutating workout status", async () => {
+    mocks.auditReturning.mockRejectedValue(new Error("audit unavailable"));
+    const { caller, db } = setup();
+
+    await expect(
+      caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE }),
+    ).rejects.toThrow("audit unavailable");
+
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("coach adherenceTrend", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-10T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns points and completed percentage for basic audits", async () => {
+    const today = todayIso();
+    const rows = [
+      makeAudit(shiftIsoDay(today, -2), "completed"),
+      makeAudit(shiftIsoDay(today, -1), "missed"),
+      makeAudit(today, "partial"),
+    ];
+    const { caller } = setup({ audits: rows });
+
+    const result = await caller.coach.adherenceTrend({
+      userId: TEST_USER_ID,
+      days: 3,
+    });
+
+    expect(result.points.map((point) => point.status)).toEqual([
+      "completed",
+      "missed",
+      "partial",
+    ]);
+    expect(result.summary.completedPct).toBe(66.67);
+  });
+
+  it("computes current and longest streaks", async () => {
+    const today = todayIso();
+    const rows = Array.from({ length: 5 }, (_, index) =>
+      makeAudit(shiftIsoDay(today, index - 4), "completed"),
+    );
+    const { caller } = setup({ audits: rows });
+
+    const result = await caller.coach.adherenceTrend({
+      userId: TEST_USER_ID,
+      days: 5,
+    });
+
+    expect(result.summary.currentStreak).toBe(5);
+    expect(result.summary.longestStreak).toBe(5);
+  });
+
+  it("ignores audit rows outside the requested days window", async () => {
+    const today = todayIso();
+    const rows = [
+      makeAudit(shiftIsoDay(today, -10), "completed"),
+      makeAudit(shiftIsoDay(today, -1), "missed"),
+      makeAudit(today, "completed"),
+    ];
+    const { caller } = setup({ audits: rows });
+
+    const result = await caller.coach.adherenceTrend({
+      userId: TEST_USER_ID,
+      days: 2,
+    });
+
+    expect(result.points.map((point) => point.date)).toEqual([
+      shiftIsoDay(today, -1),
+      today,
+    ]);
+  });
+});

--- a/packages/api/src/router/coach.ts
+++ b/packages/api/src/router/coach.ts
@@ -5,12 +5,16 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
+import type { DailyWorkoutStatus } from "@acme/db/schema";
 import type {
   DailyRecommendationInput,
   Recommendation,
   RecommendationIntensity,
+  ReconcileInput,
+  ReconcileResult,
 } from "@acme/engine";
-import { and, desc, eq, gte, lte } from "@acme/db";
+import { and, asc, desc, eq, gte, inArray, lte } from "@acme/db";
+import * as schema from "@acme/db/schema";
 import {
   Activity,
   AdvancedMetric,
@@ -26,16 +30,23 @@ import {
   computeStrainScore,
   countConsecutiveHardDays,
   recommendDay,
+  reconcilePlanVsActual,
 } from "@acme/engine";
 
 import { frameRecommendationReason, recordRecommendationAudit } from "../lib";
-import { shiftIsoDay, todayInTimezone } from "../lib/timezone";
+import { dayInTimezone, shiftIsoDay, todayInTimezone } from "../lib/timezone";
 import { protectedProcedure } from "../trpc";
 
 const LLM_FRAME_TIMEOUT_MS = 5_000;
 type EngineReadinessZone = NonNullable<
   DailyRecommendationInput["readiness"]
 >["zone"];
+type PlannedWorkoutInput = NonNullable<ReconcileInput["planned"]>;
+type ActualActivityInput = ReconcileInput["actuals"][number];
+type PersistableReconcileStatus = Extract<
+  DailyWorkoutStatus,
+  ReconcileResult["status"]
+>;
 
 const IsoDateSchema = z
   .string()
@@ -241,6 +252,155 @@ async function frameReasonWithTimeout(
   }
 }
 
+function plannedWorkoutInput(
+  workout: typeof DailyWorkout.$inferSelect | null | undefined,
+): PlannedWorkoutInput | null {
+  if (!workout) return null;
+  return {
+    workoutType: workout.workoutType,
+    sportType: workout.sportType,
+    durationMin:
+      workout.targetDurationMin ??
+      workout.targetDurationMax ??
+      (workout.workoutType.toLowerCase() === "rest" ? 0 : 30),
+    intensity: inferIntensity(workout),
+  };
+}
+
+function actualActivityInput(
+  activity: typeof Activity.$inferSelect,
+  profile: typeof Profile.$inferSelect | null | undefined,
+): ActualActivityInput {
+  return {
+    id: activity.id,
+    sportType: activity.sportType,
+    durationMin: activity.durationMinutes,
+    avgHrBpm: activity.avgHr,
+    hrMax: profile?.maxHr ?? activity.maxHr,
+  };
+}
+
+function auditKindForReconcile(
+  reconcile: ReconcileResult,
+): "workout_complete" | "workout_missed" | "override" {
+  if (reconcile.status === "missed") return "workout_missed";
+  if (
+    reconcile.status === "completed" ||
+    reconcile.status === "partial" ||
+    reconcile.status === "extra"
+  ) {
+    return "workout_complete";
+  }
+  return "override";
+}
+
+function isPersistableWorkoutStatus(
+  status: ReconcileResult["status"],
+): status is PersistableReconcileStatus {
+  return status !== "no-plan";
+}
+
+function auditDate(value: Date | string): string {
+  return typeof value === "string" ? value : value.toISOString().slice(0, 10);
+}
+
+type ReconcileAuditPayload = {
+  reconcile?: ReconcileResult;
+  plannedId?: string | null;
+  actualIds?: string[];
+  plannedDurationMin?: number | null;
+  actualDurationMin?: number;
+};
+
+type AdherencePoint = {
+  date: string;
+  status: ReconcileResult["status"];
+  plannedDurationMin: number | null;
+  actualDurationMin: number;
+  confidence: number;
+  actualIds: string[];
+};
+
+function coercePayload(value: unknown): ReconcileAuditPayload {
+  return value && typeof value === "object"
+    ? (value as ReconcileAuditPayload)
+    : {};
+}
+
+function statusFromAudit(
+  kind: string,
+  payload: ReconcileAuditPayload,
+): ReconcileResult["status"] {
+  if (payload.reconcile?.status) return payload.reconcile.status;
+  if (kind === "workout_missed") return "missed";
+  if (kind === "override") return "no-plan";
+  return "completed";
+}
+
+function trendPointFromAudit(
+  row: typeof schema.RecommendationAudit.$inferSelect,
+) {
+  const payload = coercePayload(row.payload);
+  const status = statusFromAudit(row.kind, payload);
+  return {
+    date: auditDate(row.date),
+    status,
+    plannedDurationMin: payload.plannedDurationMin ?? null,
+    actualDurationMin: payload.actualDurationMin ?? 0,
+    confidence: payload.reconcile?.confidence ?? row.confidence ?? 0,
+    actualIds: payload.actualIds ?? row.relatedActivityIds ?? [],
+  } satisfies AdherencePoint;
+}
+
+function isAdherenceSuccess(point: AdherencePoint): boolean {
+  return (
+    point.status === "completed" ||
+    point.status === "partial" ||
+    point.status === "extra" ||
+    (point.status === "no-plan" && point.actualIds.length === 0)
+  );
+}
+
+function pct(count: number, total: number): number {
+  if (total === 0) return 0;
+  return Number(((count / total) * 100).toFixed(2));
+}
+
+function adherenceSummary(points: AdherencePoint[]) {
+  let longestStreak = 0;
+  let runningStreak = 0;
+  for (const point of points) {
+    if (isAdherenceSuccess(point)) {
+      runningStreak += 1;
+      longestStreak = Math.max(longestStreak, runningStreak);
+    } else {
+      runningStreak = 0;
+    }
+  }
+
+  let currentStreak = 0;
+  for (let index = points.length - 1; index >= 0; index -= 1) {
+    const point = points[index]!;
+    if (!isAdherenceSuccess(point)) break;
+    currentStreak += 1;
+  }
+
+  return {
+    completedPct: pct(points.filter(isAdherenceSuccess).length, points.length),
+    missedPct: pct(
+      points.filter((point) => point.status === "missed").length,
+      points.length,
+    ),
+    extraCount: points.filter(
+      (point) =>
+        point.status === "extra" ||
+        (point.status === "no-plan" && point.actualIds.length > 0),
+    ).length,
+    currentStreak,
+    longestStreak,
+  };
+}
+
 export const coachRouter = {
   getDailyRecommendation: protectedProcedure
     .input(z.object({ userId: z.string(), date: IsoDateSchema.optional() }))
@@ -374,5 +534,147 @@ export const coachRouter = {
           : recommendation,
         auditId: audit.id,
       };
+    }),
+
+  reconcile: protectedProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        date: IsoDateSchema,
+        matchWindow: z
+          .object({
+            minAbsoluteDurationMin: z.number().optional(),
+            durationMinTolerancePct: z.number().optional(),
+          })
+          .optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      if (input.userId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Cannot reconcile workouts for another user",
+        });
+      }
+
+      const [profile, planned] = await Promise.all([
+        ctx.db.query.Profile.findFirst({ where: eq(Profile.userId, userId) }),
+        ctx.db.query.DailyWorkout.findFirst({
+          where: and(
+            eq(DailyWorkout.userId, userId),
+            eq(DailyWorkout.date, input.date),
+          ),
+        }),
+      ]);
+      const timezone = profile?.timezone ?? "UTC";
+      const actualRows = await ctx.db.query.Activity.findMany({
+        where: and(
+          eq(Activity.userId, userId),
+          gte(
+            Activity.startedAt,
+            new Date(`${shiftIsoDay(input.date, -1)}T00:00:00Z`),
+          ),
+          lte(
+            Activity.startedAt,
+            new Date(`${shiftIsoDay(input.date, 1)}T23:59:59.999Z`),
+          ),
+        ),
+        orderBy: asc(Activity.startedAt),
+      });
+      const actuals = actualRows
+        .filter(
+          (activity) =>
+            dayInTimezone(activity.startedAt, timezone) === input.date,
+        )
+        .map((activity) => actualActivityInput(activity, profile ?? null));
+      const plannedInput = plannedWorkoutInput(planned ?? null);
+      const reconcile = reconcilePlanVsActual({
+        date: input.date,
+        planned: plannedInput,
+        actuals,
+        matchWindow: input.matchWindow,
+      });
+      const actualIds = actuals.map((activity) => activity.id);
+      const actualDurationMin = actuals.reduce(
+        (total, activity) => total + activity.durationMin,
+        0,
+      );
+
+      // The audit trail is written before mutating DailyWorkout.status. The
+      // helper uses the central DB writer, so this ordering preserves rollback
+      // semantics for audit failures in environments without a shared tx.
+      const audit = await recordRecommendationAudit({
+        userId,
+        date: input.date,
+        kind: auditKindForReconcile(reconcile),
+        confidence: reconcile.confidence,
+        durationMin: plannedInput?.durationMin ?? null,
+        relatedWorkoutId: planned?.id,
+        relatedActivityIds: actualIds,
+        payload: {
+          reconcile,
+          plannedId: planned?.id ?? null,
+          actualIds,
+          plannedDurationMin: plannedInput?.durationMin ?? null,
+          actualDurationMin,
+        },
+      });
+
+      if (planned && isPersistableWorkoutStatus(reconcile.status)) {
+        await ctx.db
+          .update(DailyWorkout)
+          .set({ status: reconcile.status })
+          .where(
+            and(
+              eq(DailyWorkout.userId, userId),
+              eq(DailyWorkout.id, planned.id),
+            ),
+          );
+      }
+
+      return { reconcile, auditId: audit.id };
+    }),
+
+  adherenceTrend: protectedProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        days: z.number().int().min(1).max(90).default(28),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      if (input.userId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Cannot request adherence for another user",
+        });
+      }
+
+      const profile = await ctx.db.query.Profile.findFirst({
+        where: eq(Profile.userId, userId),
+      });
+      const endDate = todayInTimezone(profile?.timezone);
+      const startDate = shiftIsoDay(endDate, -(input.days - 1));
+      const rows = await ctx.db.query.RecommendationAudit.findMany({
+        where: and(
+          eq(schema.RecommendationAudit.userId, userId),
+          inArray(schema.RecommendationAudit.kind, [
+            "workout_complete",
+            "workout_missed",
+            "override",
+          ]),
+          gte(schema.RecommendationAudit.date, startDate),
+          lte(schema.RecommendationAudit.date, endDate),
+        ),
+        orderBy: asc(schema.RecommendationAudit.date),
+      });
+      const points = rows
+        .map(trendPointFromAudit)
+        .filter((point) => point.date >= startDate && point.date <= endDate)
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+      return { points, summary: adherenceSummary(points) };
     }),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary
- Add deterministic coach.reconcile mutation backed by reconcilePlanVsActual
- Write audit rows before status mutation and return audit IDs
- Add coach.adherenceTrend aggregation with streak and percentage summary
- Cover reconciliation/adherence behavior with 10 Vitest cases

## Verification
- pnpm --filter @acme/api test
- pnpm --filter @acme/engine test
- pnpm typecheck
- pnpm --filter @acme/api lint
- pnpm format
- pre-commit run --all-files

Note: pre-commit auto-fixed trailing whitespace/EOF in generated .github workflow lockfiles.