### PR TITLE
chore: harness audit remediation and AgentShield hardening

### DIFF
--- a/.claude/hooks/block-secrets.cjs
+++ b/.claude/hooks/block-secrets.cjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// PreToolUse guard: block Read/Edit/Write on secret files
+// (.env variants). .env.example is intentionally allowed.
+
+let data = "";
+process.stdin.on("data", (chunk) => {
+  data += chunk;
+});
+process.stdin.on("end", () => {
+  let input;
+  try {
+    input = JSON.parse(data);
+  } catch {
+    // Fail secure: if hook input can't be parsed we cannot verify the target,
+    // so block rather than risk leaking a secret file.
+    console.error("[Hook] BLOCKED: could not parse tool input");
+    process.exit(2);
+  }
+  const filePath = input.tool_input?.file_path || "";
+  const isSecret = /(^|\/)\.env|(^|\/)secrets\/|(^|\/)\.vercel\//.test(filePath);
+  const isExample = /(^|\/)\.env\.example$/.test(filePath);
+  if (isSecret && !isExample) {
+    console.error(`[Hook] BLOCKED: secret file ${filePath}`);
+    process.exit(2);
+  }
+});

--- a/.claude/hooks/stop-secret-audit.sh
+++ b/.claude/hooks/stop-secret-audit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stop hook: refuse to end the session while secret files are staged.
+
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+staged=$(git diff --cached --name-only \
+  | grep -E '(^|/)\.env' \
+  | grep -v '\.env\.example$' || true)
+
+if [ -n "${staged}" ]; then
+  echo "[Stop hook] Secret files are staged — unstage before finishing:" >&2
+  echo "${staged}" >&2
+  exit 2
+fi

--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -1,0 +1,48 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Project Memory — ha-garmin-fitness-coach-app
+
+Durable facts for Claude Code sessions that are not obvious from the code alone.
+
+## Architecture split
+
+- **This repo (app)**: pnpm/turbo monorepo (create-t3-turbo base) — Next.js app
+  in `apps/nextjs`, shared packages under `packages/` (`@acme/*` namespace).
+- **Companion repo (addon)**: `askb/ha-garmin-fitness-coach-addon` — Home
+  Assistant addon "PulseCoach" that **bundles tagged releases of this app**
+  into its Docker image. Version bumps here (package.json `version`) drive
+  addon bundle updates (e.g. addon commit "bundle app v0.22.0").
+
+## Deployment
+
+- Deploys to **Vercel** via `vercel.json` (buildCommand
+  `pnpm turbo build --filter=@acme/nextjs`, output `apps/nextjs/.next`).
+- `.github/workflows/vercel-deploy.yml` is **manual only**
+  (`workflow_dispatch`) — needs `VERCEL_TOKEN` / `VERCEL_ORG_ID` /
+  `VERCEL_PROJECT_ID` repo secrets before first use.
+- CI workflows use `./tooling/github/setup` composite (pnpm + node from
+  `.nvmrc` + `pnpm install`); reuse it in new workflows.
+
+## Conventions
+
+- All GitHub Actions pinned to full SHA with `# vX.Y.Z` comment; repo runs
+  **zizmor** — avoid `${{ }}` interpolation inside `run:` blocks (pass via
+  `env:` instead), add `persist-credentials: false` to checkout, and start
+  jobs with `step-security/harden-runner`.
+- REUSE-compliant (`REUSE.toml` aggregate annotations); `**/*.py` is NOT
+  covered — Python files need inline SPDX headers.
+- `postinstall` runs sherif (`lint:ws`) — workspace dependency mismatches
+  fail installs.
+- Auth: better-auth with Discord OAuth; Garmin Health API keys + webhook
+  secret in env (see `.env.example`).
+
+## Harness
+
+- `evals/` documents behavioral eval scenarios for the AI coach; `tests/`
+  currently holds one pytest file (`test_collect_failures.py`); JS/TS tests
+  run per-package via `pnpm test` (turbo).
+- `.claude/settings.json` has a PreToolUse hook blocking reads/writes of
+  `.env*` (except `.env.example`).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.local)",
+      "Read(./.vercel/**)",
+      "Read(./secrets/**)",
+      "Edit(./.env)",
+      "Edit(./.env.local)",
+      "Edit(./.vercel/**)",
+      "Edit(./secrets/**)",
+      "Write(./.env)",
+      "Write(./.env.local)",
+      "Write(./.vercel/**)",
+      "Write(./secrets/**)",
+      "Bash(rm -rf:*)",
+      "Bash(sudo:*)",
+      "Bash(chmod 777:*)",
+      "Bash(ssh:*)",
+      "Bash(* > /dev/*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-secrets.cjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-secret-audit.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,10 @@ GARMIN_WEBHOOK_SECRET=''
 
 # OpenAI (optional, for AI coach chat)
 OPENAI_API_KEY=''
