### PR TITLE
fix: render stacked charts + flag out-of-range readiness (#257, #258)

### DIFF
--- a/apps/nextjs/src/app/fitness/page.tsx
+++ b/apps/nextjs/src/app/fitness/page.tsx
@@ -527,6 +527,7 @@ export default function FitnessPage() {
                 }}
               />
               <Area
+                isAnimationActive={false}
                 type="monotone"
                 dataKey="value"
                 stroke="#3b82f6"
@@ -609,6 +610,7 @@ export default function FitnessPage() {
                 }}
               />
               <Area
+                isAnimationActive={false}
                 type="monotone"
                 dataKey="value"
                 stroke="#f59e0b"
@@ -687,6 +689,7 @@ export default function FitnessPage() {
                   }}
                 />
                 <Area
+                  isAnimationActive={false}
                   type="monotone"
                   dataKey="value"
                   stroke="#3b82f6"

--- a/apps/nextjs/src/app/hrv/page.tsx
+++ b/apps/nextjs/src/app/hrv/page.tsx
@@ -335,6 +335,7 @@ export default function HrvPage() {
                 />
               )}
               <Area
+                isAnimationActive={false}
                 type="monotone"
                 dataKey="daily"
                 stroke="#22c55e"

--- a/apps/nextjs/src/app/sleep/page.tsx
+++ b/apps/nextjs/src/app/sleep/page.tsx
@@ -548,20 +548,29 @@ export default function SleepDashboard() {
                 />
               )}
               <Bar
+                isAnimationActive={false}
                 dataKey="deep"
                 stackId="sleep"
                 fill="#4338ca"
                 radius={[0, 0, 0, 0]}
                 name="Deep"
               />
-              <Bar dataKey="rem" stackId="sleep" fill="#a855f7" name="REM" />
               <Bar
+                isAnimationActive={false}
+                dataKey="rem"
+                stackId="sleep"
+                fill="#a855f7"
+                name="REM"
+              />
+              <Bar
+                isAnimationActive={false}
                 dataKey="light"
                 stackId="sleep"
                 fill="#60a5fa"
                 name="Light"
               />
               <Bar
+                isAnimationActive={false}
                 dataKey="awake"
                 stackId="sleep"
                 fill="#f87171"
@@ -707,6 +716,7 @@ export default function SleepDashboard() {
                   }
                 />
                 <Bar
+                  isAnimationActive={false}
                   dataKey="actual"
                   fill="#60a5fa"
                   radius={[4, 4, 0, 0]}

--- a/apps/nextjs/src/app/training/page.tsx
+++ b/apps/nextjs/src/app/training/page.tsx
@@ -241,6 +241,7 @@ export default function TrainingLoadPage() {
               />
               {/* TSB filled areas */}
               <Area
+                isAnimationActive={false}
                 yAxisId="left"
                 type="monotone"
                 dataKey="tsbPos"
@@ -250,6 +251,7 @@ export default function TrainingLoadPage() {
                 legendType="none"
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="left"
                 type="monotone"
                 dataKey="tsbNeg"
@@ -416,6 +418,7 @@ export default function TrainingLoadPage() {
                 }}
               />
               <Area
+                isAnimationActive={false}
                 type="monotone"
                 dataKey="value"
                 stroke="#ef4444"
@@ -473,6 +476,7 @@ export default function TrainingLoadPage() {
                 }}
               />
               <Area
+                isAnimationActive={false}
                 type="monotone"
                 dataKey="value"
                 stroke="#3b82f6"
@@ -660,6 +664,7 @@ export default function TrainingLoadPage() {
                 }}
               />
               <Bar
+                isAnimationActive={false}
                 dataKey="value"
                 fill="#ef4444"
                 radius={[4, 4, 0, 0]}
@@ -707,6 +712,7 @@ export default function TrainingLoadPage() {
                 }}
               />
               <Bar
+                isAnimationActive={false}
                 dataKey="value"
                 fill="#6366f1"
                 radius={[4, 4, 0, 0]}
