### PR TITLE
fix: prefix stress board api calls with ingress base path

### DIFF
--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -42,6 +42,16 @@ interface StressStatus {
 
 /* ─────────────── helpers ─────────────── */
 
+// Ingress detection: under HA the app lives at /api/hassio_ingress/<token>/,
+// so absolute /api/* paths must be prefixed or they hit HA core instead.
+function apiUrl(path: string): string {
+  if (typeof window === "undefined") return path;
+  const match = /^(\/api\/hassio_ingress\/[^/]+)/.exec(
+    window.location.pathname,
+  );
+  return match ? match[1] + path : path;
+}
+
 function dbpmColor(v: number): string {
   if (v >= 5) return "text-red-400";
   if (v >= 2) return "text-orange-400";
@@ -59,7 +69,7 @@ function labelColor(label: string): string {
 
 async function fetchStatus(): Promise<StressStatus> {
   try {
-    const res = await fetch("/api/garmin/meeting-stress");
+    const res = await fetch(apiUrl("/api/garmin/meeting-stress"));
     return (await res.json()) as StressStatus;
   } catch {
     return { running: false, unreachable: true };
@@ -80,7 +90,7 @@ export default function StressBoardPage() {
 
   const run = useMutation({
     mutationFn: async () => {
-      const res = await fetch("/api/garmin/meeting-stress", {
+      const res = await fetch(apiUrl("/api/garmin/meeting-stress"), {
         method: "POST",
       });
       const data = (await res.json()) as { success: boolean; message?: string };


### PR DESCRIPTION
Under HA ingress the app is served at `/api/hassio_ingress/<token>/`, so the stress board's absolute `/api/garmin/meeting-stress` fetches hit HA core (404 HTML) and the page always showed "Cannot reach the addon auth server". Prefix both fetches with the same inline ingress detection the settings page uses (`apiUrl()`).

Verified: published 0.20.0 image runs clean locally (both Flask + Next layers respond) — the failure only occurs behind ingress, which this fixes.