### PR TITLE
fix(auth): restore DEV_BYPASS_AUTH single-user mode for the addon

### DIFF
--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -11,12 +11,11 @@ const DEV_USER_ID = "seed-user-001";
 export default async function HomePage() {
   const session = await getSession();
 
-  // In development the app is usable without OAuth via a seed user; in test
-  // the same is allowed only when DEV_BYPASS_AUTH is set. Never in production
-  // (or any other NODE_ENV), so the fallback can't leak past local/CI use.
+  // In development, or whenever the explicit DEV_BYPASS_AUTH opt-in is set
+  // (the HA add-on's single-user mode behind ingress), fall back to the seed
+  // user so the app is usable without OAuth. Real auth is required otherwise.
   const devFallbackAllowed =
-    env.NODE_ENV === "development" ||
-    (env.NODE_ENV === "test" && env.DEV_BYPASS_AUTH === "true");
+    env.NODE_ENV === "development" || env.DEV_BYPASS_AUTH === "true";
   const userId = session?.user.id ?? (devFallbackAllowed ? DEV_USER_ID : null);
 
   if (!userId) {

--- a/apps/nextjs/src/env.ts
+++ b/apps/nextjs/src/env.ts
@@ -40,7 +40,5 @@ export const env = createEnv({
   skipValidation:
     !!process.env.CI ||
     process.env.npm_lifecycle_event === "lint" ||
-    (process.env.DEV_BYPASS_AUTH === "true" &&
-      (process.env.NODE_ENV === "development" ||
-        process.env.NODE_ENV === "test")),
+    process.env.DEV_BYPASS_AUTH === "true",
 });

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -117,16 +117,15 @@ export const protectedProcedure = t.procedure
   .use(timingMiddleware)
   .use(({ ctx, next }) => {
     if (!ctx.session?.user) {
-      // Dev-only bypass: use the seed user so the app is functional without
-      // OAuth during local development / e2e. Mirrors the homepage fallback in
-      // apps/nextjs/src/app/page.tsx exactly: allowed in development, and in
-      // test only when DEV_BYPASS_AUTH is set. Fails closed for production or
-      // any other NODE_ENV, so a leaked flag cannot disable auth there.
-      const nodeEnv = process.env.NODE_ENV;
-      const devFallbackAllowed =
-        nodeEnv === "development" ||
-        (nodeEnv === "test" && process.env.DEV_BYPASS_AUTH === "true");
-      if (devFallbackAllowed) {
+      // Trusted single-user bypass. DEV_BYPASS_AUTH is an explicit opt-in flag
+      // (unset by default). The PulseCoach Home Assistant add-on deliberately
+      // sets it with NODE_ENV=production because it runs as a single user
+      // behind authenticated HA ingress — this is its documented auth model
+      // (see the add-on repository's AGENTS.md, not this repo). It also covers local development and e2e via
+      // `t._config.isDev` (true when NODE_ENV !== "production"). In a
+      // production deployment that does not set the flag, real authentication
+      // is required, so a non-opted-in production stays protected.
+      if (t._config.isDev || process.env.DEV_BYPASS_AUTH === "true") {
         return next({
           ctx: {
             session: {


### PR DESCRIPTION
## Regression fix

PR #276 gated `DEV_BYPASS_AUTH` to non-production environments. That **broke the PulseCoach HA add-on**, which runs `NODE_ENV=production` + `DEV_BYPASS_AUTH=true` as its documented single-user auth model (one user behind authenticated HA ingress — see addon `AGENTS.md`). With the gate, every `protectedProcedure` returned `UNAUTHORIZED`, so **all dashboards rendered empty** (discovered while regenerating the addon README screenshots).

## Change
Restore `DEV_BYPASS_AUTH` as an **explicit opt-in** bypass that works in any environment (its original behaviour). It is unset by default, so any deployment that doesn't deliberately opt in still requires real auth. The **webhook HMAC verification** and **tRPC CORS allow-list** from #276 are kept.

## Validation
- `pnpm turbo typecheck` (@acme/api, @acme/nextjs) ✓
- `pnpm --filter @acme/nextjs` prettier ✓
- `pnpm turbo test --filter=@acme/api` → **182 passed** ✓

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>