@@ -860,6 +866,7 @@ function LoadFocusChart({ focus }: { focus: string }) {
       <ResponsiveContainer width="100%" height={140}>
         <PieChart>
           <Pie
+            isAnimationActive={false}
             data={focusData}
             cx="50%"
             cy="50%"

--- a/apps/nextjs/src/app/trends/page.tsx
+++ b/apps/nextjs/src/app/trends/page.tsx
@@ -553,6 +553,7 @@ export default function TrendsPage() {
                 formatter={(value: string) => METRIC_LABELS[value] ?? value}
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="readiness"
                 type="monotone"
                 dataKey="readiness"
@@ -563,6 +564,7 @@ export default function TrendsPage() {
                 connectNulls
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="sleep"
                 type="monotone"
                 dataKey="sleep"
@@ -573,6 +575,7 @@ export default function TrendsPage() {
                 connectNulls
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="hrv"
                 type="monotone"
                 dataKey="hrv"
@@ -583,6 +586,7 @@ export default function TrendsPage() {
                 connectNulls
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="stress"
                 type="monotone"
                 dataKey="stress"

--- a/apps/nextjs/src/app/validation/page.tsx
+++ b/apps/nextjs/src/app/validation/page.tsx
@@ -88,19 +88,21 @@ interface RvcRow {
   raw: number;
   computed: number;
   deltaPct: number | null;
-  status: "match" | "minor" | "diverged";
+  status: "match" | "minor" | "diverged" | "invalid";
 }
 
 const RVC_STATUS_STYLE: Record<RvcRow["status"], string> = {
   match: "bg-green-100 text-green-700",
   minor: "bg-yellow-100 text-yellow-700",
   diverged: "bg-red-100 text-red-700",
+  invalid: "bg-zinc-200 text-zinc-600",
 };
 
 const RVC_STATUS_LABEL: Record<RvcRow["status"], string> = {
   match: "🟢 Match",
   minor: "🟡 Minor",
   diverged: "🔴 Diverged",
+  invalid: "⚪ Out of range",
 };
 
 function RawVsComputedTable({

--- a/apps/nextjs/src/app/vitals/page.tsx
+++ b/apps/nextjs/src/app/vitals/page.tsx
@@ -442,6 +442,7 @@ function VitalMetricSection({
                 />
               ))}
               <Area
+                isAnimationActive={false}
                 dataKey="value"
                 fill={color}
                 fillOpacity={0.15}

--- a/apps/nextjs/src/app/zones/page.tsx
+++ b/apps/nextjs/src/app/zones/page.tsx
@@ -625,6 +625,7 @@ export default function ZoneAnalysisPage() {
               />
               {(["z1", "z2", "z3", "z4", "z5"] as const).map((z) => (
                 <Bar
+                  isAnimationActive={false}
                   key={z}
                   dataKey={z}
                   stackId="zones"
@@ -727,6 +728,7 @@ export default function ZoneAnalysisPage() {
                 }}
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="pct"
                 type="monotone"
                 dataKey="easyPct"
@@ -736,6 +738,7 @@ export default function ZoneAnalysisPage() {
                 name="Easy %"
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="pct"
                 type="monotone"
                 dataKey="moderatePct"
@@ -745,6 +748,7 @@ export default function ZoneAnalysisPage() {
                 name="Moderate %"
               />
               <Area
+                isAnimationActive={false}
                 yAxisId="pct"
                 type="monotone"
                 dataKey="hardPct"
@@ -842,6 +846,7 @@ export default function ZoneAnalysisPage() {
                   const z = key.replace("Pct", "");
                   return (
                     <Area
+                      isAnimationActive={false}
                       key={key}
                       type="monotone"
                       dataKey={key}
@@ -1037,6 +1042,7 @@ export default function ZoneAnalysisPage() {
               />
               {Object.entries(SPORT_COLORS).map(([key, color]) => (
                 <Bar
+                  isAnimationActive={false}
                   key={key}
                   dataKey={key}
                   stackId="sports"

--- a/packages/api/src/router/__tests__/data-quality.test.ts
+++ b/packages/api/src/router/__tests__/data-quality.test.ts
@@ -121,4 +121,55 @@ describe("dataQuality.getRawVsComputed", () => {
     expect(res.summary.comparedPairs).toBe(0);
     expect(res.summary.agreementPct).toBeNull();
   });
+
+  it("flags out-of-range readiness as invalid and excludes it from agreement", async () => {
+    const d0 = dateString(1);
+    const d1 = dateString(2);
+    const d2 = dateString(3);
+    const caller = createCaller(
+      makeMockDb([
+        // dailyRows (garmin native readiness) — 530 is physiologically impossible
+        [
+          { date: d0, garminReadiness: 80 },
+          { date: d1, garminReadiness: 530 },
+          { date: d2, garminReadiness: 130 },
+        ],
+        // readinessRows (engine computed)
+        [
+          { date: d0, score: 81 }, // match
+          { date: d1, score: 530 }, // both out of range -> invalid
+          { date: d2, score: 46 }, // raw out of range -> invalid
+        ],
+        [], // vo2Rows
+        [], // advRows
+      ]),
+    );
+
+    const res = await caller.dataQuality.getRawVsComputed({ days: 30 });
+    const byDate = Object.fromEntries(res.readiness.map((r) => [r.date, r]));
+    expect(byDate[d0]!.status).toBe("match");
+    expect(byDate[d1]!.status).toBe("invalid");
+    expect(byDate[d2]!.status).toBe("invalid");
+    expect(res.summary.invalid).toBe(2);
+    expect(res.summary.comparedPairs).toBe(3);
+    // Agreement is computed over valid pairs only (1 match / 1 valid = 100%),
+    // not polluted by the 530/530 "Match" it would have produced before.
+    expect(res.summary.agreementPct).toBe(100);
+  });
+
+  it("returns null agreement when every pair is out of range", async () => {
+    const d0 = dateString(1);
+    const caller = createCaller(
+      makeMockDb([
+        [{ date: d0, garminReadiness: 530 }],
+        [{ date: d0, score: 530 }],
+        [],
+        [],
+      ]),
+    );
+    const res = await caller.dataQuality.getRawVsComputed();
+    expect(res.readiness[0]!.status).toBe("invalid");
+    expect(res.summary.invalid).toBe(1);
+    expect(res.summary.agreementPct).toBeNull();
+  });
 });

--- a/packages/api/src/router/__tests__/data-quality.test.ts
+++ b/packages/api/src/router/__tests__/data-quality.test.ts
@@ -150,6 +150,9 @@ describe("dataQuality.getRawVsComputed", () => {
     expect(byDate[d0]!.status).toBe("match");
     expect(byDate[d1]!.status).toBe("invalid");
     expect(byDate[d2]!.status).toBe("invalid");
+    // Invalid pairs must not surface a (misleading) delta.
+    expect(byDate[d1]!.deltaPct).toBeNull();
+    expect(byDate[d2]!.deltaPct).toBeNull();
     expect(res.summary.invalid).toBe(2);
     expect(res.summary.comparedPairs).toBe(3);
     // Agreement is computed over valid pairs only (1 match / 1 valid = 100%),

--- a/packages/api/src/router/data-quality.ts
+++ b/packages/api/src/router/data-quality.ts
@@ -58,13 +58,17 @@ function pairRow(
   computed: number,
   range?: ValidRange,
 ): RawVsComputedRow {
-  const deltaPct = raw === 0 ? null : ((computed - raw) / raw) * 100;
+  const status = classify(raw, computed, range);
+  // A meaningless comparison (out-of-range/non-finite) must not surface a
+  // delta — it would be misleading and can be NaN/Infinity.
+  const deltaPct =
+    status === "invalid" || raw === 0 ? null : ((computed - raw) / raw) * 100;
   return {
     date,
     raw,
     computed,
     deltaPct: deltaPct === null ? null : Math.round(deltaPct * 10) / 10,
-    status: classify(raw, computed, range),
+    status,
   };
 }
 

--- a/packages/api/src/router/data-quality.ts
+++ b/packages/api/src/router/data-quality.ts
@@ -23,10 +23,28 @@ export interface RawVsComputedRow {
   raw: number;
   computed: number;
   deltaPct: number | null;
-  status: "match" | "minor" | "diverged";
+  status: "match" | "minor" | "diverged" | "invalid";
 }
 
-function classify(raw: number, computed: number): RawVsComputedRow["status"] {
+interface ValidRange {
+  min: number;
+  max: number;
+}
+
+function inRange(value: number, range?: ValidRange): boolean {
+  if (!range) return true;
+  return Number.isFinite(value) && value >= range.min && value <= range.max;
+}
+
+function classify(
+  raw: number,
+  computed: number,
+  range?: ValidRange,
+): RawVsComputedRow["status"] {
+  // A physiologically-impossible value on either side means the comparison
+  // itself is meaningless — surface it as "invalid" instead of silently
+  // counting it as a match/divergence (which would pollute the agreement %).
+  if (!inRange(raw, range) || !inRange(computed, range)) return "invalid";
   if (raw === 0) return computed === 0 ? "match" : "diverged";
   const pct = Math.abs((computed - raw) / raw) * 100;
   if (pct < 5) return "match";
@@ -38,6 +56,7 @@ function pairRow(
   date: string,
   raw: number,
   computed: number,
+  range?: ValidRange,
 ): RawVsComputedRow {
   const deltaPct = raw === 0 ? null : ((computed - raw) / raw) * 100;
   return {
@@ -45,9 +64,14 @@ function pairRow(
     raw,
     computed,
     deltaPct: deltaPct === null ? null : Math.round(deltaPct * 10) / 10,
-    status: classify(raw, computed),
+    status: classify(raw, computed, range),
   };
 }
+
+// Readiness is defined on a 0–100 scale; VO2max never physically exceeds
+// ~100 ml/kg/min. Values outside these bounds indicate a sync/parsing bug.
+const READINESS_RANGE: ValidRange = { min: 0, max: 100 };
+const VO2MAX_RANGE: ValidRange = { min: 0, max: 100 };
 
 export const dataQualityRouter = {
   list: protectedProcedure.query(async ({ ctx }) => {
@@ -143,7 +167,7 @@ export const dataQualityRouter = {
       for (const r of readinessRows) {
         const raw = garminReadinessByDate.get(r.date);
         if (raw == null) continue;
-        readiness.push(pairRow(r.date, raw, r.score));
+        readiness.push(pairRow(r.date, raw, r.score, READINESS_RANGE));
       }
 
       // VO2max: Garmin official estimate vs engine effective VO2max.
@@ -178,7 +202,7 @@ export const dataQualityRouter = {
       for (const r of vo2Rows) {
         const computed = effectiveByDate.get(r.date);
         if (computed == null) continue;
-        vo2max.push(pairRow(r.date, r.value, computed));
+        vo2max.push(pairRow(r.date, r.value, computed, VO2MAX_RANGE));
       }
 
       readiness.sort((a, b) => b.date.localeCompare(a.date));
@@ -187,6 +211,10 @@ export const dataQualityRouter = {
       const all = [...readiness, ...vo2max];
       const diverged = all.filter((r) => r.status === "diverged").length;
       const matched = all.filter((r) => r.status === "match").length;
+      const invalid = all.filter((r) => r.status === "invalid").length;
+      // Out-of-range pairs are excluded from the agreement denominator so a
+      // bad sync value can't masquerade as agreement or divergence.
+      const validPairs = all.length - invalid;
 
       return {
         readiness: readiness.slice(0, 30),
@@ -195,8 +223,9 @@ export const dataQualityRouter = {
           comparedPairs: all.length,
           matched,
           diverged,
+          invalid,
           agreementPct:
-            all.length > 0 ? Math.round((matched / all.length) * 100) : null,
+            validPairs > 0 ? Math.round((matched / validPairs) * 100) : null,
         },
       };
     }),


### PR DESCRIPTION
Fixes two live-data QA bugs found in the 2026-05-31 capture.

## #257 — Zone/Sleep stacked charts render empty
Recharts 3.8 only materialises Bar/Area geometry once the entry animation
runs. Under React 19 concurrent rendering on heavy multi-chart pages the
rAF can be dropped, so the bars/areas never paint (axes + legend render,
Key Insights still cite the underlying numbers — proving the data is
present). Scatter/Line/custom charts are unaffected.

**Fix:** `isAnimationActive={false}` on every Bar/Area/Pie/Radar series
(zones, sleep, fitness, hrv, vitals, training, trends). Verified in an
isolated Recharts 3.8.0 + React 19 Playwright harness — bar paths are
absent at t=0 with animation on, full-height immediately with it off.

## #258 — Validation readiness values out of 0–100 range
Garmin sometimes returns impossible readiness (130, 530). The
Engine-vs-Garmin table classified 530/530 as a "Match", inflating the
agreement %.

**Fix:** range-guard readiness & VO2max pairs; out-of-range values get a
distinct `invalid` status ("⚪ Out of range"), excluded from the
agreement denominator, with an `invalid` count in the summary. New unit
tests cover classification + agreement math.

The addon-side sync guard (reject readiness outside 0–100 at ingest) is a
companion PR on the addon repo.

## Verification
- typecheck 5/5, lint 0 errors, format clean
- `@acme/api` 182 passed / 10 skipped; `@acme/nextjs` suite green
- data-quality.test.ts 5/5 (2 new)