### PR TITLE
chore(release): bump v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.17.0] - 2026-05-28 — AI-native coach loop
+
+### Added
+
+- Rules-first daily recommendation engine with inescapable RecommendationAudit (#206, #208, #209)
+- TodayRecommendationCard with rule trace + accept/skip/defer (#211, #214)
+- coach.accept/skip/defer mutations with audit-only side effects (#210)
+- Planned-vs-actual reconciliation engine + coach.reconcile/adherenceTrend (#207, #212)
+- AdherenceTrendCard with 7/14/28d windows (#213)
+- Integration test suite (8 scenarios, real Postgres) (#215)
+- Playwright e2e coach loop tests (#216)
+
+### Changed
+
+- Coach loop is now rules-first; LLM only frames explanations (test-enforced)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.2.13",
+  "version": "0.17.0",
   "private": true,
   "engines": {
     "node": "^22.21.0",

--- a/packages/api/src/router/__tests__/coach.test.ts
+++ b/packages/api/src/router/__tests__/coach.test.ts
@@ -178,6 +178,9 @@ function makeDb() {
           tsb: 5,
         })),
       },
+      RecommendationAudit: {
+        findFirst: vi.fn(async () => null),
+      },
     },
   };
 }
@@ -218,6 +221,7 @@ describe("coach router", () => {
       recommendation: engineRecommendation,
       auditId: "audit-1",
       date: TEST_DATE,
+      actionState: null,
     });
 
     expect(mocks.auditValues).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- bump workspace version to 0.17.0
- add v0.17.0 changelog entry for the AI-native coach loop
- align coach router unit test expectations with returned actionState

## Verification
- pnpm install
- pnpm typecheck
- pnpm format
- pnpm -r test
- pre-commit run --all-files

Note: the agent CI check is expected to remain red and is ignored for this release.