### PR TITLE
chore: release 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-05-31
+
+### Fixed
+
+- **Stacked Bar/Area charts no longer render empty (#257).** Recharts creates
+  Bar/Area geometry only after its entry-animation frame fires; under React 19
+  concurrent rendering on chart-heavy pages that frame could be dropped, so the
+  bars/areas never painted (axes and legends still showed). Disabled entry
+  animation (`isAnimationActive={false}`) on all Bar/Area/Pie/Radar series
+  across the zones, sleep, fitness, hrv, vitals, training, and trends pages.
+  Affected stacked charts (e.g. Weekly Time in Zones, Sleep Stages) now render
+  immediately.
+- **Out-of-range readiness values flagged in data validation (#258).** Garmin
+  occasionally returns malformed Training Readiness payloads (e.g. `130`, `530`)
+  outside the 0–100 scale. The Engine-vs-Garmin validation table now classifies
+  readiness/VO2max values outside their valid range as `invalid` ("⚪ Out of
+  range"), excludes them from the agreement percentage, and suppresses a
+  misleading delta, so bad source data no longer inflates the reported
+  agreement.
+
 ## [0.18.0] - 2026-05-31
 
 ### Added

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
## Summary

Patch release shipping the live-data QA bug fixes landed since `0.18.0`:

- **#257** — empty stacked Bar/Area charts now render (`isAnimationActive={false}`)
- **#258** — out-of-range Garmin readiness/VO2max flagged as `invalid` in the validation table

Bumps root + `apps/nextjs` `package.json` to `0.18.1` and promotes the changes to a dated CHANGELOG entry. Keeps the unified version line shared with the addon.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>