### PR TITLE
chore: release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-05-31
+
+### Added
+
+- **AI-native closed-loop foundations: RAG memory + learning loop.** The coach now builds and queries a retrieval-augmented memory of multi-year history, enabling token-efficient semantic answers to aggregate questions (e.g. "analyse all my runs this year") instead of raw activity dumps, plus a learning loop that adapts over time.
+- Persona-parameterized database seeding to drive the end-to-end screenshot/QA matrix across recreational, beginner, athlete, and detrained profiles.
+
+### Changed
+
+- Upgraded the lint/typecheck toolchain to ESLint 10, TypeScript 6, and `@eslint/compat` 2 (with `typescript-eslint` 8.60 and `eslint-plugin-turbo` 2.9), clearing the previously deferred majors.
+- Hardened all CI workflows with Zizmor security scanning and SHA-pinned, Node 24 actions.
+- Refreshed runtime and build dependencies (Next.js 16.2, Vite 8, Vitest 4, Tailwind 4.3, Drizzle 0.45, and related bumps).
+
 ## [0.17.8] - 2026-05-29
 
 ### Fixed

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.17.8",
+  "version": "0.18.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.17.8",
+  "version": "0.18.0",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
## Release 0.18.0 (minor)

Prepares the **0.18.0** release, keeping the app on the unified version line
shared with the addon (both were on `0.17.x`; this re-aligns them to `0.18.0`).

### Version bumps
- root `package.json`: 0.17.8 → **0.18.0**
- `apps/nextjs/package.json`: 0.17.8 → **0.18.0**
  (these had drifted behind the released tag `v0.17.10`; now re-synced)

### Why minor
New user-facing features since `v0.17.10`:
- AI-native closed-loop foundations — **RAG memory + learning loop** (#226)
- persona-parameterized seeding for the E2E screenshot matrix (#227)

Plus internal: ESLint 10 / TypeScript 6 toolchain upgrade (#254), Zizmor CI
hardening (#228), and dependency refreshes.

### Release mechanics
Merging this does **not** publish. The GitHub Release is cut by pushing the
`v0.18.0` tag (triggers `release.yaml`: validate → SBOM → release). The addon
`v0.18.0` will then point its `APP_REF` at this tag.

See `CHANGELOG.md` for the full `[0.18.0]` entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>