### PR TITLE
feat: show notice for stress-board events with no HR coverage

### DIFF
--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -38,6 +38,13 @@ interface StressStatus {
     generated: string;
     meetings: MeetingRow[];
     people: PersonRow[];
+    skipped?: {
+      total: number;
+      no_hr: number;
+      interactions_no_hr: number;
+      no_hr_titles: string[];
+      by_reason?: Record<string, number>;
+    };
   };
 }
 
@@ -135,6 +142,25 @@ export default function StressBoardPage() {
   // Setup guidance only when status loaded, addon healthy, and no source.
   const showSetup = !isLoading && !!status && !broken && !hasSource;
 
+  // Notice for events dropped because Garmin hadn't synced HR for that window
+  // (often a just-logged interaction). Built as one string so JSX whitespace
+  // can't inject a stray space before punctuation; names only when unmasked.
+  const skip = status?.results?.skipped;
+  const noHrTitles = Array.isArray(skip?.no_hr_titles) ? skip.no_hr_titles : [];
+  const skipNote =
+    skip && skip.no_hr > 0
+      ? `⚠ ${skip.no_hr} event${skip.no_hr === 1 ? "" : "s"} had no heart-rate coverage yet` +
+        (skip.interactions_no_hr > 0
+          ? ` (incl. ${skip.interactions_no_hr} logged interaction${
+              skip.interactions_no_hr === 1 ? "" : "s"
+            })`
+          : "") +
+        (!masked && noHrTitles.length > 0
+          ? ` — ${noHrTitles.join(", ")}`
+          : "") +
+        `. They'll show once Garmin syncs that time window — then hit ▶ run again.`
+      : null;
+
   return (
     <main className="min-h-screen bg-zinc-950 pb-24 font-mono text-sm text-zinc-200">
       <div className="mx-auto max-w-3xl px-4 pt-6">
@@ -190,6 +216,12 @@ export default function StressBoardPage() {
         {message && (
           <p className="mb-3 rounded border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-400">
             {message}
+          </p>
+        )}
+
+        {skipNote && (
+          <p className="mb-3 rounded border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-300">
+            {skipNote}
           </p>
         )}
 


### PR DESCRIPTION
## What

Companion UI for `ha-garmin-fitness-coach-addon` PR #259.

The addon now emits a `skipped` block in `meeting_stress.json` for events (often just-logged HA-sidebar interactions) that couldn't be scored because Garmin hadn't synced heart rate for that time window. Previously such an interaction just never showed up on the Stress Board — looking broken.

This renders an amber notice when `results.skipped.no_hr > 0`:

> ⚠ 2 events had no heart-rate coverage yet (incl. 1 logged interaction) — Mum, team review. They'll show once Garmin syncs that time window — then hit ▶ run again.

## Privacy

The notice is **mask-aware**: attendee/interaction names (`no_hr_titles`) are only listed when the board shows names. When the 🙈 mask is on, only counts are shown — names never leak into a shared screenshot. Verified end-to-end against a live dev server (unmasked lists titles; masked hides them; `typecheck` + `lint` clean, 0 errors).

## Requires

Addon build that includes the `skipped` summary (addon #259). Degrades gracefully on older addons — `skipped` is optional, so the notice simply doesn't render.