### PR TITLE
ci: add zizmor security scanning and harden all workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "Chore"
     open-pull-requests-limit: 15
@@ -19,6 +21,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "Chore"
     open-pull-requests-limit: 10

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,15 +28,17 @@ jobs:
       contents: read
     timeout-minutes: 15
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'audit'
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -71,15 +73,17 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'audit'
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -91,7 +95,7 @@ jobs:
         run: npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --output-file sbom.json --output-format json
 
       - name: 'Grype vulnerability scan'
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         with:
           sbom: sbom.json
           output-format: 'table'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Read-only by default; no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 # You can leverage Vercel Remote Caching with Turbo to speed up your builds
 # @link https://turborepo.com/docs/core-concepts/remote-caching#remote-caching-on-vercel-builds
 env:
@@ -23,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -38,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -49,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -61,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -72,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -93,6 +107,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/ha-garmin-fitness-coach-addon
           path: garmincoach-addon
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -26,15 +26,17 @@ jobs:
       matrix:
         language: ["javascript-typescript"]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
       - name: Install gh-aw extension
         uses: github/gh-aw/actions/setup-cli@58d1bedbb7200f59c2d224151339e38fd8687d05  # v0.76.1
         with:

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -66,6 +66,7 @@ jobs:
         id: bot
         env:
           GH_TOKEN: ${{ secrets.COPILOT_AGENT_PAT || github.token }}
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
           # shellcheck disable=SC2016  # GraphQL uses literal $ placeholders
@@ -77,7 +78,7 @@ jobs:
                 }
               }
             }' -F owner="${{ github.repository_owner }}" \
-               -F repo="${{ github.event.repository.name }}" \
+               -F repo="${GITHUB_EVENT_REPOSITORY_NAME}" \
             --jq '.data.repository.suggestedActors.nodes[]
                   | select(.__typename=="Bot" and .login=="copilot-swe-agent")
                   | .id' | head -1)
@@ -93,6 +94,7 @@ jobs:
         if: steps.bot.outputs.id != ''
         env:
           GH_TOKEN: ${{ secrets.COPILOT_AGENT_PAT || github.token }}
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
           # shellcheck disable=SC2016  # GraphQL uses literal $ placeholders
@@ -100,7 +102,7 @@ jobs:
             query($owner:String!,$repo:String!){
               repository(owner:$owner,name:$repo){id}
             }' -F owner="${{ github.repository_owner }}" \
-               -F repo="${{ github.event.repository.name }}" \
+               -F repo="${GITHUB_EVENT_REPOSITORY_NAME}" \
             --jq '.data.repository.id')
           echo "id=$repo_id" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: audit
 
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,18 +19,19 @@ jobs:
       contents: read
     timeout-minutes: 15
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'audit'
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0  # zizmor: ignore[cache-poisoning] caching disabled (no cache input)
         with:
           node-version: 22
-          cache: 'pnpm'
 
       - name: 'Install dependencies'
         run: pnpm install --frozen-lockfile
@@ -58,18 +59,19 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'audit'
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0  # zizmor: ignore[cache-poisoning] caching disabled (no cache input)
         with:
           node-version: 22
-          cache: 'pnpm'
 
       - name: 'Install dependencies'
         run: pnpm install --frozen-lockfile
@@ -80,7 +82,7 @@ jobs:
           npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --output-file sbom-cyclonedx.xml --output-format xml
 
       - name: 'Upload SBOM artifacts'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sbom-files
           path: |
@@ -89,7 +91,7 @@ jobs:
           retention-days: 90
 
       - name: 'Security scan with Grype'
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         id: grype
         with:
           sbom: sbom-cyclonedx.json
@@ -105,16 +107,17 @@ jobs:
       contents: write
     timeout-minutes: 5
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'audit'
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Download SBOM'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: sbom-files
           path: sbom/
@@ -135,7 +138,7 @@ jobs:
           fi
 
       - name: 'Create GitHub Release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           generate_release_notes: true
           body: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
           fi
 
       - name: 'Create GitHub Release'
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: true
           body: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Compute changed paths'
         id: diff

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 'Setup pnpm'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8

--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: audit
 
       - name: "Validate pull request title"
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Zizmor GHA Security Scan'
+
+# Static analysis of every GitHub Actions workflow and composite action in
+# the repository. Findings are published to the repository Security tab
+# (code scanning) and annotated on pull requests.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    # 03:00 UTC weekly (Monday) - catches newly disclosed action CVEs.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: "zizmor-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: 'Audit workflows'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write  # upload SARIF to code scanning
+      contents: read
+      actions: read
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 'Run zizmor'
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+        with:
+          # Audit the whole repository (all workflows + composite actions).
+          inputs: .
+          # Surface every confirmed finding in the PR and Security tab.
+          min-severity: low
+          min-confidence: low

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -4,8 +4,8 @@ description: "Common setup steps for Actions"
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v6
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version-file: ".nvmrc"
 


### PR DESCRIPTION
## What

Brings the app repo to the same GitHub Actions security baseline as the
addon repo (addon PR #184).

- **New** `.github/workflows/zizmor.yml` — `zizmorcore/zizmor-action`
  (SHA-pinned) scanning the whole repo on push/PR/weekly, publishing
  SARIF to the Security tab, gated at low severity / low confidence.
- **SHA-pin** every floating action across all hand-authored workflows
  **and** the `tooling/github/setup` composite (13 distinct actions),
  each with a `# vX.Y.Z` comment.
- **`persist-credentials: false`** on every checkout (no workflow pushes).
- **Template-injection** — move `github.event.repository.name` into env
  vars in `fix.yml`.
- **`permissions: contents: read`** on `ci.yml` (read-only; no writes).
- **Cache-poisoning** — drop the pnpm cache from the tag-publish release
  workflow and annotate the now-cacheless `setup-node` steps.
- **Dependabot** — 7-day cooldown.

## Result

Full-repo `zizmor --min-severity low --min-confidence low .` → **zero
findings**. `actionlint`, `yamllint`, and REUSE/SPDX all pass.
Generated gh-aw `*.lock.yml` files are left untouched (compiled
artifacts).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>