### PR TITLE
feat(web): v0.17.0 wire accept/skip/defer buttons to coach mutations

### DIFF
--- a/apps/nextjs/src/app/_components/__tests__/today-recommendation-card.test.tsx
+++ b/apps/nextjs/src/app/_components/__tests__/today-recommendation-card.test.tsx
@@ -12,24 +12,70 @@ import type { Recommendation } from "@acme/engine";
 import { TodayRecommendationCard } from "../today-recommendation-card";
 
 const mockUseQuery = jest.fn();
+const mockUseMutation = jest.fn();
+const mockInvalidateQueries = jest.fn();
 const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+const mockAcceptMutate = jest.fn();
+const mockSkipMutate = jest.fn();
+const mockDeferMutate = jest.fn();
+type MockMutationOptions = {
+  mutationKey?: string[];
+  onError?: (error: { message: string }) => void;
+  onSuccess?: () => void;
+};
+
+const mockMutationOptions: Record<string, MockMutationOptions> = {};
+const mockMutationStates = {
+  accept: { isPending: false, mutate: mockAcceptMutate },
+  skip: { isPending: false, mutate: mockSkipMutate },
+  defer: { isPending: false, mutate: mockDeferMutate },
+};
 
 jest.mock("~/trpc/react", () => ({
   useTRPC: () => ({
     coach: {
       getDailyRecommendation: {
+        queryKey: (input: unknown) => [
+          "coach",
+          "getDailyRecommendation",
+          input,
+        ],
         queryOptions: (input: unknown) => ({ queryKey: ["coach", input] }),
+      },
+      accept: {
+        mutationOptions: (options: unknown) => ({
+          ...(options as object),
+          mutationKey: ["coach", "accept"],
+        }),
+      },
+      skip: {
+        mutationOptions: (options: unknown) => ({
+          ...(options as object),
+          mutationKey: ["coach", "skip"],
+        }),
+      },
+      defer: {
+        mutationOptions: (options: unknown) => ({
+          ...(options as object),
+          mutationKey: ["coach", "defer"],
+        }),
       },
     },
   }),
 }));
 
 jest.mock("@tanstack/react-query", () => ({
+  useMutation: (...args: unknown[]) => mockUseMutation(...args),
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
 }));
 
 jest.mock("@acme/ui/toast", () => ({
-  toast: { success: (message: string) => mockToastSuccess(message) },
+  toast: {
+    error: (message: string) => mockToastError(message),
+    success: (message: string) => mockToastSuccess(message),
+  },
 }));
 
 function makeRecommendation(confidence = 0.85): Recommendation {
@@ -75,10 +121,14 @@ function makeRecommendation(confidence = 0.85): Recommendation {
   };
 }
 
