### PR TITLE
fix: satisfy lint and format gates on pwa files

### DIFF
--- a/apps/nextjs/public/sw.js
+++ b/apps/nextjs/public/sw.js
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+/* eslint-disable no-undef, @typescript-eslint/no-empty-function -- service worker: `self` is the SW global; empty fetch handler is intentional */
 // @ts-nocheck -- service-worker globals (self.skipWaiting, clients) aren't in the DOM lib
 // Minimal service worker: exists only so the site is an installable PWA
 // (Bubblewrap/TWA prerequisite). No offline caching — out of MVP scope.

--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -15,9 +15,24 @@ export default function manifest(): MetadataRoute.Manifest {
     background_color: "#0f172a",
     theme_color: "#0f172a",
     icons: [
-      { src: "/icons/icon-192.png", sizes: "192x192", type: "image/png", purpose: "any" },
-      { src: "/icons/icon-512.png", sizes: "512x512", type: "image/png", purpose: "any" },
-      { src: "/icons/icon-512.png", sizes: "512x512", type: "image/png", purpose: "maskable" },
+      {
+        src: "/icons/icon-192.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icons/icon-512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icons/icon-512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
     ],
   };
 }


### PR DESCRIPTION
## Summary

Fixes the `lint` and `format` CI failures on PR #351 (release → main). The
release branch's own CI didn't run these gates, but `main` does.

- **sw.js** — disable `no-undef` / `no-empty-function`: `self` is the
  service-worker global (not DOM), and the empty fetch handler is intentional
  (no offline caching in MVP).
- **manifest.ts** — reformat the icons array to Prettier style.

## Verification

- `pnpm --filter @acme/nextjs lint` → 0 errors (233 pre-existing warnings).
- `prettier --check` → clean.
- `typecheck` still passes.

Once merged, #351 re-runs green and can promote to `main`.