### PR TITLE
chore: release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2026-07-06
+
+### Fixed
+
+- **Stress Board unreachable under HA ingress (#322).** The page fetched
+  absolute `/api/garmin/meeting-stress` paths, which resolve against HA
+  core instead of the ingress-prefixed app root, so the board always
+  reported the auth server unreachable. Fetches now use the shared
+  `getIngressUrl()` helper.
+
 ## [0.20.0] - 2026-07-06
 
 ### Added

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { cn } from "@acme/ui";
 
 import { BottomNav } from "../_components/bottom-nav";
+import { getIngressUrl } from "../_components/ingress-provider";
 
 /* ─────────────── types (shape of meeting_stress.json) ─────────────── */
 
@@ -42,16 +43,6 @@ interface StressStatus {
 
 /* ─────────────── helpers ─────────────── */
 
-// Ingress detection: under HA the app lives at /api/hassio_ingress/<token>/,
-// so absolute /api/* paths must be prefixed or they hit HA core instead.
-function apiUrl(path: string): string {
-  if (typeof window === "undefined") return path;
-  const match = /^(\/api\/hassio_ingress\/[^/]+)/.exec(
-    window.location.pathname,
-  );
-  return match ? match[1] + path : path;
-}
-
 function dbpmColor(v: number): string {
   if (v >= 5) return "text-red-400";
   if (v >= 2) return "text-orange-400";
@@ -69,7 +60,7 @@ function labelColor(label: string): string {
 
 async function fetchStatus(): Promise<StressStatus> {
   try {
-    const res = await fetch(apiUrl("/api/garmin/meeting-stress"));
+    const res = await fetch(getIngressUrl("/api/garmin/meeting-stress"));
     return (await res.json()) as StressStatus;
   } catch {
     return { running: false, unreachable: true };
@@ -90,7 +81,7 @@ export default function StressBoardPage() {
 
   const run = useMutation({
     mutationFn: async () => {
-      const res = await fetch(apiUrl("/api/garmin/meeting-stress"), {
+      const res = await fetch(getIngressUrl("/api/garmin/meeting-stress"), {
         method: "POST",
       });
       const data = (await res.json()) as { success: boolean; message?: string };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
Patch release: Stress Board ingress fix (#322) + reuse shared getIngressUrl helper. Tag v0.20.1 follows merge.