-function mockRecommendation(confidence = 0.85) {
+function mockRecommendation(
+  confidence = 0.85,
+  recommendationDate = "2026-05-27",
+) {
   mockUseQuery.mockReturnValue({
     data: {
-      auditId: "audit-123",
+      auditId: "00000000-0000-4000-8000-000000000123",
+      date: recommendationDate,
       recommendation: makeRecommendation(confidence),
     },
     isLoading: false,
@@ -86,9 +136,27 @@ function mockRecommendation(confidence = 0.85) {
   });
 }
 
+function setupMutations() {
+  mockUseMutation.mockImplementation((options: MockMutationOptions) => {
+    const action = options.mutationKey?.[1] ?? "";
+    mockMutationOptions[action] = options;
+    return mockMutationStates[action as "accept" | "skip" | "defer"];
+  });
+}
+
 describe("TodayRecommendationCard", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockMutationOptions.accept = {};
+    mockMutationOptions.skip = {};
+    mockMutationOptions.defer = {};
+    mockMutationStates.accept.isPending = false;
+    mockMutationStates.skip.isPending = false;
+    mockMutationStates.defer.isPending = false;
+    mockAcceptMutate.mockReset();
+    mockSkipMutate.mockReset();
+    mockDeferMutate.mockReset();
+    setupMutations();
   });
 
   it("renders the recommendation, hard block, and fired rule trace", () => {
@@ -164,36 +232,129 @@ describe("TodayRecommendationCard", () => {
     expect(screen.getByText(label)).toBeInTheDocument();
   });
 
-  it("fires accept, skip, and defer placeholder handlers", () => {
+  it("calls accept mutation with the recommendation audit args", () => {
     mockRecommendation();
-    const logSpy = jest
-      .spyOn(console, "log")
-      .mockImplementation(() => undefined);
 
     render(
       <TodayRecommendationCard userId="seed-user-001" date="2026-05-27" />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(mockAcceptMutate).toHaveBeenCalledWith({
+      auditId: "00000000-0000-4000-8000-000000000123",
+      date: "2026-05-27",
+      userId: "seed-user-001",
+    });
+  });
+
+  it("calls skip mutation with the recommendation audit args", () => {
+    mockRecommendation();
+
+    render(
+      <TodayRecommendationCard userId="seed-user-001" date="2026-05-27" />,
+    );
+
     fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(mockSkipMutate).toHaveBeenCalledWith({
+      auditId: "00000000-0000-4000-8000-000000000123",
+      date: "2026-05-27",
+      userId: "seed-user-001",
+    });
+  });
+
+  it("uses the recommendation response date when no date prop is provided", () => {
+    mockRecommendation(0.85, "2026-05-26");
+
+    render(<TodayRecommendationCard userId="seed-user-001" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(mockAcceptMutate).toHaveBeenCalledWith({
+      auditId: "00000000-0000-4000-8000-000000000123",
+      date: "2026-05-26",
+      userId: "seed-user-001",
+    });
+  });
+
+  it("opens defer picker and submits tomorrow's date", () => {
+    mockRecommendation();
+
+    render(
+      <TodayRecommendationCard userId="seed-user-001" date="2026-05-27" />,
+    );
+
     fireEvent.click(screen.getByRole("button", { name: "Defer" }));
+    const dateInput = screen.getByLabelText("Defer to") as HTMLInputElement;
 
-    expect(logSpy).toHaveBeenCalledWith("[v0.17.0-w1.4] accept", {
-      auditId: "audit-123",
-      userId: "seed-user-001",
+    expect(dateInput.value).toBe("2026-05-28");
+    expect(dateInput.min).toBe("2026-05-28");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save defer date" }));
+
+    expect(mockDeferMutate).toHaveBeenCalledWith({
+      auditId: "00000000-0000-4000-8000-000000000123",
       date: "2026-05-27",
+      deferToDate: "2026-05-28",
+      userId: "seed-user-001",
     });
-    expect(logSpy).toHaveBeenCalledWith("[v0.17.0-w1.4] skip", {
-      auditId: "audit-123",
-      userId: "seed-user-001",
-      date: "2026-05-27",
-    });
-    expect(logSpy).toHaveBeenCalledWith("[v0.17.0-w1.4] defer", {
-      auditId: "audit-123",
-      userId: "seed-user-001",
-      date: "2026-05-27",
+  });
+
+  it("prevents same-day or past defer dates at the UI level", () => {
+    mockRecommendation();
+
+    render(
+      <TodayRecommendationCard userId="seed-user-001" date="2026-05-27" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Defer" }));
+    fireEvent.change(screen.getByLabelText("Defer to"), {
+      target: { value: "2026-05-27" },
     });
 
-    logSpy.mockRestore();
+    expect(
+      screen.getByText("Choose a defer date after the recommendation date."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save defer date" }),
+    ).toBeDisabled();
+    expect(mockDeferMutate).not.toHaveBeenCalled();
+  });
+
+  it("disables all action buttons while any mutation is pending", () => {
+    mockRecommendation();
+    mockMutationStates.skip.isPending = true;
+
+    render(
+      <TodayRecommendationCard userId="seed-user-001" date="2026-05-27" />,
+    );
+
+    expect(screen.getByRole("button", { name: /Accept/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Skip/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Defer/ })).toBeDisabled();
+    expect(screen.getByLabelText("Skip pending")).toBeInTheDocument();
+  });
+
+  it("shows a success toast and invalidates the recommendation query on success", () => {
+    mockRecommendation();
+    mockAcceptMutate.mockImplementation(() => {
+      mockMutationOptions.accept?.onSuccess?.();
+    });
+
+    render(
+      <TodayRecommendationCard userId="seed-user-001" date="2026-05-27" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(mockToastSuccess).toHaveBeenCalledWith("Recommendation accepted");
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: [
+        "coach",
+        "getDailyRecommendation",
+        { date: "2026-05-27", userId: "seed-user-001" },
+      ],
+    });
   });
 });

--- a/apps/nextjs/src/app/_components/today-recommendation-card.tsx
+++ b/apps/nextjs/src/app/_components/today-recommendation-card.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
+import type { FormEvent } from "react";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { Recommendation, RuleTrace } from "@acme/engine";
 import { cn } from "@acme/ui";
@@ -15,6 +16,7 @@ import { useTRPC } from "~/trpc/react";
 type RecommendationPayload = {
   recommendation: Recommendation;
   auditId: string;
+  date: string;
 } | null;
 
 interface TodayRecommendationCardProps {
@@ -114,6 +116,12 @@ function hardBlockLabel(ruleId: string, rules: RuleTrace[]): string {
   );
 }
 
+function shiftIsoDay(value: string, days: number): string {
+  const shifted = new Date(`${value}T12:00:00Z`);
+  shifted.setUTCDate(shifted.getUTCDate() + days);
+  return shifted.toISOString().slice(0, 10);
+}
+
 function RecommendationSkeleton() {
   return (
     <section
@@ -141,11 +149,46 @@ export function TodayRecommendationCard({
   date,
 }: TodayRecommendationCardProps) {
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const [showAllRules, setShowAllRules] = useState(false);
+  const [isDeferOpen, setIsDeferOpen] = useState(false);
+  const [deferDate, setDeferDate] = useState("");
+  const [deferError, setDeferError] = useState<string | null>(null);
   const queryInput = date ? { userId, date } : { userId };
   const query = useQuery(
     trpc.coach.getDailyRecommendation.queryOptions(queryInput),
   );
+
+  const handleMutationSuccess = (message: string) => {
+    toast.success(message);
+    setIsDeferOpen(false);
+    void queryClient.invalidateQueries({
+      queryKey: trpc.coach.getDailyRecommendation.queryKey(queryInput),
+    });
+  };
+
+  const acceptMutation = useMutation(
+    trpc.coach.accept.mutationOptions({
+      onSuccess: () => handleMutationSuccess("Recommendation accepted"),
+      onError: (error) => toast.error(error.message),
+    }),
+  );
+  const skipMutation = useMutation(
+    trpc.coach.skip.mutationOptions({
+      onSuccess: () => handleMutationSuccess("Recommendation skipped"),
+      onError: (error) => toast.error(error.message),
+    }),
+  );
+  const deferMutation = useMutation(
+    trpc.coach.defer.mutationOptions({
+      onSuccess: () => handleMutationSuccess("Recommendation deferred"),
+      onError: (error) => toast.error(error.message),
+    }),
+  );
+  const isAnyMutationPending =
+    acceptMutation.isPending ||
+    skipMutation.isPending ||
+    deferMutation.isPending;
 
   if (query.isLoading) return <RecommendationSkeleton />;
 
@@ -188,14 +231,35 @@ export function TodayRecommendationCard({
   }
 
   const auditId = data?.auditId ?? "";
+  const effectiveDate = data.date;
+  const minDeferDate = shiftIsoDay(effectiveDate, 1);
+  const actionInput = { userId, date: effectiveDate, auditId };
   const firedRules = recommendation.rules.filter((rule) => rule.fired);
   const visibleRules = showAllRules ? recommendation.rules : firedRules;
   const confidence = confidenceLevel(recommendation.confidence);
 
-  function handleAction(action: "accept" | "skip" | "defer") {
-    // TODO(v0.17.0 W2.3): wire accept/skip/defer to coach.{accept,skip,defer} mutations.
-    console.log(`[v0.17.0-w1.4] ${action}`, { auditId, userId, date });
-    toast.success(`Recommendation ${action} recorded locally`);
+  function openDeferPicker() {
+    setDeferDate(minDeferDate);
+    setDeferError(null);
+    setIsDeferOpen(true);
+  }
+
+  function updateDeferDate(value: string) {
+    setDeferDate(value);
+    setDeferError(
+      value && value <= effectiveDate
+        ? "Choose a defer date after the recommendation date."
+        : null,
+    );
+  }
+
+  function submitDefer(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!deferDate || deferDate <= effectiveDate) {
+      setDeferError("Choose a defer date after the recommendation date.");
+      return;
+    }
+    deferMutation.mutate({ ...actionInput, deferToDate: deferDate });
   }
 
   return (
@@ -288,27 +352,106 @@ export function TodayRecommendationCard({
         <Button
           type="button"
           className="w-full bg-green-600 text-white hover:bg-green-500"
-          onClick={() => handleAction("accept")}
+          disabled={isAnyMutationPending || !auditId}
+          onClick={() => acceptMutation.mutate(actionInput)}
         >
+          {acceptMutation.isPending ? (
+            <span aria-label="Accept pending" role="status">
+              ⏳
+            </span>
+          ) : null}
           Accept
         </Button>
         <Button
           type="button"
           variant="secondary"
           className="w-full"
-          onClick={() => handleAction("skip")}
+          disabled={isAnyMutationPending || !auditId}
+          onClick={() => skipMutation.mutate(actionInput)}
         >
+          {skipMutation.isPending ? (
+            <span aria-label="Skip pending" role="status">
+              ⏳
+            </span>
+          ) : null}
           Skip
         </Button>
         <Button
           type="button"
           variant="outline"
           className="w-full"
-          onClick={() => handleAction("defer")}
+          disabled={isAnyMutationPending || !auditId}
+          onClick={openDeferPicker}
         >
+          {deferMutation.isPending ? (
+            <span aria-label="Defer pending" role="status">
+              ⏳
+            </span>
+          ) : null}
           Defer
         </Button>
       </div>
+
+      {isDeferOpen && (
+        <div
+          aria-labelledby="defer-dialog-title"
+          aria-modal="true"
+          className="bg-background mt-4 rounded-xl border p-4 shadow-sm"
+          role="dialog"
+        >
+          <form className="space-y-3" onSubmit={submitDefer}>
+            <h3 id="defer-dialog-title" className="text-sm font-semibold">
+              Defer recommendation
+            </h3>
+            <div>
+              <label className="text-sm font-medium" htmlFor="defer-to-date">
+                Defer to
+              </label>
+              <input
+                className="border-input bg-background mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                disabled={isAnyMutationPending}
+                id="defer-to-date"
+                min={minDeferDate}
+                onChange={(event) => updateDeferDate(event.target.value)}
+                type="date"
+                value={deferDate}
+              />
+            </div>
+            {deferError ? (
+              <p className="text-destructive text-sm" role="alert">
+                {deferError}
+              </p>
+            ) : null}
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={
+                  isAnyMutationPending ||
+                  !deferDate ||
+                  deferDate <= effectiveDate
+                }
+              >
+                {deferMutation.isPending ? (
+                  <span aria-label="Defer pending" role="status">
+                    ⏳
+                  </span>
+                ) : null}
+                Save defer date
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                disabled={isAnyMutationPending}
+                onClick={() => setIsDeferOpen(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
     </section>
   );
 }

--- a/packages/api/src/router/__tests__/coach.test.ts
+++ b/packages/api/src/router/__tests__/coach.test.ts
@@ -217,6 +217,7 @@ describe("coach router", () => {
     expect(result).toEqual({
       recommendation: engineRecommendation,
       auditId: "audit-1",
+      date: TEST_DATE,
     });
 
     expect(mocks.auditValues).toHaveBeenCalledTimes(1);

--- a/packages/api/src/router/coach.ts
+++ b/packages/api/src/router/coach.ts
@@ -601,6 +601,7 @@ export const coachRouter = {
           ? { ...recommendation, reason: framedReason }
           : recommendation,
         auditId: audit.id,
+        date,
       };
     }),
 


### PR DESCRIPTION
## Summary
- Wire TodayRecommendationCard Accept/Skip/Defer buttons to coach mutations
- Add defer date picker with next-day minimum validation
- Show toast feedback and invalidate daily recommendation query on success
- Extend card tests for mutation args, pending state, defer validation, and success refresh

## Verification
- pnpm typecheck
- pnpm --filter @acme/nextjs lint
- pnpm --filter @acme/nextjs exec jest --runInBand
- pnpm --filter @acme/api exec vitest run --reporter=basic
- pnpm format
- pre-commit run --all-files