+
+# Vercel deployment (used by `pnpm vercel:pull` / `pnpm vercel:deploy` and
+# the manual .github/workflows/vercel-deploy.yml workflow). Get values via
+# `vercel link` (writes .vercel/project.json) and https://vercel.com/account/tokens
+VERCEL_TOKEN=''
+VERCEL_ORG_ID=''
+VERCEL_PROJECT_ID=''

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+* @askb

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Summary
+
+<!-- What does this PR change and why? Link related issues: Fixes #NNN -->
+
+## Changes
+
+-
+
+## Test Plan
+
+- [ ] `pnpm lint` and `pnpm typecheck` pass
+- [ ] `pnpm test` passes
+- [ ] `pnpm build` succeeds
+
+## Checklist
+
+- [ ] Conventional commit type (`feat`/`fix`/`docs`/`test`/`refactor`/`chore`/`ci`)
+- [ ] Commits signed off (`git commit -s`, DCO)
+- [ ] New env vars documented in `.env.example`
+- [ ] Workflow changes keep actions SHA-pinned and pass zizmor
+- [ ] No secrets, tokens, or personal data in the diff

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Manual Vercel deploy. Never runs automatically — trigger from the
+# Actions tab. Requires repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID,
+# VERCEL_PROJECT_ID.
+---
+name: Vercel Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy target"
+        type: choice
+        options:
+          - preview
+          - production
+        default: preview
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vercel-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      DEPLOY_ENV: ${{ inputs.environment }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      # Pinned for reproducible deploys; bump deliberately.
+      VERCEL_CLI: vercel@55.0.0
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./tooling/github/setup
+
+      - name: Verify required secrets
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "$VERCEL_TOKEN" ] || missing="$missing VERCEL_TOKEN"
+          [ -n "$VERCEL_ORG_ID" ] || missing="$missing VERCEL_ORG_ID"
+          [ -n "$VERCEL_PROJECT_ID" ] || missing="$missing VERCEL_PROJECT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required repo secret(s):$missing" \
+              "— set them under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      - name: Pull Vercel environment
+        run: |
+          set -euo pipefail
+          pnpm dlx "$VERCEL_CLI" pull --yes --environment="$DEPLOY_ENV"
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          if [ "$DEPLOY_ENV" = "production" ]; then
+            pnpm dlx "$VERCEL_CLI" build --prod
+          else
+            pnpm dlx "$VERCEL_CLI" build
+          fi
+
+      - name: Deploy prebuilt output
+        run: |
+          set -euo pipefail
+          if [ "$DEPLOY_ENV" = "production" ]; then
+            url=$(pnpm dlx "$VERCEL_CLI" deploy --prebuilt --prod)
+          else
+            url=$(pnpm dlx "$VERCEL_CLI" deploy --prebuilt)
+          fi
+          {
+            echo "## Vercel deploy (${DEPLOY_ENV})"
+            echo ""
+            echo "${url}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,31 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Evals
+
+Behavioral evaluations for the PulseCoach web app, complementing the
+per-package unit tests (`pnpm test`) with scenario-level checks.
+
+- [`coaching-scenarios.md`](coaching-scenarios.md) — canonical input →
+  expected-behavior scenarios for the AI coach chat and readiness
+  surfaces. Used to spot-check regressions after prompt, model, or
+  threshold changes, and as ground truth when writing automated evals.
+
+## Philosophy
+
+Unit tests pin exact outputs; evals pin **behavioral invariants** that
+must hold across refactors:
+
+- The coach never recommends high-intensity work when readiness signals
+  are critically low.
+- Recommendations always carry a rationale a user can act on.
+- Missing Garmin data degrades conservatively, never aggressively.
+
+## Running
+
+Scenario checks that require the AI coach need `OPENAI_API_KEY` set
+locally (see `.env.example`). Deterministic scenarios can be verified
+against the bundled coaching logic in the companion addon repo:
+`ha-garmin-fitness-coach-addon/evals/smoke_eval.py`.

--- a/evals/coaching-scenarios.md
+++ b/evals/coaching-scenarios.md
@@ -1,0 +1,28 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Coaching Eval Scenarios
+
+Canonical scenarios for evaluating coach recommendations. Signals mirror
+the Garmin-derived metrics the app ingests (ACWR, TSB, Body Battery,
+stress, sleep debt, readiness, training status).
+
+| # | Scenario | Signals | Expected behavior |
+|---|----------|---------|-------------------|
+| 1 | Fresh athlete, balanced load | ACWR 1.0, TSB +5, BB 80, stress 25, sleep debt 15m, 0 hard days, readiness 85, PRODUCTIVE | Recommends a workout (not rest) with rationale |
+| 2 | Overreached | ACWR 1.7, TSB −30, BB 25, stress 70, sleep debt 150m, 4 hard days, readiness 18, OVERREACHING | Rest day, rationale cites overload signals |
+| 3 | Critically low readiness alone | ACWR 1.0, TSB 0, BB 60, readiness 20 | Rest day even though other signals are fine |
+| 4 | All signals missing | everything null/0 | Conservative output; never high intensity |
+| 5 | Sleep-deprived but fresh | ACWR 1.1, TSB −5, sleep debt 180m, readiness 45 | No high-intensity recommendation |
+
+## Invariants (must hold for every scenario)
+
+1. `is_rest_day == true` ⇒ non-empty rationale.
+2. Readiness < 25 ⇒ rest day (hard floor).
+3. Missing data never produces a more aggressive plan than complete data.
+4. Output is stable for identical inputs (deterministic engine).
+
+Scenarios 1–5 are executable against the deterministic engine in the
+addon repo: `ha-garmin-fitness-coach-addon/evals/smoke_eval.py`.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "postinstall": "pnpm lint:ws",
     "typecheck": "turbo run typecheck",
     "ui-add": "turbo run ui-add",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "vercel:pull": "pnpm dlx vercel@55.0.0 pull --yes --environment=production",
+    "vercel:deploy": "pnpm dlx vercel@55.0.0 deploy",
+    "vercel:deploy:prod": "pnpm dlx vercel@55.0.0 deploy --prod"
   },
   "devDependencies": {
     "@acme/prettier-config": "workspace:*",


### PR DESCRIPTION
## Summary

Remediates all repo-level failing checks from the deterministic harness audit (rubric `2026-05-19`) and hardens the Claude Code harness config per an AgentShield scan. Harness audit score: **24/49 → 45/49** (the remaining 4 pts are a user-level plugin-install check, not repo state). AgentShield grade: **96 → 98/100**. Vercel Integration category: 3/10 → 10/10.

## Changes

- **.claude/settings.json** — deny-only permissions block (`.env`, `.vercel/`, `secrets/`, `rm -rf`, `sudo`, `chmod 777`, `ssh`, device writes) + PreToolUse/Stop hooks
- **.claude/hooks/block-secrets.cjs** — auditable PreToolUse guard blocking Read/Edit/Write on `.env*` files (`.env.example` allowed)
- **.claude/hooks/stop-secret-audit.sh** — Stop hook refusing to end a session with secret files staged
- **.claude/memory.md** — durable project memory (monorepo layout, Vercel deploy config, workflow conventions)
- **evals/** — behavioral coaching scenarios and invariants complementing per-package unit tests
- **.github/workflows/vercel-deploy.yml** — `workflow_dispatch`-only Vercel deploy (pull → build → deploy `--prebuilt`); never auto-runs; gated on `VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` secrets (not yet configured — deploys stay on Vercel git integration until they are)
- **package.json** — `vercel:pull` / `vercel:deploy` scripts
- **.env.example** — Vercel env keys documented
- **.github/** — PR template, CODEOWNERS

## Test Plan

- [x] `pre-commit run --all-files` — 12/12 hooks passed (incl. reuse, yamllint, actionlint)
- [x] `zizmor .github/workflows/vercel-deploy.yml` — no findings
- [x] Actions SHA-pinned with version comments; `persist-credentials: false`; harden-runner first step; no `${{ }}` interpolation in `run:` blocks
- [x] Hook behavior verified: blocks `.env`/`.env.local`, allows `.env.example`
- [x] Harness audit re-run: 45/49, 0 repo-level failing checks
- [ ] Configure Vercel secrets and dispatch a preview deploy to validate the workflow end-to-end