### PR TITLE
feat: interaction quick-add on the Stress Board

### DIFF
--- a/apps/nextjs/src/__tests__/stress-board-quick-add.test.ts
+++ b/apps/nextjs/src/__tests__/stress-board-quick-add.test.ts
@@ -3,6 +3,7 @@ import {
   END_CHOICES,
   endIsoFromChoice,
   fmtEnd,
+  parseApiResponse,
 } from "../app/stress-board/quick-add-lib";
 
 describe("endIsoFromChoice", () => {
@@ -30,18 +31,46 @@ describe("endIsoFromChoice", () => {
 
 describe("fmtEnd", () => {
   const now = new Date("2026-07-11T22:00:00");
+  // Derive expectations with the same Intl options fmtEnd uses, so the
+  // assertions hold in any CI locale / hour-cycle.
+  const timeOf = (d: Date) =>
+    d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  const dateOf = (d: Date) =>
+    d.toLocaleDateString([], { month: "short", day: "numeric" });
 
   it("shows time only for same-day ends", () => {
-    expect(fmtEnd("2026-07-11T14:15:00", now)).toMatch(/2:15/);
-    expect(fmtEnd("2026-07-11T14:15:00", now)).not.toMatch(/Jul/);
+    const end = new Date("2026-07-11T14:15:00");
+    expect(fmtEnd("2026-07-11T14:15:00", now)).toBe(timeOf(end));
   });
 
   it("adds the date for older ends", () => {
-    expect(fmtEnd("2026-07-09T14:15:00", now)).toMatch(/Jul 9/);
+    const end = new Date("2026-07-09T14:15:00");
+    expect(fmtEnd("2026-07-09T14:15:00", now)).toBe(
+      `${dateOf(end)} ${timeOf(end)}`,
+    );
   });
 
   it("falls back to the raw string when unparseable", () => {
     expect(fmtEnd("garbage", now)).toBe("garbage");
+  });
+});
+
+describe("parseApiResponse", () => {
+  // jsdom has no global Response; a {json, status} stub is all it needs.
+  it("returns the parsed body for JSON responses", async () => {
+    const res = { status: 200, json: () => Promise.resolve({ success: true }) };
+    await expect(parseApiResponse(res)).resolves.toEqual({ success: true });
+  });
+
+  it("degrades non-JSON bodies to an HTTP-status message", async () => {
+    const res = {
+      status: 500,
+      json: () => Promise.reject(new SyntaxError("Unexpected token <")),
+    };
+    await expect(parseApiResponse(res)).resolves.toEqual({
+      success: false,
+      message: "Unexpected response (HTTP 500)",
+    });
   });
 });
 

--- a/apps/nextjs/src/__tests__/stress-board-quick-add.test.ts
+++ b/apps/nextjs/src/__tests__/stress-board-quick-add.test.ts
@@ -1,0 +1,52 @@
+import {
+  DURATION_CHIPS,
+  END_CHOICES,
+  endIsoFromChoice,
+  fmtEnd,
+} from "../app/stress-board/quick-add-lib";
+
+describe("endIsoFromChoice", () => {
+  const now = new Date("2026-07-11T10:00:00.000Z");
+
+  it("returns undefined for 'just now' so the server stamps the time", () => {
+    expect(endIsoFromChoice("now", now)).toBeUndefined();
+  });
+
+  it("computes relative timestamps for each ago choice", () => {
+    expect(endIsoFromChoice("30m", now)).toBe("2026-07-11T09:30:00.000Z");
+    expect(endIsoFromChoice("1h", now)).toBe("2026-07-11T09:00:00.000Z");
+    expect(endIsoFromChoice("2h", now)).toBe("2026-07-11T08:00:00.000Z");
+    expect(endIsoFromChoice("4h", now)).toBe("2026-07-11T06:00:00.000Z");
+  });
+
+  it("covers every non-now choice in END_CHOICES", () => {
+    for (const c of END_CHOICES) {
+      const iso = endIsoFromChoice(c.key, now);
+      if (c.key === "now") expect(iso).toBeUndefined();
+      else expect(iso).toBeDefined();
+    }
+  });
+});
+
+describe("fmtEnd", () => {
+  const now = new Date("2026-07-11T22:00:00");
+
+  it("shows time only for same-day ends", () => {
+    expect(fmtEnd("2026-07-11T14:15:00", now)).toMatch(/2:15/);
+    expect(fmtEnd("2026-07-11T14:15:00", now)).not.toMatch(/Jul/);
+  });
+
+  it("adds the date for older ends", () => {
+    expect(fmtEnd("2026-07-09T14:15:00", now)).toMatch(/Jul 9/);
+  });
+
+  it("falls back to the raw string when unparseable", () => {
+    expect(fmtEnd("garbage", now)).toBe("garbage");
+  });
+});
+
+describe("constants", () => {
+  it("duration chips are sane meeting lengths", () => {
+    expect(DURATION_CHIPS).toEqual([15, 30, 45, 60]);
+  });
+});

--- a/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
@@ -7,28 +7,33 @@ function getAuthServerBase() {
 }
 
 /**
- * Forward a Google Calendar request to the addon auth server and normalise the
- * response. Shared by the gcal-link and gcal-calendars proxy routes so the
- * 404-degradation and success-flag contract stay in one place.
+ * Forward a request to the addon auth server and normalise the response.
+ * Shared by the gcal-* and interactions proxy routes so the 404-degradation
+ * and success-flag contract stay in one place. `unsupportedMessage` is
+ * returned when the addon predates the endpoint (auth server 404s).
  */
-export async function gcalForward(path: string, init?: RequestInit) {
+export async function authForward(
+  path: string,
+  init: RequestInit | undefined,
+  unsupportedMessage: string,
+) {
   try {
     const res = await fetch(`${getAuthServerBase()}${path}`, init);
     const text = await res.text();
     let data: Record<string, unknown> = {};
+    let isJson = false;
     try {
       data = JSON.parse(text) as Record<string, unknown>;
+      isJson = true;
     } catch {
       if (text) data = { message: text.slice(0, 300) };
     }
     if (!res.ok) {
-      if (res.status === 404) {
+      // A JSON 404 is an endpoint answering (e.g. "not found" for an id);
+      // an HTML 404 means the addon predates the endpoint entirely.
+      if (res.status === 404 && !isJson) {
         return NextResponse.json(
-          {
-            success: false,
-            message:
-              "Google Calendar linking not available. Update addon to v0.22.0+",
-          },
+          { success: false, message: unsupportedMessage },
           { status: 404 },
         );
       }
@@ -47,4 +52,12 @@ export async function gcalForward(path: string, init?: RequestInit) {
       { status: 502 },
     );
   }
+}
+
+export async function gcalForward(path: string, init?: RequestInit) {
+  return authForward(
+    path,
+    init,
+    "Google Calendar linking not available. Update addon to v0.22.0+",
+  );
 }

--- a/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
@@ -23,8 +23,15 @@ export async function authForward(
     let data: Record<string, unknown> = {};
     let isJson = false;
     try {
-      data = JSON.parse(text) as Record<string, unknown>;
-      isJson = true;
+      // Only accept a JSON object — a primitive or array would spread into
+      // a malformed proxy response, so treat it like a non-JSON body.
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        data = parsed as Record<string, unknown>;
+        isJson = true;
+      } else if (text) {
+        data = { message: text.slice(0, 300) };
+      }
     } catch {
       if (text) data = { message: text.slice(0, 300) };
     }

--- a/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
@@ -37,10 +37,12 @@ export async function authForward(
     }
     if (!res.ok) {
       // A JSON 404 is an endpoint answering (e.g. "not found" for an id);
-      // an HTML 404 means the addon predates the endpoint entirely.
+      // an HTML 404 means the addon predates the endpoint entirely. The
+      // explicit `unsupported` flag lets clients detect this case without
+      // sniffing status codes or message strings.
       if (res.status === 404 && !isJson) {
         return NextResponse.json(
-          { success: false, message: unsupportedMessage },
+          { success: false, unsupported: true, message: unsupportedMessage },
           { status: 404 },
         );
       }

--- a/apps/nextjs/src/app/api/garmin/interactions/[id]/route.ts
+++ b/apps/nextjs/src/app/api/garmin/interactions/[id]/route.ts
@@ -1,0 +1,22 @@
+import { requireSession } from "~/auth/guard";
+import { authForward } from "../../_lib/gcal-proxy";
+
+export const dynamic = "force-dynamic";
+
+const UNSUPPORTED =
+  "Interaction logging not available. Update addon to v0.26.0+";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireSession();
+  if (denied) return denied;
+  const { id } = await params;
+  // The id is a short hex token; encode defensively anyway.
+  return authForward(
+    `/auth/interactions/${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+    UNSUPPORTED,
+  );
+}

--- a/apps/nextjs/src/app/api/garmin/interactions/route.ts
+++ b/apps/nextjs/src/app/api/garmin/interactions/route.ts
@@ -1,0 +1,28 @@
+import { requireSession } from "~/auth/guard";
+import { authForward } from "../_lib/gcal-proxy";
+
+export const dynamic = "force-dynamic";
+
+const UNSUPPORTED =
+  "Interaction logging not available. Update addon to v0.26.0+";
+
+export async function GET() {
+  const denied = await requireSession();
+  if (denied) return denied;
+  return authForward("/auth/interactions", undefined, UNSUPPORTED);
+}
+
+export async function POST(req: Request) {
+  const denied = await requireSession();
+  if (denied) return denied;
+  const body = await req.text();
+  return authForward(
+    "/auth/interactions",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    },
+    UNSUPPORTED,
+  );
+}

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -586,6 +586,7 @@ export default function StressBoardPage() {
                       onClick={() => deleteInteraction.mutate(r.id)}
                       disabled={deleteInteraction.isPending}
                       title="Remove this interaction"
+                      aria-label={`Remove interaction with ${r.person}`}
                       className="rounded px-1 text-zinc-600 hover:bg-red-500/10 hover:text-red-400"
                     >
                       ×

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -5,8 +5,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { cn } from "@acme/ui";
 
+import type { EndChoice, InteractionRec } from "./quick-add-lib";
 import { BottomNav } from "../_components/bottom-nav";
 import { getIngressUrl } from "../_components/ingress-provider";
+import {
+  DURATION_CHIPS,
+  END_CHOICES,
+  endIsoFromChoice,
+  fmtEnd,
+} from "./quick-add-lib";
 
 /* ─────────────── types (shape of meeting_stress.json) ─────────────── */
 
@@ -241,6 +248,83 @@ export default function StressBoardPage() {
     onError: (err) => setMessage(err.message),
   });
 
+  /* ─────────────── interaction quick-add ─────────────── */
+  const [personInput, setPersonInput] = useState("");
+  const [minutes, setMinutes] = useState<number>(30);
+  const [endChoice, setEndChoice] = useState<EndChoice>("now");
+
+  const addonHealthy =
+    !isLoading && !!status && !(status.unsupported ?? status.unreachable);
+
+  const { data: ixData } = useQuery({
+    queryKey: ["interactions"],
+    queryFn: async (): Promise<{
+      interactions?: InteractionRec[];
+      success?: boolean;
+      unsupported?: boolean;
+    }> => {
+      try {
+        const res = await fetch(getIngressUrl("/api/garmin/interactions"));
+        if (res.status === 404) return { success: false, unsupported: true };
+        return (await res.json()) as {
+          interactions?: InteractionRec[];
+          success?: boolean;
+        };
+      } catch {
+        return { success: false };
+      }
+    },
+    enabled: addonHealthy,
+  });
+  const recent = ixData?.interactions ?? [];
+  const ixSupported = !ixData?.unsupported;
+
+  const addInteraction = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(getIngressUrl("/api/garmin/interactions"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          person: personInput.trim(),
+          minutes,
+          end: endIsoFromChoice(endChoice),
+        }),
+      });
+      const data = (await res.json()) as { success: boolean; message?: string };
+      if (!data.success) throw new Error(data.message ?? "Failed to log");
+      return data;
+    },
+    onSuccess: () => {
+      setPersonInput("");
+      setEndChoice("now");
+      setMessage("Logged — hit ▶ run to score it against your heart rate.");
+      void queryClient.invalidateQueries({ queryKey: ["interactions"] });
+    },
+    onError: (err) => setMessage(err.message),
+  });
+
+  const deleteInteraction = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(
+        getIngressUrl(`/api/garmin/interactions/${encodeURIComponent(id)}`),
+        { method: "DELETE" },
+      );
+      const data = (await res.json()) as { success: boolean; message?: string };
+      if (!data.success) throw new Error(data.message ?? "Failed to delete");
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["interactions"] });
+    },
+    onError: (err) => setMessage(err.message),
+  });
+
+  const canLog =
+    personInput.trim().length > 0 &&
+    !addInteraction.isPending &&
+    minutes > 0 &&
+    minutes <= 1440;
+
   const results = status?.results;
   const maxAbsRidge = useMemo(
     () => Math.max(1, ...(results?.people ?? []).map((p) => Math.abs(p.ridge))),
@@ -417,6 +501,97 @@ export default function StressBoardPage() {
                   {saveCals.isPending ? "saving…" : "Save selection"}
                 </button>
               </>
+            )}
+          </div>
+        )}
+
+        {addonHealthy && ixSupported && (
+          <div className="mb-3 rounded border border-zinc-800 bg-zinc-900 p-3 text-xs">
+            <p className="mb-2 font-bold tracking-widest text-zinc-100">
+              LOG INTERACTION{" "}
+              <span className="font-normal tracking-normal text-zinc-500">
+                off-calendar chat, call, drop-by
+              </span>
+            </p>
+            <form
+              className="flex flex-wrap items-center gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (canLog) addInteraction.mutate();
+              }}
+            >
+              <input
+                value={personInput}
+                onChange={(e) => setPersonInput(e.target.value)}
+                list="known-people"
+                placeholder="who?"
+                autoComplete="off"
+                autoCapitalize="off"
+                className="w-36 rounded border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-zinc-200 placeholder:text-zinc-600"
+              />
+              <datalist id="known-people">
+                {(results?.people ?? []).map((p) => (
+                  <option key={p.attendee} value={p.attendee} />
+                ))}
+              </datalist>
+              <span className="flex overflow-hidden rounded border border-zinc-700">
+                {DURATION_CHIPS.map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => setMinutes(m)}
+                    className={cn(
+                      "px-2 py-1.5",
+                      minutes === m
+                        ? "bg-zinc-700 font-bold text-zinc-100"
+                        : "text-zinc-400 hover:bg-zinc-800",
+                    )}
+                  >
+                    {m}m
+                  </button>
+                ))}
+              </span>
+              <select
+                value={endChoice}
+                onChange={(e) => setEndChoice(e.target.value as EndChoice)}
+                className="rounded border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-zinc-300"
+              >
+                {END_CHOICES.map((c) => (
+                  <option key={c.key} value={c.key}>
+                    ended {c.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="submit"
+                disabled={!canLog}
+                className="rounded border border-zinc-700 px-3 py-1.5 text-zinc-200 hover:bg-zinc-800 disabled:cursor-not-allowed disabled:text-zinc-600"
+              >
+                {addInteraction.isPending ? "logging…" : "+ log"}
+              </button>
+            </form>
+            {recent.length > 0 && (
+              <ul className="mt-2 space-y-0.5">
+                {recent.slice(0, 6).map((r) => (
+                  <li
+                    key={r.id}
+                    className="flex items-center gap-2 text-zinc-500"
+                  >
+                    <span className="text-zinc-300">{person(r.person)}</span>
+                    <span>
+                      {r.minutes}m · ended {fmtEnd(r.end)}
+                    </span>
+                    <button
+                      onClick={() => deleteInteraction.mutate(r.id)}
+                      disabled={deleteInteraction.isPending}
+                      title="Remove this interaction"
+                      className="rounded px-1 text-zinc-600 hover:bg-red-500/10 hover:text-red-400"
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         )}

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -255,7 +255,7 @@ export default function StressBoardPage() {
   const [endChoice, setEndChoice] = useState<EndChoice>("now");
 
   const addonHealthy =
-    !isLoading && !!status && !(status.unsupported ?? status.unreachable);
+    !isLoading && !!status && !status.unsupported && !status.unreachable;
 
   const { data: ixData } = useQuery({
     queryKey: ["interactions"],
@@ -282,7 +282,9 @@ export default function StressBoardPage() {
     enabled: addonHealthy,
   });
   const recent = ixData?.interactions ?? [];
-  const ixSupported = !ixData?.unsupported;
+  // Only show the panel once the probe has answered — defaulting to
+  // "supported" would flash the form on addons that predate the endpoint.
+  const ixSupported = !!ixData && !ixData.unsupported;
 
   const addInteraction = useMutation({
     mutationFn: async () => {

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -13,6 +13,7 @@ import {
   END_CHOICES,
   endIsoFromChoice,
   fmtEnd,
+  parseApiResponse,
 } from "./quick-add-lib";
 
 /* ─────────────── types (shape of meeting_stress.json) ─────────────── */
@@ -290,7 +291,7 @@ export default function StressBoardPage() {
           end: endIsoFromChoice(endChoice),
         }),
       });
-      const data = (await res.json()) as { success: boolean; message?: string };
+      const data = await parseApiResponse(res);
       if (!data.success) throw new Error(data.message ?? "Failed to log");
       return data;
     },
@@ -309,7 +310,7 @@ export default function StressBoardPage() {
         getIngressUrl(`/api/garmin/interactions/${encodeURIComponent(id)}`),
         { method: "DELETE" },
       );
-      const data = (await res.json()) as { success: boolean; message?: string };
+      const data = await parseApiResponse(res);
       if (!data.success) throw new Error(data.message ?? "Failed to delete");
       return data;
     },

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -266,10 +266,12 @@ export default function StressBoardPage() {
     }> => {
       try {
         const res = await fetch(getIngressUrl("/api/garmin/interactions"));
-        if (res.status === 404) return { success: false, unsupported: true };
+        // The proxy marks addon-predates-endpoint 404s with an explicit
+        // `unsupported` flag; a plain JSON 404 is a real answer.
         return (await res.json()) as {
           interactions?: InteractionRec[];
           success?: boolean;
+          unsupported?: boolean;
         };
       } catch {
         return { success: false };
@@ -586,7 +588,7 @@ export default function StressBoardPage() {
                       onClick={() => deleteInteraction.mutate(r.id)}
                       disabled={deleteInteraction.isPending}
                       title="Remove this interaction"
-                      aria-label={`Remove interaction with ${r.person}`}
+                      aria-label={`Remove interaction with ${person(r.person)}`}
                       className="rounded px-1 text-zinc-600 hover:bg-red-500/10 hover:text-red-400"
                     >
                       ×

--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -263,6 +263,7 @@ export default function StressBoardPage() {
       interactions?: InteractionRec[];
       success?: boolean;
       unsupported?: boolean;
+      message?: string;
     }> => {
       try {
         const res = await fetch(getIngressUrl("/api/garmin/interactions"));
@@ -272,6 +273,7 @@ export default function StressBoardPage() {
           interactions?: InteractionRec[];
           success?: boolean;
           unsupported?: boolean;
+          message?: string;
         };
       } catch {
         return { success: false };
@@ -528,6 +530,7 @@ export default function StressBoardPage() {
                 onChange={(e) => setPersonInput(e.target.value)}
                 list="known-people"
                 placeholder="who?"
+                aria-label="Person you interacted with"
                 autoComplete="off"
                 autoCapitalize="off"
                 className="w-36 rounded border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-zinc-200 placeholder:text-zinc-600"
@@ -557,6 +560,7 @@ export default function StressBoardPage() {
               <select
                 value={endChoice}
                 onChange={(e) => setEndChoice(e.target.value as EndChoice)}
+                aria-label="When the interaction ended"
                 className="rounded border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-zinc-300"
               >
                 {END_CHOICES.map((c) => (

--- a/apps/nextjs/src/app/stress-board/quick-add-lib.ts
+++ b/apps/nextjs/src/app/stress-board/quick-add-lib.ts
@@ -1,0 +1,47 @@
+/** Pure helpers for the Stress Board interaction quick-add. */
+
+export interface InteractionRec {
+  id: string;
+  person: string;
+  minutes: number;
+  end: string;
+}
+
+/** "Ended…" choices: key → minutes ago. "now" is the server default. */
+export const END_CHOICES = [
+  { key: "now", label: "just now", minutesAgo: 0 },
+  { key: "30m", label: "30 min ago", minutesAgo: 30 },
+  { key: "1h", label: "1 hour ago", minutesAgo: 60 },
+  { key: "2h", label: "2 hours ago", minutesAgo: 120 },
+  { key: "4h", label: "4 hours ago", minutesAgo: 240 },
+] as const;
+
+export type EndChoice = (typeof END_CHOICES)[number]["key"];
+
+export const DURATION_CHIPS = [15, 30, 45, 60] as const;
+
+/**
+ * ISO timestamp for a relative end choice, or undefined for "just now"
+ * (the addon then stamps now server-side, avoiding clock skew).
+ */
+export function endIsoFromChoice(
+  choice: EndChoice,
+  now: Date = new Date(),
+): string | undefined {
+  const found = END_CHOICES.find((c) => c.key === choice);
+  if (!found || found.minutesAgo === 0) return undefined;
+  return new Date(now.getTime() - found.minutesAgo * 60_000).toISOString();
+}
+
+/** Compact "ended" stamp for the recent list: time today, date+time before. */
+export function fmtEnd(endIso: string, now: Date = new Date()): string {
+  const end = new Date(endIso);
+  if (Number.isNaN(end.getTime())) return endIso;
+  const sameDay = end.toDateString() === now.toDateString();
+  const time = end.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  if (sameDay) return time;
+  return `${end.toLocaleDateString([], { month: "short", day: "numeric" })} ${time}`;
+}

--- a/apps/nextjs/src/app/stress-board/quick-add-lib.ts
+++ b/apps/nextjs/src/app/stress-board/quick-add-lib.ts
@@ -7,6 +7,23 @@ export interface InteractionRec {
   end: string;
 }
 
+/**
+ * Parse a mutation response without letting a non-JSON body (e.g. an HTML
+ * 500 page) surface as a SyntaxError — fall back to the HTTP status.
+ */
+export async function parseApiResponse(
+  res: Pick<Response, "json" | "status">,
+): Promise<{ success: boolean; message?: string }> {
+  try {
+    return (await res.json()) as { success: boolean; message?: string };
+  } catch {
+    return {
+      success: false,
+      message: `Unexpected response (HTTP ${res.status})`,
+    };
+  }
+}
+
 /** "Ended…" choices: key → minutes ago. "now" is the server default. */
 export const END_CHOICES = [
   { key: "now", label: "just now", minutesAgo: 0 },


### PR DESCRIPTION
## Summary

UI half of the Stress Board interaction quick-add (backend endpoints land in the addon repo as `feat/interactions-ui`, addon v0.26.0).

- **LOG INTERACTION panel** on the Stress Board: person input with a datalist of known attendees, duration chips (15/30/45/60m), "ended just now / 30 min / 1h / 2h / 4h ago" select (just-now is server-stamped to avoid clock skew), Enter-to-submit
- **Recent list** (last 6) with per-entry delete; names respect the existing 🙈 screenshot mask mode
- New `/api/garmin/interactions` (+ `[id]` DELETE) proxy routes behind `requireSession`, forwarding to the addon auth server
- `gcalForward` refactored into a generic `authForward` with per-feature unsupported-messages; a JSON 404 (endpoint answered "not found") is now distinguished from an HTML 404 (addon predates the endpoint), so the panel hides itself gracefully on older addons

## Test plan

- [x] 7 new unit tests for the pure time helpers (`quick-add-lib.ts`)
- [x] Full jest suite 177/177, tsc clean, eslint 0 errors, prettier applied

## Notes

The bundled addon UI picks this up at the next app release + `APP_REF` bump in the addon Dockerfile.