### PR TITLE
feat: mask toggle on stress board + release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-07-07
+
+### Added
+
+- **Stress Board mask toggle.** One-tap privacy mode for screenshots:
+  attendees render as stable initials, meeting titles as generic labels.
+  Real names remain the default for private use.
+
 ## [0.20.1] - 2026-07-06
 
 ### Fixed

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -67,11 +67,12 @@ async function fetchStatus(): Promise<StressStatus> {
   }
 }
 
-/** Stable short alias per attendee: "Casey Cain" → CC, "mwatkins" → MW. */
+/** Stable short alias per attendee: "Casey Cain" → CC, "mwatkins" → MW.
+ * Names are sorted first so collision suffixes don't depend on rank order. */
 function buildMaskMap(people: string[]): Map<string, string> {
   const map = new Map<string, string>();
   const used = new Set<string>();
-  for (const name of people) {
+  for (const name of [...people].sort()) {
     const words = name.split(/[\s._-]+/).filter(Boolean);
     let alias =
       words.length > 1

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -67,11 +67,32 @@ async function fetchStatus(): Promise<StressStatus> {
   }
 }
 
+/** Stable short alias per attendee: "Casey Cain" → CC, "mwatkins" → MW. */
+function buildMaskMap(people: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  const used = new Set<string>();
+  for (const name of people) {
+    const words = name.split(/[\s._-]+/).filter(Boolean);
+    let alias =
+      words.length > 1
+        ? words.map((w) => (w[0] ?? "").toUpperCase()).join("")
+        : name.slice(0, 2).toUpperCase();
+    let candidate = alias;
+    let i = 2;
+    while (used.has(candidate)) candidate = `${alias}${i++}`;
+    alias = candidate;
+    used.add(alias);
+    map.set(name, alias);
+  }
+  return map;
+}
+
 /* ─────────────── page ─────────────── */
 
 export default function StressBoardPage() {
   const queryClient = useQueryClient();
   const [message, setMessage] = useState<string | null>(null);
+  const [masked, setMasked] = useState(false);
 
   const { data: status, isLoading } = useQuery({
     queryKey: ["meeting-stress"],
@@ -100,6 +121,14 @@ export default function StressBoardPage() {
     () => Math.max(1, ...(results?.people ?? []).map((p) => Math.abs(p.ridge))),
     [results],
   );
+  const maskMap = useMemo(
+    () => buildMaskMap((results?.people ?? []).map((p) => p.attendee)),
+    [results],
+  );
+  // Screenshot mode: alias people, hide meeting titles (titles leak names too).
+  const person = (name: string) =>
+    masked ? (maskMap.get(name) ?? "??") : name;
+  const title = (t: string, i: number) => (masked ? `meeting #${i + 1}` : t);
   const hasSource = !!(status?.calendar_linked ?? status?.events_file);
   const broken = !!(status?.unsupported ?? status?.unreachable);
   // Setup guidance only when status loaded, addon healthy, and no source.
@@ -129,18 +158,32 @@ export default function StressBoardPage() {
                 : ""}
             </p>
           </div>
-          <button
-            onClick={() => run.mutate()}
-            disabled={status?.running || run.isPending || !hasSource}
-            className={cn(
-              "rounded border border-zinc-700 px-3 py-1.5 text-xs",
-              status?.running || run.isPending
-                ? "cursor-wait text-zinc-500"
-                : "text-zinc-200 hover:bg-zinc-800",
-            )}
-          >
-            {status?.running ? "running…" : "▶ run"}
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setMasked((m) => !m)}
+              title="Mask names for screenshots"
+              className={cn(
+                "rounded border px-3 py-1.5 text-xs",
+                masked
+                  ? "border-yellow-600 text-yellow-400"
+                  : "border-zinc-700 text-zinc-400 hover:bg-zinc-800",
+              )}
+            >
+              {masked ? "🙈 masked" : "👁 names"}
+            </button>
+            <button
+              onClick={() => run.mutate()}
+              disabled={status?.running || run.isPending || !hasSource}
+              className={cn(
+                "rounded border border-zinc-700 px-3 py-1.5 text-xs",
+                status?.running || run.isPending
+                  ? "cursor-wait text-zinc-500"
+                  : "text-zinc-200 hover:bg-zinc-800",
+              )}
+            >
+              {status?.running ? "running…" : "▶ run"}
+            </button>
+          </div>
         </div>
 
         {message && (
@@ -207,7 +250,7 @@ export default function StressBoardPage() {
                     return (
                       <tr key={p.attendee} className="align-middle">
                         <td className="py-0.5 pr-2 font-bold text-zinc-100">
-                          {p.attendee}
+                          {person(p.attendee)}
                         </td>
                         <td className="pr-2 text-right">{p.n}</td>
                         <td className="pr-2 text-right">
@@ -286,10 +329,10 @@ export default function StressBoardPage() {
                         {Math.round(m.elev * 100)}%
                       </td>
                       <td className="max-w-40 truncate pr-2 text-zinc-100">
-                        {m.title}
+                        {title(m.title, i)}
                       </td>
                       <td className="text-zinc-500">
-                        {m.attendees.join(", ")}
+                        {m.attendees.map(person).join(", ")}
                       </td>
                     </tr>
                   ))}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
Adds a 🙈 **mask** toggle to the Stress Board for shareable screenshots (community-launch prerequisite):

- Attendees alias to stable initials ("Casey Cain" → CC; single-word names → first two letters; collisions deduped)
- Meeting titles — which leak names ("Anil / Casey 1:1") — render as `meeting #N` while masked
- Pure client-side; real names stay the default for private use
- Release 0.21.0 (feature + version bump, atomic commits)

typecheck green; eslint 0 errors (1 pre-existing warning on untouched line).