### PR TITLE
fix(chat): treat upstream provider errors as a backend miss

### DIFF
--- a/packages/api/src/lib/__tests__/ha-conversation.test.ts
+++ b/packages/api/src/lib/__tests__/ha-conversation.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isHaAssistFallback } from "../ha-conversation";
+import { isHaAssistFallback, isProviderError } from "../ha-conversation";
 
 describe("isHaAssistFallback", () => {
   it("detects the canned 'As a voice assistant' fallback", () => {
@@ -36,5 +36,57 @@ describe("isHaAssistFallback", () => {
 
   it("returns false for empty input", () => {
     expect(isHaAssistFallback("")).toBe(false);
+  });
+});
+
+describe("isProviderError", () => {
+  it("detects HA's 'Sorry, I had a problem getting a response from <provider>' wrapper", () => {
+    expect(
+      isProviderError(
+        "Sorry, I had a problem getting a response from Google Generative AI.: This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.",
+      ),
+    ).toBe(true);
+    expect(
+      isProviderError("Sorry, I had a problem getting a response from OpenAI."),
+    ).toBe(true);
+  });
+
+  it("detects 'experiencing high demand' / 'overloaded' phrases", () => {
+    expect(
+      isProviderError("This model is currently experiencing high demand."),
+    ).toBe(true);
+    expect(
+      isProviderError("This model is currently overloaded; try again later."),
+    ).toBe(true);
+  });
+
+  it("detects rate-limit / quota / resource-exhausted phrases", () => {
+    expect(isProviderError("Rate limit exceeded. Try again in 60s.")).toBe(
+      true,
+    );
+    expect(isProviderError("RESOURCE_EXHAUSTED: quota exceeded")).toBe(true);
+    expect(isProviderError("Your daily quota exhausted for this model.")).toBe(
+      true,
+    );
+  });
+
+  it("detects 503 Service Unavailable / 529 overloaded variants", () => {
+    expect(isProviderError("HTTP 503 Service Unavailable")).toBe(true);
+    expect(isProviderError("Received 529 overloaded from upstream")).toBe(true);
+  });
+
+  it("does NOT flag a normal coaching reply as provider error", () => {
+    expect(
+      isProviderError(
+        "Your last 5 runs averaged 28km/week at HR 152. Easy pace 6:30/km — recovery on track.",
+      ),
+    ).toBe(false);
+    expect(
+      isProviderError("You ran 503 calories yesterday in your easy session."),
+    ).toBe(false);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isProviderError("")).toBe(false);
   });
 });

--- a/packages/api/src/lib/ha-conversation.ts
+++ b/packages/api/src/lib/ha-conversation.ts
@@ -133,6 +133,30 @@ export function isHaAssistFallback(text: string): boolean {
   return HA_ASSIST_FALLBACK_PATTERNS.some((re) => re.test(text));
 }
 
+// When the upstream LLM provider (Google AI, OpenAI, Anthropic) returns
+// an error, HA wraps it in a successful Conversation response and the
+// error text becomes the user-visible answer. Detect those wrappers so
+// the caller can fall through to Ollama instead of surfacing
+// "This model is currently experiencing high demand" to the user.
+//
+// Patterns are intentionally narrow: they target HA's wrapper prefix
+// ("Sorry, I had a problem getting a response from …") and a small
+// set of upstream-only error phrases that are very unlikely to appear
+// in a real coaching answer.
+const HA_PROVIDER_ERROR_PATTERNS: RegExp[] = [
+  /sorry,?\s*i had a problem getting a response from/i,
+  /this model is currently (experiencing high demand|overloaded)/i,
+  /spikes in demand are usually temporary/i,
+  /(resource[_ ]exhausted|rate[_ ]?limit(ed|s)?|quota (exceeded|exhausted))/i,
+  /\b5(0[023]|29)\b.*(service unavailable|overloaded|gateway)/i,
+  /generativeai (api )?error/i,
+];
+
+export function isProviderError(text: string): boolean {
+  if (!text) return false;
+  return HA_PROVIDER_ERROR_PATTERNS.some((re) => re.test(text));
+}
+
 /**
  * Send a prompt to the HA conversation agent and return the text response.
  *
@@ -231,6 +255,22 @@ export async function haConversationChat(
       _cachedAgentId = null;
       _cachedAgentIdAt = 0;
       throw new Error("HA Conversation returned built-in Assist fallback");
+    }
+
+    // Upstream provider errors (Gemini quota/overload, OpenAI rate-limit,
+    // Anthropic 5xx) come back as a "successful" HA Conversation response
+    // whose speech text contains the wrapped error. Surfacing these as a
+    // chat reply tells the user "this model is experiencing high demand"
+    // instead of routing through Ollama. Throw so the caller falls through.
+    // Do NOT invalidate the agent cache — the agent is fine, the upstream
+    // provider is just busy; re-discovering would not help.
+    if (isProviderError(text)) {
+      console.warn(
+        `[AI] HA returned upstream provider error ("${text.slice(0, 120)}…") — falling through to next backend`,
+      );
+      throw new Error(
+        `HA Conversation upstream provider error: ${text.slice(0, 200)}`,
+      );
     }
 
     console.log(`[AI] Got response (${text.length} chars)`);


### PR DESCRIPTION
## What

When the HA Conversation agent's upstream LLM (Google AI / OpenAI / Anthropic) hits a quota or overload error, HA wraps the error string in a *successful* Conversation response. The speech payload becomes:

> Sorry, I had a problem getting a response from Google Generative AI.: This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.

`isHaAssistFallback()` only caught built-in HA Assist canned phrases, so these provider errors flowed through to the user as the assistant reply.

## Why now

Particularly painful for **aggregate-intent** questions (e.g. *'analyse my runs this year'*) which build a bigger context payload that's more likely to trip Gemini's overload guardrail than a short readiness ask. Today the user sees a different result depending on phrasing:

| Question | Result |
| --- | --- |
| 'What should my training look like today based on my readiness?' | ✅ Real coaching answer |
| 'Analyse my last few runs and let me know how I am going? Give me stats' | ❌ 'This model is currently experiencing high demand…' |

## What changed

- New `isProviderError(text)` with narrow regexes matching HA's wrapper prefix (`Sorry, I had a problem getting a response from …`) and a small set of upstream-only phrases (`high demand` / `overloaded` / `rate limit` / `quota` / `503` / `529`).
- `haConversationChat` calls it after the existing `isHaAssistFallback` check. On match it throws with the upstream text so the existing fallback chain in `router/chat.ts` routes the request through Ollama.
- Does **not** invalidate the agent cache — the agent is fine, the upstream provider is just busy. Re-discovering would not help.
- 6 new vitest cases cover the wrapper, overload/high-demand, rate-limit/quota, 503/529, plus a guard that `'You ran 503 calories yesterday'` is **not** a false positive.

## Test

- `pnpm --filter @acme/api test -- --run ha-conversation` → 157 passed, 0 failed
- Manual: reproduce in HA with Gemini Pro rate-limited (toggle a tiny daily quota in AI Studio) and confirm a coaching reply now comes back via Ollama instead of the canned overload string.