### PR TITLE
fix(db): populate screenshot demo data (VO2max history + stop e2e wipe)

### DIFF
--- a/packages/db/src/seed-e2e.ts
+++ b/packages/db/src/seed-e2e.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /** Idempotent e2e seed for the AI-native coach loop Playwright suite. */
-import { eq, sql } from "drizzle-orm";
+import { and, eq, like, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 
@@ -40,18 +40,41 @@ function dateAt(day: string, hour: number): Date {
 }
 
 async function resetSeedData(): Promise<void> {
+  const today = isoDay();
+  // Coach-loop / auth state that this seed fully owns — safe to clear wholesale
+  // so repeated runs (Playwright beforeEach) stay idempotent.
   await db.delete(session).where(eq(session.userId, USER_ID));
   await db.delete(account).where(eq(account.userId, USER_ID));
   await db
     .delete(RecommendationAudit)
     .where(eq(RecommendationAudit.userId, USER_ID));
-  await db.delete(Activity).where(eq(Activity.userId, USER_ID));
-  await db.delete(AdvancedMetric).where(eq(AdvancedMetric.userId, USER_ID));
   await db.delete(DailyWorkout).where(eq(DailyWorkout.userId, USER_ID));
-  await db.delete(ReadinessScore).where(eq(ReadinessScore.userId, USER_ID));
-  await db.delete(DailyMetric).where(eq(DailyMetric.userId, USER_ID));
-  await db.delete(Profile).where(eq(Profile.userId, USER_ID));
-  await db.delete(user).where(eq(user.id, USER_ID));
+  // Historical-demo tables are SHARED with the 90-day seed (seed.ts). Only
+  // remove the rows this e2e seed itself creates — today's single-day metrics
+  // and its `e2e-` prefixed activities — so the rich history survives when both
+  // seeds run (the addon screenshot pipeline). In the standalone coach-loop
+  // test DB these scoped deletes are equivalent to the previous wholesale ones.
+  await db
+    .delete(Activity)
+    .where(
+      and(
+        eq(Activity.userId, USER_ID),
+        like(Activity.garminActivityId, "e2e-%"),
+      ),
+    );
+  await db
+    .delete(AdvancedMetric)
+    .where(
+      and(eq(AdvancedMetric.userId, USER_ID), eq(AdvancedMetric.date, today)),
+    );
+  await db
+    .delete(ReadinessScore)
+    .where(
+      and(eq(ReadinessScore.userId, USER_ID), eq(ReadinessScore.date, today)),
+    );
+  await db
+    .delete(DailyMetric)
+    .where(and(eq(DailyMetric.userId, USER_ID), eq(DailyMetric.date, today)));
 }
 
 async function seed(): Promise<void> {
@@ -59,39 +82,51 @@ async function seed(): Promise<void> {
   const today = isoDay();
   await resetSeedData();
 
-  await db.insert(user).values({
-    id: USER_ID,
-    name: "E2E Coach User",
-    email: "e2e@local",
-    emailVerified: true,
-    image: null,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await db.insert(Profile).values({
-    userId: USER_ID,
-    age: 36,
-    sex: "male",
-    massKg: 72,
-    heightCm: 178,
-    timezone: "UTC",
-    experienceLevel: "intermediate",
-    primarySports: ["running"],
-    goals: [
-      {
-        sport: "running",
-        goalType: "consistency",
-        target: "steady aerobic base",
-      },
-    ],
-    weeklyDays: ["mon", "wed", "fri", "sun"],
-    minutesPerDay: 45,
-    maxHr: 190,
-    restingHrBaseline: 52,
-    hrvBaseline: 64,
-    sleepBaseline: 450,
-    vo2maxRunning: 50,
-  });
+  await db
+    .insert(user)
+    .values({
+      id: USER_ID,
+      name: "E2E Coach User",
+      email: "e2e@local",
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+  await db
+    .insert(Profile)
+    .values({
+      userId: USER_ID,
+      age: 36,
+      sex: "male",
+      massKg: 72,
+      heightCm: 178,
+      timezone: "UTC",
+      experienceLevel: "intermediate",
+      primarySports: ["running"],
+      goals: [
+        {
+          sport: "running",
+          goalType: "consistency",
+          target: "steady aerobic base",
+        },
+      ],
+      weeklyDays: ["mon", "wed", "fri", "sun"],
+      minutesPerDay: 45,
+      maxHr: 190,
+      restingHrBaseline: 52,
+      hrvBaseline: 64,
+      sleepBaseline: 450,
+      vo2maxRunning: 50,
+    })
+    // If the 90-day seed already created the profile, keep it but force the
+    // timezone to UTC so it matches the UTC day boundaries this seed uses for
+    // `today` (the coach loop derives "today" from Profile.timezone).
+    .onConflictDoUpdate({
+      target: Profile.userId,
+      set: { timezone: "UTC" },
+    });
   await db.insert(DailyMetric).values({
     userId: USER_ID,
     date: today,

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -501,7 +501,8 @@ async function seed() {
 
   // --- VO2max estimates (historical tracking) ---
   // garmin_official readings are tied to qualifying runs (above); a parallel
-  // uth_estimated weekly series gives the Fitness page its second trend line.
+  // uth_ratio weekly series gives the Fitness page its second trend line
+  // (analytics.getVO2maxHistory recognises uth_method / uth_ratio).
   let vo2maxCount = 0;
   for (const r of vo2maxReadings) {
     await db
@@ -527,7 +528,7 @@ async function seed() {
         value: parseFloat(
           (vo2maxAt(day.daysAgo) - 1 + rng.float(-0.3, 0.3, 1)).toFixed(1),
         ),
-        source: "uth_estimated",
+        source: "uth_ratio",
       })
       .onConflictDoNothing();
     vo2maxCount++;

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -15,6 +15,7 @@ import {
   JournalEntry,
   Profile,
   SessionReport,
+  VO2maxEstimate,
 } from "./schema";
 
 const DATABASE_URL = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
@@ -316,6 +317,17 @@ async function seed() {
     load: number;
   }[] = [];
 
+  // Garmin records a VO2max estimate after a qualifying outdoor run (12+ min
+  // with HR). Collect one reading per such run so the Fitness page renders a
+  // real Garmin VO2max trend, current value, and race predictions instead of
+  // the "No VO2max data" empty state. The series trends gently upward over the
+  // 90-day window to read as improving fitness.
+  const vo2maxBase = persona.vo2maxRunning;
+  const vo2maxAt = (daysAgo: number): number =>
+    vo2maxBase - 2.5 + ((90 - daysAgo) / 90) * 2.5;
+  const vo2maxReadings: { date: string; value: number; activityId: string }[] =
+    [];
+
   for (const day of days.filter((d) => d.actType !== null)) {
     const { daysAgo, date, actType, load } = day;
     const garminId = `seed-${date}-${actType}`;
@@ -423,6 +435,12 @@ async function seed() {
     const startTime = dateAt(daysAgo, 7, 0);
     const endTime = new Date(startTime.getTime() + durationMinutes * 60000);
 
+    // Qualifying outdoor run with HR → Garmin would emit a VO2max estimate.
+    const vo2maxEstimate =
+      sportType === "running" && durationMinutes >= 12
+        ? parseFloat((vo2maxAt(daysAgo) + rng.float(-0.4, 0.4, 1)).toFixed(1))
+        : null;
+
     const numLaps =
       sportType === "running"
         ? Math.ceil(durationMinutes / 5)
@@ -460,6 +478,7 @@ async function seed() {
         aerobicTE,
         anaerobicTE,
         trimpScore: load,
+        vo2maxEstimate,
         laps,
         rawGarminData: { source: "seed", version: "1.0" },
       })
@@ -468,10 +487,52 @@ async function seed() {
 
     if (inserted) {
       insertedActivities.push({ id: inserted.id, date, actType, load });
+      if (vo2maxEstimate !== null) {
+        vo2maxReadings.push({
+          date,
+          value: vo2maxEstimate,
+          activityId: inserted.id,
+        });
+      }
     }
   }
 
   console.log(`✅ ${insertedActivities.length} activities inserted`);
+
+  // --- VO2max estimates (historical tracking) ---
+  // garmin_official readings are tied to qualifying runs (above); a parallel
+  // uth_estimated weekly series gives the Fitness page its second trend line.
+  let vo2maxCount = 0;
+  for (const r of vo2maxReadings) {
+    await db
+      .insert(VO2maxEstimate)
+      .values({
+        userId: USER_ID,
+        date: r.date,
+        sport: "running",
+        value: r.value,
+        source: "garmin_official",
+        activityId: r.activityId,
+      })
+      .onConflictDoNothing();
+    vo2maxCount++;
+  }
+  for (const day of days.filter((d) => d.daysAgo % 7 === 0)) {
+    await db
+      .insert(VO2maxEstimate)
+      .values({
+        userId: USER_ID,
+        date: day.date,
+        sport: "running",
+        value: parseFloat(
+          (vo2maxAt(day.daysAgo) - 1 + rng.float(-0.3, 0.3, 1)).toFixed(1),
+        ),
+        source: "uth_estimated",
+      })
+      .onConflictDoNothing();
+    vo2maxCount++;
+  }
+  console.log(`✅ ${vo2maxCount} VO2max estimates inserted`);
 
   // --- Daily Metrics (90 days) ---
   let runningFatigue = 0;


### PR DESCRIPTION
## Summary
Fixes the empty screens in the addon README screenshots. Two root causes, two atomic commits:

### 1. `fix(db): stop e2e seed from wiping the 90-day demo history`
The addon screenshot pipeline runs `seed.ts` (90-day persona history) **then** `seed-e2e.ts` (coach-loop fixtures). `seed-e2e`'s `resetSeedData()` deleted **all** DailyMetric/Activity/AdvancedMetric/ReadinessScore for the user — erasing the history `seed.ts` had just written. So HRV/Trends/Fitness/zones/sleep rendered with a **single day** of data ("Not enough data", empty charts).

Fix: scope the reset to only the rows this seed owns (today's metrics + `e2e-` activities); stop deleting Profile/user (inserts are now `onConflictDoNothing`). In the standalone coach-loop test DB these scoped deletes are equivalent to the old wholesale ones — verified idempotent (audit rows stay 8, activities stay 5).

### 2. `feat(db): seed VO2max history so the fitness page renders`
`seed.ts` never wrote VO2max estimates → Fitness showed "No VO2max data / No Garmin readings / No race predictions". Seeds `garmin_official` readings per qualifying run (+ `activity.vo2maxEstimate`) and a weekly `uth_ratio` series.

## Validation (local Postgres, athlete persona, exact workflow order)
After `seed.ts` → `seed-e2e.ts` → `metrics-compute.py --once`:
```
before fix:  metrics-compute → 1 dates, 0 VO2max points, 1 readiness scores
after  fix:  metrics-compute → 91 dates, 39 VO2max points, 91 readiness scores
daily_metric 91 (hrv 91) · activity 69 (e2e 5) · vo2max_estimate 52 · readiness_score 91
```
typecheck ✓ · prettier ✓ · seed-e2e idempotency ✓

Consumed by the addon E2E Screenshots workflow to regenerate the README screenshots.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
