### PR TITLE
docs: use fictional names in mask alias example

### DIFF
--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -74,7 +74,7 @@ async function fetchStatus(): Promise<StressStatus> {
   }
 }
 
-/** Stable short alias per attendee: "Casey Cain" → CC, "mwatkins" → MW.
+/** Stable short alias per attendee: "Waffle Nimbus" → WN, "jbolt" → JB.
  * Names are sorted first so collision suffixes don't depend on rank order. */
 function buildMaskMap(people: string[]): Map<string, string> {
   const map = new Map<string, string>();


### PR DESCRIPTION
The `buildMaskMap` docstring illustrated the alias rule with real colleague names ("Casey Cain", "mwatkins"). Replace them with invented examples ("Waffle Nimbus", "jbolt") so nothing traceable to real people ships in the public repo.

Privacy hardening ahead of the community forum post. No behaviour change.