### PR TITLE
ci: pin checkout version comment to exact tag

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Install gh-aw extension


### PR DESCRIPTION
## What

zizmor code-scanning flagged `ref-version-mismatch` on `actions/checkout` in `copilot-setup-steps.yml`: the SHA pin carried a floating-major comment (`# v6`) but the pinned commit `de0fac2e` resolves to `v6.0.2`, and the `v6` major tag has since moved past it.

## Fix

`# v6` → `# v6.0.2` (SHA unchanged). Clears code-scanning alert #10.

## Test

No behavior change — SHA pin identical; only the comment updated. Verified SHA→tag via the GitHub tags API.