### PR TITLE
test: add coach loop Playwright e2e

### DIFF
--- a/apps/nextjs/e2e/coach-loop.spec.ts
+++ b/apps/nextjs/e2e/coach-loop.spec.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+function isoDay(offsetDays = 0): string {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+  return date.toISOString().slice(0, 10);
+}
+
+const today = isoDay();
+const tomorrow = isoDay(1);
+
+function seedCoachLoop(): void {
+  execFileSync("pnpm", ["--filter", "@acme/db", "db:seed:e2e"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+}
+
+test.describe.serial("AI-native coach loop", () => {
+  test.beforeEach(() => seedCoachLoop());
+
+  test("daily recommendation visible with expandable rule trace", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("today-recommendation-card")).toBeVisible();
+    await expect(
+      page.getByTestId("today-recommendation-headline"),
+    ).toContainText(/z2 run/i);
+    await expect(page.getByTestId("today-recommendation-duration")).toHaveText(
+      "30 min",
+    );
+    const ruleTrace = page.getByTestId("rule-trace-accordion");
+    await expect(ruleTrace).not.toHaveAttribute("open", "");
+    await ruleTrace.locator("summary").click();
+    await expect(ruleTrace).toHaveAttribute("open", "");
+    await expect(page.getByTestId("rule-trace-row").first()).toBeVisible();
+    await ruleTrace.locator("summary").click();
+    await expect(ruleTrace).not.toHaveAttribute("open", "");
+  });
+
+  test("accept records feedback and reflects accepted state", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("recommendation-accept").click();
+    await expect(page.getByText("Recommendation accepted")).toBeVisible();
+    await expect(
+      page.getByTestId("today-recommendation-action-state"),
+    ).toHaveText("Accepted");
+  });
+
+  test("skip records feedback and shows a success toast", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("recommendation-skip").click();
+    await expect(page.getByText("Recommendation skipped")).toBeVisible();
+  });
+
+  test("defer validates same-day dates and saves tomorrow", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("recommendation-defer").click();
+    const dateInput = page.getByTestId("recommendation-defer-date");
+    const saveButton = page.getByTestId("recommendation-save-defer");
+    await expect(dateInput).toHaveValue(tomorrow);
+    await dateInput.fill(today);
+    await expect(
+      page.getByText("Choose a defer date after the recommendation date."),
+    ).toBeVisible();
+    await expect(saveButton).toBeDisabled();
+    await dateInput.fill(tomorrow);
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+    await expect(page.getByText("Recommendation deferred")).toBeVisible();
+  });
+
+  test("adherence trend card renders seeded seven-day history", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("adherence-trend-card")).toBeVisible();
+    await expect(page.getByTestId("adherence-rate")).toContainText(/\d+%/);
+    await expect(page.getByTestId("adherence-cell")).toHaveCount(14);
+  });
+
+  test("rule trace accordion exposes rule explanations", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("rule-trace-accordion").locator("summary").click();
+    await expect(page.getByTestId("rule-trace-row").first()).toContainText(
+      /Plan day|Readiness|signals/i,
+    );
+  });
+});

--- a/apps/nextjs/playwright.config.ts
+++ b/apps/nextjs/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "list",
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
@@ -17,5 +17,20 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  // Don't auto-start webServer — assumes dev server is already running
+  webServer: {
+    command: "pnpm --filter @acme/nextjs exec -- next dev --hostname 127.0.0.1",
+    env: {
+      AUTH_DISCORD_ID: "ci-placeholder",
+      AUTH_DISCORD_SECRET: "ci-placeholder",
+      AUTH_SECRET: "ci-secret",
+      DEV_BYPASS_AUTH: "true",
+      NODE_ENV: "development",
+      POSTGRES_URL:
+        process.env.POSTGRES_URL ??
+        "postgresql://postgres:postgres@localhost:5432/pulsecoach_e2e",
+    },
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: "http://localhost:3000",
+  },
 });

