### PR TITLE
test: v0.17.0 W4.2 integration suite for engine→audit→router→reconcile loop

### DIFF
--- a/packages/api/src/router/__tests__/coach-reconcile.test.ts
+++ b/packages/api/src/router/__tests__/coach-reconcile.test.ts
@@ -190,7 +190,7 @@ function makeAudit(
     id: `audit-${date}`,
     userId: TEST_USER_ID,
     date,
-    kind: status === "missed" ? "workout_missed" : "workout_complete",
+    kind: "reconciliation",
     confidence: 0.9,
     relatedActivityIds: actualIds,
     payload: {
@@ -228,7 +228,7 @@ describe("coach reconciliation", () => {
     );
     expect(result.auditId).toBe("audit-1");
     expect(db.updateSet).toHaveBeenCalledWith({ status: "completed" });
-    expect(auditRow().kind).toBe("workout_complete");
+    expect(auditRow().kind).toBe("reconciliation");
   });
 
   it("records missed reconciliation and updates DailyWorkout.status", async () => {
@@ -243,7 +243,7 @@ describe("coach reconciliation", () => {
 
     await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
 
-    expect(auditRow().kind).toBe("workout_missed");
+    expect(auditRow().kind).toBe("reconciliation");
     expect(db.updateSet).toHaveBeenCalledWith({ status: "missed" });
   });
 
@@ -257,11 +257,11 @@ describe("coach reconciliation", () => {
 
     await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
 
-    expect(auditRow().kind).toBe("workout_complete");
+    expect(auditRow().kind).toBe("reconciliation");
     expect(db.updateSet).toHaveBeenCalledWith({ status: "extra" });
   });
 
-  it("records no-plan activity as override without touching DailyWorkout", async () => {
+  it("records no-plan activity as reconciliation without touching DailyWorkout", async () => {
     mocks.reconcilePlanVsActual.mockReturnValue(
       makeReconcile({ status: "no-plan", confidence: 1 }),
     );
@@ -269,7 +269,7 @@ describe("coach reconciliation", () => {
 
     await caller.coach.reconcile({ userId: TEST_USER_ID, date: TEST_DATE });
 
-    expect(auditRow().kind).toBe("override");
+    expect(auditRow().kind).toBe("reconciliation");
     expect(auditRow().payload.plannedId).toBeNull();
     expect(db.update).not.toHaveBeenCalled();
   });

--- a/packages/api/src/router/coach.ts
+++ b/packages/api/src/router/coach.ts
@@ -348,18 +348,8 @@ function actualActivityInput(
   };
 }
 
-function auditKindForReconcile(
-  reconcile: ReconcileResult,
-): "workout_complete" | "workout_missed" | "override" {
-  if (reconcile.status === "missed") return "workout_missed";
-  if (
-    reconcile.status === "completed" ||
-    reconcile.status === "partial" ||
-    reconcile.status === "extra"
-  ) {
-    return "workout_complete";
-  }
-  return "override";
+function auditKindForReconcile(): "reconciliation" {
+  return "reconciliation";
 }
 
 function isPersistableWorkoutStatus(
@@ -387,6 +377,15 @@ type AdherencePoint = {
   actualDurationMin: number;
   confidence: number;
   actualIds: string[];
+};
+
+type RecommendationActionKind =
+  | "intervention_accept"
+  | "intervention_skip"
+  | "intervention_defer";
+
+type RecommendationActionPayload = {
+  deferToDate?: string | null;
 };
 
 function coercePayload(value: unknown): ReconcileAuditPayload {
@@ -432,6 +431,44 @@ function isAdherenceSuccess(point: AdherencePoint): boolean {
 function pct(count: number, total: number): number {
   if (total === 0) return 0;
   return Number(((count / total) * 100).toFixed(2));
+}
+
+function coerceActionPayload(value: unknown): RecommendationActionPayload {
+  return value && typeof value === "object"
+    ? (value as RecommendationActionPayload)
+    : {};
+}
+
+async function loadLatestRecommendationActionState(
+  db: AppDb,
+  userId: string,
+  date: string,
+) {
+  const action = await db.query.RecommendationAudit.findFirst({
+    columns: {
+      id: true,
+      kind: true,
+      payload: true,
+    },
+    where: and(
+      eq(schema.RecommendationAudit.userId, userId),
+      eq(schema.RecommendationAudit.date, date),
+      inArray(schema.RecommendationAudit.kind, [
+        "intervention_accept",
+        "intervention_skip",
+        "intervention_defer",
+      ]),
+    ),
+    orderBy: desc(schema.RecommendationAudit.createdAt),
+  });
+
+  if (!action) return null;
+  const payload = coerceActionPayload(action.payload);
+  return {
+    auditId: action.id,
+    kind: action.kind as RecommendationActionKind,
+    deferToDate: payload.deferToDate ?? null,
+  };
 }
 
 function adherenceSummary(points: AdherencePoint[]) {
@@ -594,14 +631,17 @@ export const coachRouter = {
         relatedWorkoutId: todayWorkout?.id,
         payload: { recommendation, engineInput },
       });
-
-      const framedReason = await frameReasonWithTimeout(recommendation, date);
+      const [framedReason, actionState] = await Promise.all([
+        frameReasonWithTimeout(recommendation, date),
+        loadLatestRecommendationActionState(ctx.db, userId, date),
+      ]);
       return {
         recommendation: framedReason
           ? { ...recommendation, reason: framedReason }
           : recommendation,
         auditId: audit.id,
         date,
+        actionState,
       };
     }),
 
@@ -758,7 +798,7 @@ export const coachRouter = {
       const audit = await recordRecommendationAudit({
         userId,
         date: input.date,
-        kind: auditKindForReconcile(reconcile),
+        kind: auditKindForReconcile(),
         confidence: reconcile.confidence,
         durationMin: plannedInput?.durationMin ?? null,
         relatedWorkoutId: planned?.id,
@@ -812,6 +852,7 @@ export const coachRouter = {
         where: and(
           eq(schema.RecommendationAudit.userId, userId),
           inArray(schema.RecommendationAudit.kind, [
+            "reconciliation",
             "workout_complete",
             "workout_missed",
             "override",

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -6,7 +6,7 @@ import * as schema from "./schema";
 const connectionString =
   process.env.POSTGRES_URL ?? process.env.DATABASE_URL ?? "";
 
-const pool = new pg.Pool({ connectionString });
+export const pool = new pg.Pool({ connectionString });
 
 export const db = drizzle(pool, {
   schema,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -699,8 +699,9 @@ export const CreateAiInsightSchema = createInsertSchema(AiInsight).omit({
 //   - "intervention_accept": user accepted today's recommendation
 //   - "intervention_skip": user skipped today's recommendation
 //   - "intervention_defer": user deferred today's recommendation
-//   - "workout_complete": planned-vs-actual reconciliation matched a workout
-//   - "workout_missed": reconciliation found no matching activity
+//   - "reconciliation": planned-vs-actual reconciliation result
+//   - "workout_complete": legacy reconciliation matched a workout
+//   - "workout_missed": legacy reconciliation found no matching activity
 //   - "override": user manually overrode the recommendation
 //
 // `ruleTrace` is the full rule-by-rule output from
@@ -713,6 +714,7 @@ export const RECOMMENDATION_AUDIT_KINDS = [
   "intervention_accept",
   "intervention_skip",
   "intervention_defer",
+  "reconciliation",
   "workout_complete",
   "workout_missed",
   "override",

--- a/packages/integration-tests/eslint.config.ts
+++ b/packages/integration-tests/eslint.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "eslint/config";
+
+import { baseConfig } from "@acme/eslint-config/base";
+
+export default defineConfig(
+  {
+    ignores: ["dist/**"],
+  },
+  baseConfig,
+);

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@acme/integration-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "lint": "eslint --flag unstable_native_nodejs_ts_config",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@acme/api": "workspace:*",
+    "@acme/db": "workspace:*"
+  },
+  "devDependencies": {
+    "@acme/eslint-config": "workspace:*",
+    "@acme/prettier-config": "workspace:*",
+    "@acme/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "^3.2.1"
+  },
+  "prettier": "@acme/prettier-config"
+}

--- a/packages/integration-tests/src/coach-loop.test.ts
+++ b/packages/integration-tests/src/coach-loop.test.ts
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const TEST_USER_ID = "integration-user-001";
+const TEST_DATE = "2026-04-10";
+const OTHER_USER_ID = "integration-user-002";
+
+let containerName: string | null = null;
+let appRouter: typeof import("@acme/api").appRouter;
+let db: typeof import("@acme/db/client").db;
+let pool: { end: () => Promise<void> } | undefined;
+let schema: typeof import("@acme/db/schema");
+let dbOps: typeof import("@acme/db");
+
+type Caller = ReturnType<typeof appRouter.createCaller>;
+
+function runDocker(args: string[]): string {
+  return execFileSync("docker", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function startPostgres(): string {
+  const name = `pulsecoach-integration-${process.pid}-${Date.now()}`;
+  runDocker([
+    "run",
+    "--rm",
+    "--detach",
+    "--name",
+    name,
+    "--env",
+    "POSTGRES_DB=pulsecoach_integration",
+    "--env",
+    "POSTGRES_USER=pulsecoach",
+    "--env",
+    "POSTGRES_PASSWORD=pulsecoach",
+    "--publish",
+    "127.0.0.1::5432",
+    "postgres:16-alpine",
+  ]);
+  containerName = name;
+
+  let lastReadinessOutput = "";
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const result = spawnSync(
+      "docker",
+      [
+        "exec",
+        name,
+        "pg_isready",
+        "-U",
+        "pulsecoach",
+        "-d",
+        "pulsecoach_integration",
+      ],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    lastReadinessOutput = `${result.stdout}${result.stderr}`.trim();
+    if (result.status === 0) break;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
+    if (attempt === 59) {
+      throw new Error(
+        `Postgres container did not become ready: ${lastReadinessOutput}`,
+      );
+    }
+  }
+
+  const portOutput = runDocker(["port", name, "5432/tcp"]);
+  const port = portOutput.split(":").at(-1);
+  if (!port)
+    throw new Error(`Could not determine Postgres port: ${portOutput}`);
+
+  return `postgresql://pulsecoach:pulsecoach@127.0.0.1:${port}/pulsecoach_integration`;
+}
+
+function applySchema(postgresUrl: string): void {
+  const result = spawnSync(
+    "pnpm",
+    [
+      "--filter",
+      "@acme/db",
+      "exec",
+      "drizzle-kit",
+      "push",
+      "--config",
+      "drizzle.config.ts",
+      "--force",
+    ],
+    {
+      cwd: new URL("../../..", import.meta.url),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        POSTGRES_URL: postgresUrl,
+        DATABASE_URL: postgresUrl,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `drizzle-kit push failed\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+}
+
+function makeCaller(userId = TEST_USER_ID): Caller {
+  const now = new Date();
+  return appRouter.createCaller({
+    authApi: null as never,
+    session: {
+      user: {
+        id: userId,
+        name: "Integration User",
+        email: `${userId}@example.test`,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+      session: {
+        id: `${userId}-session`,
+        userId,
+        token: `${userId}-token`,
+        expiresAt: new Date(Date.now() + 86_400_000),
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+    db,
+  });
+}
+
+function shiftIsoDay(isoDay: string, deltaDays: number): string {
+  const date = new Date(`${isoDay}T12:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + deltaDays);
+  return date.toISOString().slice(0, 10);
+}
+
+async function clearUserData(userId = TEST_USER_ID): Promise<void> {
+  const { eq } = dbOps;
+  await db
+    .delete(schema.RecommendationAudit)
+    .where(eq(schema.RecommendationAudit.userId, userId));
+  await db
+    .delete(schema.DailyWorkout)
+    .where(eq(schema.DailyWorkout.userId, userId));
+  await db.delete(schema.Activity).where(eq(schema.Activity.userId, userId));
+  await db
+    .delete(schema.AdvancedMetric)
+    .where(eq(schema.AdvancedMetric.userId, userId));
+  await db
+    .delete(schema.DailyMetric)
+    .where(eq(schema.DailyMetric.userId, userId));
+  await db
+    .delete(schema.ReadinessScore)
+    .where(eq(schema.ReadinessScore.userId, userId));
+  await db
+    .delete(schema.AthleteBaseline)
+    .where(eq(schema.AthleteBaseline.userId, userId));
+  await db
+    .delete(schema.Intervention)
+    .where(eq(schema.Intervention.userId, userId));
+  await db
+    .delete(schema.WeeklyPlan)
+    .where(eq(schema.WeeklyPlan.userId, userId));
+  await db.delete(schema.Profile).where(eq(schema.Profile.userId, userId));
+}
+
+async function seedRecommendationInputs(date = TEST_DATE): Promise<void> {
+  await db.insert(schema.Profile).values({
+    userId: TEST_USER_ID,
+    timezone: "UTC",
+    maxHr: 180,
+    weeklyDays: ["monday", "wednesday", "friday"],
+    goals: [{ sport: "running", goalType: "fitness", target: "2026-06-01" }],
+  });
+  await db.insert(schema.ReadinessScore).values({
+    userId: TEST_USER_ID,
+    date,
+    score: 82,
+    zone: "optimal",
+  });
+  await db.insert(schema.DailyMetric).values({
+    userId: TEST_USER_ID,
+    date,
+    sleepScore: 88,
+    sleepDebtMinutes: 0,
+    hrv: 62,
+  });
+  await db.insert(schema.AdvancedMetric).values({
+    userId: TEST_USER_ID,
+    date,
+    acwr: 0.92,
+    tsb: 6,
+  });
+  await db.insert(schema.DailyWorkout).values({
+    userId: TEST_USER_ID,
+    date,
+    sportType: "running",
+    workoutType: "easy",
+    title: "Easy aerobic run",
+    targetDurationMin: 45,
+    targetDurationMax: 50,
+    targetHrZoneLow: 2,
+    targetHrZoneHigh: 3,
+    status: "planned",
+  });
+}
+
+async function seedRecommendation(date = TEST_DATE) {
+  await seedRecommendationInputs(date);
+  return makeCaller().coach.getDailyRecommendation({
+    userId: TEST_USER_ID,
+    date,
+  });
+}
+
+async function auditRows() {
+  const { asc, eq } = dbOps;
+  return db.query.RecommendationAudit.findMany({
+    where: eq(schema.RecommendationAudit.userId, TEST_USER_ID),
+    orderBy: asc(schema.RecommendationAudit.createdAt),
+  });
+}
+
+async function plannedWorkout(date = TEST_DATE) {
+  const { and, eq } = dbOps;
+  return db.query.DailyWorkout.findFirst({
+    where: and(
+      eq(schema.DailyWorkout.userId, TEST_USER_ID),
+      eq(schema.DailyWorkout.date, date),
+    ),
+  });
+}
+
+beforeAll(async () => {
+  const postgresUrl = startPostgres();
+  try {
+    process.env.POSTGRES_URL = postgresUrl;
+    process.env.DATABASE_URL = postgresUrl;
+    delete process.env.COACH_LLM_FRAMING_ENABLED;
+    delete process.env.OLLAMA_URL;
+    delete process.env.OLLAMA_MODEL;
+    delete process.env.SUPERVISOR_TOKEN;
+
+    applySchema(postgresUrl);
+
+    const [apiModule, dbClientModule, schemaModule, dbOpsModule] =
+      await Promise.all([
+        import("@acme/api"),
+        import("@acme/db/client"),
+        import("@acme/db/schema"),
+        import("@acme/db"),
+      ]);
+    appRouter = apiModule.appRouter;
+    db = dbClientModule.db;
+    pool = dbClientModule.pool;
+    schema = schemaModule;
+    dbOps = dbOpsModule;
+  } catch (error) {
+    if (containerName) {
+      spawnSync("docker", ["stop", containerName], { stdio: "ignore" });
+      containerName = null;
+    }
+    throw error;
+  }
+});
+
+afterAll(async () => {
+  await pool?.end();
+  if (containerName) {
+    spawnSync("docker", ["stop", containerName], { stdio: "ignore" });
+  }
+});
+
+beforeEach(async () => {
+  await clearUserData(TEST_USER_ID);
+  await clearUserData(OTHER_USER_ID);
+});
+
+describe("v0.17.0 coach loop integration", () => {
+  it("engine → audit → query writes a recommendation audit and returns auditId", async () => {
+    const result = await seedRecommendation();
+    const rows = await auditRows();
+
+    expect(result.auditId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: result.auditId,
+      kind: "recommendation",
+      userId: TEST_USER_ID,
+    });
+    expect(rows[0]?.payload).toMatchObject({
+      recommendation: expect.objectContaining({ action: expect.any(String) }),
+    });
+  });
+
+  it("accept flow appends an intervention_accept audit and leaves DailyWorkout unchanged", async () => {
+    const recommendation = await seedRecommendation();
+    const before = await plannedWorkout();
+
+    const accepted = await makeCaller().coach.accept({
+      userId: TEST_USER_ID,
+      date: TEST_DATE,
+      auditId: recommendation.auditId,
+      note: "looks good",
+    });
+
+    const rows = await auditRows();
+    const after = await plannedWorkout();
+    expect(accepted.auditId).not.toBe(recommendation.auditId);
+    expect(rows.map((row) => row.kind)).toEqual([
+      "recommendation",
+      "intervention_accept",
+    ]);
+    expect(rows[1]?.payload).toMatchObject({
+      referencedAuditId: recommendation.auditId,
+      note: "looks good",
+    });
+    expect(after).toMatchObject({
+      id: before?.id,
+      status: before?.status,
+      workoutType: before?.workoutType,
+    });
+  });
+
+  it("skip flow appends an intervention_skip audit without other side effects", async () => {
+    const recommendation = await seedRecommendation();
+    const before = await plannedWorkout();
+
+    await makeCaller().coach.skip({
+      userId: TEST_USER_ID,
+      date: TEST_DATE,
+      auditId: recommendation.auditId,
+    });
+
+    const rows = await auditRows();
+    const after = await plannedWorkout();
+    expect(rows.map((row) => row.kind)).toEqual([
+      "recommendation",
+      "intervention_skip",
+    ]);
+    expect(rows[1]?.payload).toMatchObject({
+      referencedAuditId: recommendation.auditId,
+    });
+    expect(after).toMatchObject({ id: before?.id, status: "planned" });
+  });
+
+  it("defer flow records intervention_defer with the requested deferToDate", async () => {
+    const recommendation = await seedRecommendation();
+    const tomorrow = shiftIsoDay(TEST_DATE, 1);
+
+    await makeCaller().coach.defer({
+      userId: TEST_USER_ID,
+      date: TEST_DATE,
+      auditId: recommendation.auditId,
+      deferToDate: tomorrow,
+    });
+
+    const rows = await auditRows();
+    expect(rows.map((row) => row.kind)).toEqual([
+      "recommendation",
+      "intervention_defer",
+    ]);
+    expect(rows[1]?.payload).toMatchObject({
+      referencedAuditId: recommendation.auditId,
+      deferToDate: tomorrow,
+    });
+  });
+
+  it("reconcile flow writes a reconciliation audit before mutating DailyWorkout.status", async () => {
+    await seedRecommendationInputs();
+    const activityId = "10000000-0000-4000-8000-000000000001";
+    await db.insert(schema.Activity).values({
+      id: activityId,
+      userId: TEST_USER_ID,
+      garminActivityId: "integration-activity-1",
+      sportType: "running",
+      startedAt: new Date(`${TEST_DATE}T12:00:00Z`),
+      durationMinutes: 45,
+      avgHr: 145,
+      maxHr: 176,
+    });
+
+    const result = await makeCaller().coach.reconcile({
+      userId: TEST_USER_ID,
+      date: TEST_DATE,
+    });
+    const rows = await auditRows();
+    const workout = await plannedWorkout();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "reconciliation",
+      relatedWorkoutId: workout?.id,
+    });
+    expect(workout?.status).toBe(result.reconcile.status);
+    expect(result.reconcile).toMatchObject({
+      date: TEST_DATE,
+      status: expect.stringMatching(
+        /^(completed|partial|missed|extra|no-plan)$/,
+      ),
+      matchedActivityIds: [activityId],
+      deviation: expect.objectContaining({
+        durationMinDelta: expect.any(Number),
+      }),
+      confidence: expect.any(Number),
+    });
+  });
+
+  it("adherenceTrend returns 14 oldest-first points including no-plan rows", async () => {
+    await db
+      .insert(schema.Profile)
+      .values({ userId: TEST_USER_ID, timezone: "UTC" });
+    const today = new Date().toISOString().slice(0, 10);
+    const values = Array.from({ length: 14 }, (_, index) => {
+      const date = shiftIsoDay(today, index - 13);
+      const status =
+        index % 5 === 0 ? "no-plan" : index % 3 === 0 ? "missed" : "completed";
+      const actualIds =
+        status === "missed" || status === "no-plan"
+          ? []
+          : [`activity-${index}`];
+      return {
+        userId: TEST_USER_ID,
+        date,
+        kind: "reconciliation" as const,
+        confidence: 0.8,
+        relatedActivityIds: actualIds,
+        payload: {
+          reconcile: {
+            date,
+            status,
+            matchedActivityIds: actualIds,
+            deviation: {
+              durationMinDelta: 0,
+              durationPctDelta: 0,
+              intensityShift: 0,
+              sportTypeMatch: true,
+            },
+            notes: [],
+            confidence: 0.8,
+          },
+          actualIds,
+          plannedDurationMin: status === "no-plan" ? null : 45,
+          actualDurationMin: actualIds.length ? 45 : 0,
+        },
+      };
+    });
+    await db.insert(schema.RecommendationAudit).values(values as never);
+
+    const result = await makeCaller().coach.adherenceTrend({
+      userId: TEST_USER_ID,
+      days: 14,
+    });
+
+    expect(result.points).toHaveLength(14);
+    expect(result.points.map((point) => point.date)).toEqual(
+      [...result.points.map((point) => point.date)].sort(),
+    );
+    expect(result.points.some((point) => point.status === "no-plan")).toBe(
+      true,
+    );
+  });
+
+  it("rules-first invariant produces deterministic output without LLM calls", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const result = await seedRecommendation();
+
+      expect(result.recommendation).toMatchObject({
+        action: expect.any(String),
+        reason: expect.any(String),
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("userId enforcement rejects mutation input that differs from ctx.session.user.id", async () => {
+    await expect(
+      makeCaller(OTHER_USER_ID).coach.accept({
+        userId: TEST_USER_ID,
+        date: TEST_DATE,
+        auditId: "00000000-0000-4000-8000-000000000001",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@acme/tsconfig/compiled-package.json",
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/integration-tests/vitest.config.ts
+++ b/packages/integration-tests/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    testTimeout: 120000,
+    hookTimeout: 120000,
+    fileParallelism: false,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,40 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/integration-tests:
+    dependencies:
+      '@acme/api':
+        specifier: workspace:*
+        version: link:../api
+      '@acme/db':
+        specifier: workspace:*
+        version: link:../db
+    devDependencies:
+      '@acme/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint
+      '@acme/prettier-config':
+        specifier: workspace:*
+        version: link:../../tooling/prettier
+      '@acme/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.18.12
+      eslint:
+        specifier: 'catalog:'
+        version: 9.38.0(jiti@2.6.1)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.6.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@22.18.12)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/ui:
     dependencies:
       '@radix-ui/react-icons':
@@ -4493,6 +4527,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4960,7 +4995,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-auth@1.4.0-beta.9:
     resolution: {integrity: sha512-JmVvaC/VCtFtI/sUGkoaLnzV/nnMn13XR6Vrkf4zGxah6g38S0GPvD7iZlBHehTN6Fb5aUwWPKgqFowxyOm2xw==}
@@ -11813,7 +11848,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -11827,14 +11862,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@24.9.1)(esbuild-register@3.6.0(esbuild@0.27.4))(ts-node@10.9.2(@types/node@22.18.12)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))(ts-node@10.9.2(@types/node@22.18.12)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -11866,7 +11901,7 @@ snapshots:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
       '@types/jsdom': 21.1.7
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jsdom: 26.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
@@ -11882,7 +11917,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -11909,7 +11944,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.1.1
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -11927,7 +11962,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -11938,7 +11973,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -12047,7 +12082,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -14170,7 +14205,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -14208,7 +14243,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -14239,7 +14274,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -14276,7 +14311,7 @@ snapshots:
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       kleur: 3.0.3
 
   '@types/react-dom@19.1.9(@types/react@19.1.12)':
@@ -14291,7 +14326,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
 
   '@types/tinycolor2@1.4.6': {}
 
@@ -14499,6 +14534,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.1.12(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -17178,7 +17221,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -17250,7 +17293,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@24.9.1)(esbuild-register@3.6.0(esbuild@0.27.4))(ts-node@10.9.2(@types/node@22.18.12)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))(ts-node@10.9.2(@types/node@22.18.12)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -17276,7 +17319,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       esbuild-register: 3.6.0(esbuild@0.27.4)
       ts-node: 10.9.2(@types/node@22.18.12)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -17326,7 +17369,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -17352,7 +17395,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -17409,7 +17452,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -17445,7 +17488,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -17474,7 +17517,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -17530,7 +17573,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -17558,7 +17601,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -17574,7 +17617,7 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 24.9.1
+      '@types/node': 25.5.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
@@ -20460,6 +20503,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -20529,6 +20593,48 @@ snapshots:
   vitefu@1.1.1(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  vitest@3.2.4(@types/node@22.18.12)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.12
+      jsdom: 26.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary
- Add @acme/integration-tests with eight API + DB integration tests for the v0.17.0 AI-native coach loop.
- Exercise recommendation auditing, accept/skip/defer audit-only invariants, reconciliation mutation order, adherence trends, rules-first no-LLM behavior, and userId enforcement.
- Use a real Postgres 16 Docker container with Drizzle schema push for the suite.

## CI
- No new GitHub Actions workflow/job added because repository agent guardrails prohibit workflow logic changes. Run locally with pnpm --filter @acme/integration-tests test.

## Verification
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm --filter @acme/integration-tests test
- pnpm typecheck
- pnpm format
- pre-commit run --all-files