### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2026-07-10
+
+### Changed
+
+- **Development harness hardening (no user-facing change).** Applied the
+  deterministic harness audit remediations and AgentShield findings:
+  deny-only Claude Code permissions, fail-secure secret-guard hooks
+  (PreToolUse + Stop), durable project memory, behavioral coaching evals,
+  a dispatch-only Vercel deploy workflow, and PR/issue templates plus
+  CODEOWNERS.
+
 ## [0.22.0] - 2026-07-09
 
 ### Added

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-turbo",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "engines": {
     "node": "^22.21.0",


### PR DESCRIPTION
Bumps app to **v0.23.0** for the harness/AgentShield hardening merged in #336. Tooling-only — no product behavior change. CHANGELOG updated.