### PR TITLE
fix(coach): time-of-day greeting + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2026-05-28
+
+### Fixed
+
+- Dashboard greeting now reflects the user's configured timezone and local time of day.
+
 ## [0.17.1] - 2026-05-28
 
 ### Fixed

--- a/apps/nextjs/e2e/home.spec.ts
+++ b/apps/nextjs/e2e/home.spec.ts
@@ -3,7 +3,9 @@ import { expect, test } from "@playwright/test";
 test.describe("Home / Today page", () => {
   test("renders the greeting and date", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("Good morning")).toBeVisible();
+    await expect(
+      page.getByText(/Good (morning|afternoon|evening|night)/),
+    ).toBeVisible();
     // Date should be visible
     const today = new Date().toLocaleDateString("en-US", {
       weekday: "long",

--- a/apps/nextjs/e2e/navigation.spec.ts
+++ b/apps/nextjs/e2e/navigation.spec.ts
@@ -22,7 +22,9 @@ test.describe("Navigation", () => {
     await page.getByRole("navigation").getByText("Today").click();
     await expect(page).toHaveURL("/");
     await expect(
-      page.getByRole("heading", { name: "Good morning" }),
+      page.getByRole("heading", {
+        name: /Good (morning|afternoon|evening|night)/,
+      }),
     ).toBeVisible();
   });
 });

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/nextjs/src/app/_components/dashboard-home.tsx
+++ b/apps/nextjs/src/app/_components/dashboard-home.tsx
@@ -2,7 +2,11 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { formatDateInTz, useUserTimezone } from "~/lib/format-date";
+import {
+  formatDateInTz,
+  getGreeting,
+  useUserTimezone,
+} from "~/lib/format-date";
 import { useTRPC } from "~/trpc/react";
 import { AdherenceTrendCard } from "./adherence-trend-card";
 import { BottomNav } from "./bottom-nav";
@@ -17,6 +21,7 @@ import { WorkoutCard } from "./workout-card";
 export function DashboardHome({ userId }: { userId: string }) {
   const trpc = useTRPC();
   const timezone = useUserTimezone();
+  const greeting = getGreeting(new Date(), timezone);
   const queryClient = useQueryClient();
 
   const readiness = useQuery(trpc.readiness.getToday.queryOptions());
@@ -141,7 +146,7 @@ export function DashboardHome({ userId }: { userId: string }) {
     <div className="space-y-4">
       {/* Header */}
       <div>
-        <h1 className="pl-12 text-2xl font-bold">Good morning 👋</h1>
+        <h1 className="pl-12 text-2xl font-bold">{greeting}</h1>
         <p className="text-muted-foreground text-sm">
           {formatDateInTz(new Date(), timezone, {
             weekday: "long",

--- a/apps/nextjs/src/lib/__tests__/format-date.test.ts
+++ b/apps/nextjs/src/lib/__tests__/format-date.test.ts
@@ -1,4 +1,4 @@
-import { formatDateInTz, formatTimeInTz } from "../format-date";
+import { formatDateInTz, formatTimeInTz, getGreeting } from "../format-date";
 
 // SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
@@ -58,6 +58,24 @@ describe("formatDateInTz", () => {
     );
     const epoch = Date.UTC(2026, 4, 14, 12, 0, 0);
     expect(formatDateInTz(epoch, "UTC")).toBe("Thu, May 14");
+  });
+});
+
+describe("getGreeting", () => {
+  it.each<[string, string]>([
+    ["2026-05-14T09:00:00.000Z", "Good morning ☀️"],
+    ["2026-05-14T13:00:00.000Z", "Good afternoon 🌤️"],
+    ["2026-05-14T19:00:00.000Z", "Good evening 🌙"],
+    ["2026-05-14T23:00:00.000Z", "Good night ✨"],
+    ["2026-05-14T04:00:00.000Z", "Good night ✨"],
+  ])("returns %s greeting for UTC hour", (input, expected) => {
+    expect(getGreeting(new Date(input), "UTC")).toBe(expected);
+  });
+
+  it("uses the configured timezone to determine local hour", () => {
+    expect(
+      getGreeting(new Date("2026-05-14T12:00:00.000Z"), "Australia/Brisbane"),
+    ).toBe("Good night ✨");
   });
 });
 

--- a/apps/nextjs/src/lib/format-date.ts
+++ b/apps/nextjs/src/lib/format-date.ts
@@ -80,6 +80,20 @@ export function formatDateInTz(
   }).format(d);
 }
 
+export function getGreeting(date: Date, timezone: string): string {
+  const rawHour = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    hour12: false,
+  }).format(date);
+  const hour = Number.parseInt(rawHour, 10) % 24;
+
+  if (hour >= 5 && hour <= 11) return "Good morning ☀️";
+  if (hour >= 12 && hour <= 16) return "Good afternoon 🌤️";
+  if (hour >= 17 && hour <= 21) return "Good evening 🌙";
+  return "Good night ✨";
+}
+
 /**
  * Format the time-of-day in the user's timezone.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
## Summary
- replace hardcoded dashboard greeting with timezone-aware time-of-day copy
- add greeting unit coverage and loosen e2e greeting assertions
- bump app packages and changelog to v0.17.2

## Validation
- pnpm -r test: 561 passed, 10 skipped
- pnpm lint: passed (existing warnings only)
- pre-commit run --all-files: passed