### PR TITLE
feat: make Garmin backend URL configurable via GARMIN_AUTH_SERVER

### DIFF
--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+import { getAuthServerBase } from "./auth-server";
+
+const LOCAL = "http://127.0.0.1:8099";
+
+describe("getAuthServerBase", () => {
+  afterEach(() => {
+    delete process.env.GARMIN_AUTH_SERVER;
+  });
+
+  it("defaults to the local addon service when unset", () => {
+    delete process.env.GARMIN_AUTH_SERVER;
+    expect(getAuthServerBase()).toBe(LOCAL);
+  });
+
+  it("falls back to local when blank/whitespace", () => {
+    process.env.GARMIN_AUTH_SERVER = "   ";
+    expect(getAuthServerBase()).toBe(LOCAL);
+  });
+
+  it("uses a configured value", () => {
+    process.env.GARMIN_AUTH_SERVER = "https://backend.example.com";
+    expect(getAuthServerBase()).toBe("https://backend.example.com");
+  });
+
+  it("strips trailing slashes so callers don't produce //", () => {
+    process.env.GARMIN_AUTH_SERVER = "https://backend.example.com/";
+    expect(getAuthServerBase()).toBe("https://backend.example.com");
+  });
+});

--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
@@ -1,12 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
+/* eslint-disable no-restricted-properties -- test manipulates the raw GARMIN_AUTH_SERVER env by design */
 import { getAuthServerBase } from "./auth-server";
 
 const LOCAL = "http://127.0.0.1:8099";
 
 describe("getAuthServerBase", () => {
+  const original = process.env.GARMIN_AUTH_SERVER;
+
   afterEach(() => {
-    delete process.env.GARMIN_AUTH_SERVER;
+    if (original === undefined) delete process.env.GARMIN_AUTH_SERVER;
+    else process.env.GARMIN_AUTH_SERVER = original;
   });
 
   it("defaults to the local addon service when unset", () => {

--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Base URL of the Garmin auth/sync backend.
+ *
+ * Configurable via `GARMIN_AUTH_SERVER` so the frontend can point at a hosted
+ * backend when deployed standalone (outside the HA addon). Defaults to the
+ * addon's local service, so addon behavior is unchanged when the var is unset.
+ * A blank/whitespace value is treated as unset (`??` alone would keep an empty
+ * string and produce relative-URL fetches).
+ */
+export function getAuthServerBase(): string {
+  // Server-side only; the `~/env` shim isn't available in route handlers.
+  // eslint-disable-next-line no-restricted-properties
+  const configured = process.env.GARMIN_AUTH_SERVER?.trim();
+  return configured ? configured : "http://127.0.0.1:8099";
+}

--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
@@ -8,11 +8,12 @@
  * backend when deployed standalone (outside the HA addon). Defaults to the
  * addon's local service, so addon behavior is unchanged when the var is unset.
  * A blank/whitespace value is treated as unset (`??` alone would keep an empty
- * string and produce relative-URL fetches).
+ * string and produce relative-URL fetches). A trailing slash is stripped so
+ * callers can safely append `/auth/...` without producing `//`.
  */
 export function getAuthServerBase(): string {
   // Server-side only; the `~/env` shim isn't available in route handlers.
   // eslint-disable-next-line no-restricted-properties
-  const configured = process.env.GARMIN_AUTH_SERVER?.trim();
+  const configured = process.env.GARMIN_AUTH_SERVER?.trim().replace(/\/+$/, "");
   return configured ? configured : "http://127.0.0.1:8099";
 }

--- a/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/gcal-proxy.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 
-function getAuthServerBase() {
-  // Server-side route in addon container; `~/env` shim isn't available.
-  // eslint-disable-next-line no-restricted-properties
-  return process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
-}
+import { getAuthServerBase } from "./auth-server";
 
 /**
  * Forward a request to the addon auth server and normalise the response.

--- a/apps/nextjs/src/app/api/garmin/auth/route.ts
+++ b/apps/nextjs/src/app/api/garmin/auth/route.ts
@@ -3,11 +3,14 @@ import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
 
-const AUTH_SERVER =
-  // Configurable so the app can point at a hosted Garmin backend outside the
-  // addon; defaults to the addon's local service so addon behavior is unchanged.
-  // eslint-disable-next-line no-restricted-properties
-  process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
+// Configurable so the app can point at a hosted Garmin backend outside the
+// addon; defaults to the addon's local service so addon behavior is unchanged.
+// A blank/whitespace value falls back too (?? alone would keep an empty string).
+// eslint-disable-next-line no-restricted-properties
+const configuredAuthServer = process.env.GARMIN_AUTH_SERVER?.trim();
+const AUTH_SERVER = configuredAuthServer
+  ? configuredAuthServer
+  : "http://127.0.0.1:8099";
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/auth/route.ts
+++ b/apps/nextjs/src/app/api/garmin/auth/route.ts
@@ -3,7 +3,11 @@ import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
 
-const AUTH_SERVER = "http://127.0.0.1:8099";
+const AUTH_SERVER =
+  // Configurable so the app can point at a hosted Garmin backend outside the
+  // addon; defaults to the addon's local service so addon behavior is unchanged.
+  // eslint-disable-next-line no-restricted-properties
+  process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/auth/route.ts
+++ b/apps/nextjs/src/app/api/garmin/auth/route.ts
@@ -2,15 +2,9 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
+import { getAuthServerBase } from "../_lib/auth-server";
 
-// Configurable so the app can point at a hosted Garmin backend outside the
-// addon; defaults to the addon's local service so addon behavior is unchanged.
-// A blank/whitespace value falls back too (?? alone would keep an empty string).
-// eslint-disable-next-line no-restricted-properties
-const configuredAuthServer = process.env.GARMIN_AUTH_SERVER?.trim();
-const AUTH_SERVER = configuredAuthServer
-  ? configuredAuthServer
-  : "http://127.0.0.1:8099";
+const AUTH_SERVER = getAuthServerBase();
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/meeting-stress/route.ts
+++ b/apps/nextjs/src/app/api/garmin/meeting-stress/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse } from "next/server";
 
-export const dynamic = "force-dynamic";
+import { getAuthServerBase } from "../_lib/auth-server";
 
-function getAuthServerBase() {
-  // Server-side route in addon container; `~/env` shim isn't available.
-  // eslint-disable-next-line no-restricted-properties
-  return process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
-}
+export const dynamic = "force-dynamic";
 
 export async function POST() {
   try {

--- a/apps/nextjs/src/app/api/garmin/recompute/route.ts
+++ b/apps/nextjs/src/app/api/garmin/recompute/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
+import { getAuthServerBase } from "../_lib/auth-server";
 
 export const dynamic = "force-dynamic";
-
-function getAuthServerBase() {
-  // Server-side route in addon container; `~/env` shim isn't available.
-  // eslint-disable-next-line no-restricted-properties
-  return process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
-}
 
 export async function POST() {
   const denied = await requireSession();

--- a/apps/nextjs/src/app/api/garmin/sync/route.ts
+++ b/apps/nextjs/src/app/api/garmin/sync/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
 
-const AUTH_SERVER = "http://127.0.0.1:8099";
+const AUTH_SERVER =
+  // Configurable so the app can point at a hosted Garmin backend outside the
+  // addon; defaults to the addon's local service so addon behavior is unchanged.
+  // eslint-disable-next-line no-restricted-properties
+  process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/sync/route.ts
+++ b/apps/nextjs/src/app/api/garmin/sync/route.ts
@@ -2,11 +2,14 @@ import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
 
-const AUTH_SERVER =
-  // Configurable so the app can point at a hosted Garmin backend outside the
-  // addon; defaults to the addon's local service so addon behavior is unchanged.
-  // eslint-disable-next-line no-restricted-properties
-  process.env.GARMIN_AUTH_SERVER ?? "http://127.0.0.1:8099";
+// Configurable so the app can point at a hosted Garmin backend outside the
+// addon; defaults to the addon's local service so addon behavior is unchanged.
+// A blank/whitespace value falls back too (?? alone would keep an empty string).
+// eslint-disable-next-line no-restricted-properties
+const configuredAuthServer = process.env.GARMIN_AUTH_SERVER?.trim();
+const AUTH_SERVER = configuredAuthServer
+  ? configuredAuthServer
+  : "http://127.0.0.1:8099";
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/sync/route.ts
+++ b/apps/nextjs/src/app/api/garmin/sync/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
+import { getAuthServerBase } from "../_lib/auth-server";
 
-// Configurable so the app can point at a hosted Garmin backend outside the
-// addon; defaults to the addon's local service so addon behavior is unchanged.
-// A blank/whitespace value falls back too (?? alone would keep an empty string).
-// eslint-disable-next-line no-restricted-properties
-const configuredAuthServer = process.env.GARMIN_AUTH_SERVER?.trim();
-const AUTH_SERVER = configuredAuthServer
-  ? configuredAuthServer
-  : "http://127.0.0.1:8099";
+const AUTH_SERVER = getAuthServerBase();
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";


### PR DESCRIPTION
## Summary

Makes the Garmin backend URL configurable so the same frontend runs both as the
HA addon (backend co-located) and as a cloud/standalone deployment (backend
hosted elsewhere).

Previously `auth` and `sync` hard-coded `http://127.0.0.1:8099`, and the
resolution logic was duplicated across five routes. This PR:

- Adds a single helper `_lib/auth-server.ts` → `getAuthServerBase()` that reads
  `GARMIN_AUTH_SERVER`, trims it, and falls back to `http://127.0.0.1:8099`
  when unset **or blank** (`??` alone would keep an empty string).
- Routes `auth`, `sync`, `recompute`, `meeting-stress`, and `gcal-proxy` all use
  the one helper — no more per-file copies.

## Non-breaking

- **HA addon**: `GARMIN_AUTH_SERVER` unset → falls back to the local addon
  service → identical behavior.
- **Cloud/standalone**: set `GARMIN_AUTH_SERVER=https://<hosted-backend>` → the
  frontend talks to the hosted Garmin backend.

The `http://127.0.0.1:8099` literal remains only as the **default** inside the
one helper (intentional — it's the addon's local service).

## Verification
- `typecheck`, `prettier`, `lint` (0 errors) pass.
- Single source of truth: `getAuthServerBase`/`GARMIN_AUTH_SERVER` now live only
  in `_lib/auth-server.ts`.