--- a/apps/nextjs/src/app/_components/adherence-trend-card.tsx
+++ b/apps/nextjs/src/app/_components/adherence-trend-card.tsx
@@ -231,7 +231,10 @@ export function AdherenceTrendCard({ userId }: { userId: string }) {
   }
 
   return (
-    <section className="bg-card rounded-2xl border p-5 shadow-sm">
+    <section
+      className="bg-card rounded-2xl border p-5 shadow-sm"
+      data-testid="adherence-trend-card"
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="text-muted-foreground text-sm font-medium">
@@ -269,6 +272,7 @@ export function AdherenceTrendCard({ userId }: { userId: string }) {
             <div
               className="text-4xl font-bold tabular-nums"
               aria-label={`Adherence rate ${rate} percent`}
+              data-testid="adherence-rate"
             >
               {rate}%
             </div>
@@ -281,6 +285,7 @@ export function AdherenceTrendCard({ userId }: { userId: string }) {
           <div
             className="mt-5 flex gap-1"
             aria-label={`${days} day adherence strip`}
+            data-testid="adherence-strip"
           >
             {cells.map((cell) => {
               const status = cell.point?.status ?? "no-data";
@@ -301,6 +306,7 @@ export function AdherenceTrendCard({ userId }: { userId: string }) {
                   onClick={() => setSelectedDate(cell.date)}
                   onFocus={() => setSelectedDate(cell.date)}
                   onMouseEnter={() => setSelectedDate(cell.date)}
+                  data-testid="adherence-cell"
                 />
               );
             })}

--- a/apps/nextjs/src/app/_components/today-recommendation-card.tsx
+++ b/apps/nextjs/src/app/_components/today-recommendation-card.tsx
@@ -6,6 +6,7 @@ import type { FormEvent } from "react";
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import type { RouterOutputs } from "@acme/api";
 import type { Recommendation, RuleTrace } from "@acme/engine";
 import { cn } from "@acme/ui";
 import { Button } from "@acme/ui/button";
@@ -13,11 +14,10 @@ import { toast } from "@acme/ui/toast";
 
 import { useTRPC } from "~/trpc/react";
 
-type RecommendationPayload = {
-  recommendation: Recommendation;
-  auditId: string;
-  date: string;
-} | null;
+type RecommendationPayload = RouterOutputs["coach"]["getDailyRecommendation"];
+type RecommendationActionState = NonNullable<
+  NonNullable<RecommendationPayload>["actionState"]
+>;
 
 interface TodayRecommendationCardProps {
   userId: string;
@@ -29,6 +29,12 @@ const ACTION_LABEL: Record<Recommendation["action"], string> = {
   rest: "Rest day",
   active_recovery: "Active recovery",
   deload: "Deload",
+};
+
+const ACTION_STATE_LABEL: Record<RecommendationActionState["kind"], string> = {
+  intervention_accept: "Accepted",
+  intervention_skip: "Skipped",
+  intervention_defer: "Deferred",
 };
 
 const SEVERITY_STYLE: Record<
@@ -210,10 +216,9 @@ export function TodayRecommendationCard({
     );
   }
 
-  const data = query.data as RecommendationPayload | undefined;
-  const recommendation = data?.recommendation;
+  const data = query.data;
 
-  if (!recommendation) {
+  if (!data?.recommendation) {
     return (
       <section className="bg-card rounded-2xl border p-5 text-center">
         <h2 className="text-lg font-semibold">No recommendation for today</h2>
@@ -230,8 +235,10 @@ export function TodayRecommendationCard({
     );
   }
 
-  const auditId = data?.auditId ?? "";
+  const recommendation = data.recommendation;
+  const auditId = data.auditId;
   const effectiveDate = data.date;
+  const actionState = data.actionState;
   const minDeferDate = shiftIsoDay(effectiveDate, 1);
   const actionInput = { userId, date: effectiveDate, auditId };
   const firedRules = recommendation.rules.filter((rule) => rule.fired);
@@ -263,16 +270,36 @@ export function TodayRecommendationCard({
   }
 
   return (
-    <section className="bg-card rounded-2xl border p-5 shadow-sm">
+    <section
+      className="bg-card rounded-2xl border p-5 shadow-sm"
+      data-testid="today-recommendation-card"
+    >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="bg-primary text-primary-foreground rounded-full px-3 py-1 text-xs font-semibold">
+            <span
+              className="bg-primary text-primary-foreground rounded-full px-3 py-1 text-xs font-semibold"
+              data-testid="today-recommendation-headline"
+            >
               {formatHeadline(recommendation)}
             </span>
-            <span className="text-muted-foreground text-xs font-medium tabular-nums">
+            <span
+              className="text-muted-foreground text-xs font-medium tabular-nums"
+              data-testid="today-recommendation-duration"
+            >
               {formatDuration(recommendation.durationMin)}
             </span>
+            {actionState ? (
+              <span
+                className="border-primary/30 bg-primary/10 text-primary rounded-full border px-3 py-1 text-xs font-semibold"
+                data-testid="today-recommendation-action-state"
+              >
+                {ACTION_STATE_LABEL[actionState.kind]}
+                {actionState.deferToDate
+                  ? ` to ${actionState.deferToDate}`
+                  : ""}
+              </span>
+            ) : null}
           </div>
           <h2 className="mt-3 text-xl leading-tight font-semibold">
             {recommendation.reason}
@@ -305,7 +332,10 @@ export function TodayRecommendationCard({
         </div>
       )}
 
-      <details className="mt-4 rounded-xl border p-3">
+      <details
+        className="mt-4 rounded-xl border p-3"
+        data-testid="rule-trace-accordion"
+      >
         <summary className="focus-visible:ring-ring cursor-pointer text-sm font-semibold focus-visible:ring-2 focus-visible:outline-none">
           Why
         </summary>
@@ -316,6 +346,7 @@ export function TodayRecommendationCard({
               return (
                 <div
                   key={rule.ruleId}
+                  data-testid="rule-trace-row"
                   className={cn(
                     "rounded-lg border px-3 py-2 text-sm",
                     style.className,
@@ -354,6 +385,7 @@ export function TodayRecommendationCard({
           className="w-full bg-green-600 text-white hover:bg-green-500"
           disabled={isAnyMutationPending || !auditId}
           onClick={() => acceptMutation.mutate(actionInput)}
+          data-testid="recommendation-accept"
         >
           {acceptMutation.isPending ? (
             <span aria-label="Accept pending" role="status">
@@ -368,6 +400,7 @@ export function TodayRecommendationCard({
           className="w-full"
           disabled={isAnyMutationPending || !auditId}
           onClick={() => skipMutation.mutate(actionInput)}
+          data-testid="recommendation-skip"
         >
           {skipMutation.isPending ? (
             <span aria-label="Skip pending" role="status">
@@ -382,6 +415,7 @@ export function TodayRecommendationCard({
           className="w-full"
           disabled={isAnyMutationPending || !auditId}
           onClick={openDeferPicker}
+          data-testid="recommendation-defer"
         >
           {deferMutation.isPending ? (
             <span aria-label="Defer pending" role="status">
@@ -415,6 +449,7 @@ export function TodayRecommendationCard({
                 onChange={(event) => updateDeferDate(event.target.value)}
                 type="date"
                 value={deferDate}
+                data-testid="recommendation-defer-date"
               />
             </div>
             {deferError ? (
@@ -431,6 +466,7 @@ export function TodayRecommendationCard({
                   !deferDate ||
                   deferDate <= effectiveDate
                 }
+                data-testid="recommendation-save-defer"
               >
                 {deferMutation.isPending ? (
                   <span aria-label="Defer pending" role="status">

--- a/packages/api/src/router/coach.ts
+++ b/packages/api/src/router/coach.ts
@@ -389,6 +389,18 @@ type AdherencePoint = {
   actualIds: string[];
 };
 
+const RECOMMENDATION_ACTION_KINDS = [
+  "intervention_accept",
+  "intervention_skip",
+  "intervention_defer",
+] as const;
+
+type RecommendationActionKind = (typeof RECOMMENDATION_ACTION_KINDS)[number];
+
+type RecommendationActionPayload = {
+  deferToDate?: string | null;
+};
+
 function coercePayload(value: unknown): ReconcileAuditPayload {
   return value && typeof value === "object"
     ? (value as ReconcileAuditPayload)
@@ -432,6 +444,35 @@ function isAdherenceSuccess(point: AdherencePoint): boolean {
 function pct(count: number, total: number): number {
   if (total === 0) return 0;
   return Number(((count / total) * 100).toFixed(2));
+}
+
+function coerceActionPayload(value: unknown): RecommendationActionPayload {
+  return value && typeof value === "object"
+    ? (value as RecommendationActionPayload)
+    : {};
+}
+
+async function loadLatestRecommendationActionState(
+  db: AppDb,
+  userId: string,
+  date: string,
+) {
+  const action = await db.query.RecommendationAudit.findFirst({
+    where: and(
+      eq(schema.RecommendationAudit.userId, userId),
+      eq(schema.RecommendationAudit.date, date),
+      inArray(schema.RecommendationAudit.kind, RECOMMENDATION_ACTION_KINDS),
+    ),
+    orderBy: desc(schema.RecommendationAudit.createdAt),
+  });
+
+  if (!action) return null;
+  const payload = coerceActionPayload(action.payload);
+  return {
+    auditId: action.id,
+    kind: action.kind as RecommendationActionKind,
+    deferToDate: payload.deferToDate ?? null,
+  };
 }
 
 function adherenceSummary(points: AdherencePoint[]) {
@@ -595,13 +636,17 @@ export const coachRouter = {
         payload: { recommendation, engineInput },
       });
 
-      const framedReason = await frameReasonWithTimeout(recommendation, date);
+      const [framedReason, actionState] = await Promise.all([
+        frameReasonWithTimeout(recommendation, date),
+        loadLatestRecommendationActionState(ctx.db, userId, date),
+      ]);
       return {
         recommendation: framedReason
           ? { ...recommendation, reason: framedReason }
           : recommendation,
         auditId: audit.id,
         date,
+        actionState,
       };
     }),
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,7 +27,8 @@
     "studio": "pnpm with-env drizzle-kit studio",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "with-env": "dotenv -e ../../.env --",
-    "db:seed": "dotenv -e ../../.env -- tsx src/seed.ts"
+    "db:seed": "dotenv -e ../../.env -- tsx src/seed.ts",
+    "db:seed:e2e": "tsx src/seed-e2e.ts"
   },
   "dependencies": {
     "drizzle-orm": "^0.44.7",

--- a/packages/db/src/seed-e2e.ts
+++ b/packages/db/src/seed-e2e.ts
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/** Idempotent e2e seed for the AI-native coach loop Playwright suite. */
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+
+import {
+  account,
+  Activity,
+  AdvancedMetric,
+  DailyMetric,
+  DailyWorkout,
+  Profile,
+  ReadinessScore,
+  RecommendationAudit,
+  session,
+  user,
+} from "./schema";
+
+const USER_ID = "seed-user-001";
+const DATABASE_URL = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error("POSTGRES_URL or DATABASE_URL must be set");
+
+const pool = new pg.Pool({
+  connectionString: DATABASE_URL.replace(":6543", ":5432"),
+});
+const db = drizzle(pool, { casing: "snake_case" });
+
+function isoDay(offsetDays = 0): string {
+  const date = new Date();
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+  return date.toISOString().slice(0, 10);
+}
+
+function dateAt(day: string, hour: number): Date {
+  return new Date(`${day}T${String(hour).padStart(2, "0")}:00:00.000Z`);
+}
+
+async function resetSeedData(): Promise<void> {
+  await db.delete(session).where(eq(session.userId, USER_ID));
+  await db.delete(account).where(eq(account.userId, USER_ID));
+  await db
+    .delete(RecommendationAudit)
+    .where(eq(RecommendationAudit.userId, USER_ID));
+  await db.delete(Activity).where(eq(Activity.userId, USER_ID));
+  await db.delete(AdvancedMetric).where(eq(AdvancedMetric.userId, USER_ID));
+  await db.delete(DailyWorkout).where(eq(DailyWorkout.userId, USER_ID));
+  await db.delete(ReadinessScore).where(eq(ReadinessScore.userId, USER_ID));
+  await db.delete(DailyMetric).where(eq(DailyMetric.userId, USER_ID));
+  await db.delete(Profile).where(eq(Profile.userId, USER_ID));
+  await db.delete(user).where(eq(user.id, USER_ID));
+}
+
+async function seed(): Promise<void> {
+  const now = new Date();
+  const today = isoDay();
+  await resetSeedData();
+
+  await db.insert(user).values({
+    id: USER_ID,
+    name: "E2E Coach User",
+    email: "e2e@local",
+    emailVerified: true,
+    image: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(Profile).values({
+    userId: USER_ID,
+    age: 36,
+    sex: "male",
+    massKg: 72,
+    heightCm: 178,
+    timezone: "UTC",
+    experienceLevel: "intermediate",
+    primarySports: ["running"],
+    goals: [
+      {
+        sport: "running",
+        goalType: "consistency",
+        target: "steady aerobic base",
+      },
+    ],
+    weeklyDays: ["mon", "wed", "fri", "sun"],
+    minutesPerDay: 45,
+    maxHr: 190,
+    restingHrBaseline: 52,
+    hrvBaseline: 64,
+    sleepBaseline: 450,
+    vo2maxRunning: 50,
+  });
+  await db.insert(DailyMetric).values({
+    userId: USER_ID,
+    date: today,
+    sleepScore: 78,
+    totalSleepMinutes: 440,
+    deepSleepMinutes: 85,
+    remSleepMinutes: 110,
+    lightSleepMinutes: 225,
+    awakeMinutes: 20,
+    hrv: 62,
+    restingHr: 53,
+    stressScore: 22,
+    bodyBatteryStart: 82,
+    bodyBatteryEnd: 36,
+    steps: 8200,
+    garminTrainingReadiness: 66,
+    garminTrainingReadinessLevel: "medium",
+    garminTrainingLoad: 38,
+    intensityMinutes: 20,
+    calories: 2300,
+    maxHr: 145,
+  });
+  await db.insert(ReadinessScore).values({
+    userId: USER_ID,
+    date: today,
+    score: 64,
+    zone: "balanced",
+    sleepQuantityComponent: 70,
+    sleepQualityComponent: 68,
+    hrvComponent: 62,
+    restingHrComponent: 65,
+    trainingLoadComponent: 58,
+    stressComponent: 66,
+    explanation: "Medium readiness: aerobic work is appropriate.",
+    factors: { source: "e2e", level: "medium" },
+  });
+  await db.insert(AdvancedMetric).values({
+    userId: USER_ID,
+    date: today,
+    ctl: 38,
+    atl: 35,
+    tsb: 3,
+    acwr: 0.92,
+    rampRate: 1.4,
+  });
+  const [workout] = await db
+    .insert(DailyWorkout)
+    .values({
+      userId: USER_ID,
+      date: today,
+      sportType: "running",
+      workoutType: "z2_run",
+      title: "Z2 30min Run",
+      description: "Easy zone 2 aerobic run for 30 minutes.",
+      targetDurationMin: 30,
+      targetDurationMax: 30,
+      targetHrZoneLow: 2,
+      targetHrZoneHigh: 2,
+      targetStrainLow: 4,
+      targetStrainHigh: 7,
+      status: "planned",
+      explanation: "Seeded e2e workout for the coach loop.",
+    })
+    .returning({ id: DailyWorkout.id });
+  await db.insert(RecommendationAudit).values({
+    userId: USER_ID,
+    date: today,
+    kind: "recommendation",
+    action: "workout",
+    intensity: "easy",
+    workoutType: "z2_run",
+    durationMin: 30,
+    confidence: 0.72,
+    hardBlocks: [],
+    ruleTrace: [
+      {
+        ruleId: "plan-honored-when-safe",
+        fired: true,
+        severity: "info",
+        message: "Plan day — no signals against your scheduled workout.",
+        inputs: { plannedWorkoutType: "z2_run" },
+      },
+      {
+        ruleId: "readiness-balanced-allows-training",
+        fired: true,
+        severity: "info",
+        message:
+          "Readiness is balanced, so a steady aerobic session is appropriate.",
+        inputs: { readiness: "balanced" },
+      },
+    ],
+    relatedWorkoutId: workout?.id,
+    payload: { source: "e2e-seed" },
+  });
+
+  for (let offset = -7; offset <= -1; offset += 1) {
+    const date = isoDay(offset);
+    const completed = offset % 3 !== 0;
+    let activityId: string | null = null;
+    if (completed) {
+      const [activity] = await db
+        .insert(Activity)
+        .values({
+          userId: USER_ID,
+          garminActivityId: `e2e-${date}`,
+          sportType: "running",
+          subType: "easy",
+          startedAt: dateAt(date, 7),
+          endedAt: dateAt(date, 8),
+          durationMinutes: 31,
+          distanceMeters: 5000,
+          avgHr: 138,
+          maxHr: 155,
+          calories: 360,
+          trimpScore: 35,
+          rawGarminData: { source: "e2e" },
+        })
+        .returning({ id: Activity.id });
+      activityId = activity?.id ?? null;
+    }
+    await db.insert(RecommendationAudit).values({
+      userId: USER_ID,
+      date,
+      kind: completed ? "workout_complete" : "workout_missed",
+      confidence: 0.82,
+      durationMin: 30,
+      relatedWorkoutId: null,
+      relatedActivityIds: activityId ? [activityId] : [],
+      payload: {
+        reconcile: {
+          status: completed ? "completed" : "missed",
+          confidence: 0.82,
+        },
+        plannedId: null,
+        actualIds: activityId ? [activityId] : [],
+        plannedDurationMin: 30,
+        actualDurationMin: completed ? 31 : 0,
+      },
+    });
+  }
+  await db.execute(sql`select 1`);
+  await pool.end();
+  console.log(`Seeded e2e coach-loop data for ${USER_ID} on ${today}`);
+}
+
+seed().catch(async (error) => {
+  console.error("E2E seed failed", error);
+  await pool.end();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add Playwright coach-loop e2e coverage for daily recommendation visibility, accept, skip, defer validation, adherence trend, and rule-trace rows.
- Add idempotent @acme/db e2e seed for seed-user-001 and expose action state from daily recommendations for UI assertions.
- Add data-testid attributes for TodayRecommendationCard and AdherenceTrendCard.

## CI
- New workflow not added because repository AGENTS.md prohibits modifying .github/workflows/*.yml/*.yaml. Tests remain runnable via pnpm --filter @acme/nextjs exec playwright test.

## Verification
- pnpm --filter @acme/nextjs build
- pnpm --filter @acme/nextjs exec playwright test e2e/coach-loop.spec.ts (6 passed)
- pnpm typecheck
- pnpm format
- pre-commit run --all-files