### PR TITLE
feat: forward session user id to Garmin backend in multi-tenant mode

### DIFF
--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
@@ -3,6 +3,14 @@
 /* eslint-disable no-restricted-properties -- test manipulates the raw GARMIN_AUTH_SERVER env by design */
 import { garminUserHeaders, getAuthServerBase } from "./auth-server";
 
+jest.mock("~/auth/server", () => ({
+  getSession: jest.fn(),
+}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { getSession } = require("~/auth/server") as {
+  getSession: jest.Mock;
+};
+
 const LOCAL = "http://127.0.0.1:8099";
 
 describe("getAuthServerBase", () => {
@@ -46,6 +54,20 @@ describe("garminUserHeaders", () => {
     process.env.DEV_BYPASS_AUTH = "true";
     // Must not forward a user id — the addon keeps its shared token dir. This
     // path returns before importing the session module, so no mocking needed.
+    await expect(garminUserHeaders()).resolves.toEqual({});
+  });
+
+  it("forwards the session user id when not in bypass mode", async () => {
+    delete process.env.DEV_BYPASS_AUTH;
+    getSession.mockResolvedValue({ user: { id: "user-42" } });
+    await expect(garminUserHeaders()).resolves.toEqual({
+      "X-PulseCoach-User": "user-42",
+    });
+  });
+
+  it("sends no header when there is no session", async () => {
+    delete process.env.DEV_BYPASS_AUTH;
+    getSession.mockResolvedValue(null);
     await expect(garminUserHeaders()).resolves.toEqual({});
   });
 });

--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 /* eslint-disable no-restricted-properties -- test manipulates the raw GARMIN_AUTH_SERVER env by design */
-import { getAuthServerBase } from "./auth-server";
+import { garminUserHeaders, getAuthServerBase } from "./auth-server";
 
 const LOCAL = "http://127.0.0.1:8099";
 
@@ -31,5 +31,21 @@ describe("getAuthServerBase", () => {
   it("strips trailing slashes so callers don't produce //", () => {
     process.env.GARMIN_AUTH_SERVER = "https://backend.example.com/";
     expect(getAuthServerBase()).toBe("https://backend.example.com");
+  });
+});
+
+describe("garminUserHeaders", () => {
+  const original = process.env.DEV_BYPASS_AUTH;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.DEV_BYPASS_AUTH;
+    else process.env.DEV_BYPASS_AUTH = original;
+  });
+
+  it("sends no user header in addon single-user mode (DEV_BYPASS_AUTH)", async () => {
+    process.env.DEV_BYPASS_AUTH = "true";
+    // Must not forward a user id — the addon keeps its shared token dir. This
+    // path returns before importing the session module, so no mocking needed.
+    await expect(garminUserHeaders()).resolves.toEqual({});
   });
 });

--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
@@ -17,3 +17,27 @@ export function getAuthServerBase(): string {
   const configured = process.env.GARMIN_AUTH_SERVER?.trim().replace(/\/+$/, "");
   return configured ? configured : "http://127.0.0.1:8099";
 }
+
+/** Header the backend reads to scope tokens/sync per user (see request_user.py). */
+export const GARMIN_USER_HEADER = "X-PulseCoach-User";
+
+/**
+ * Header(s) identifying the acting user to the Garmin backend.
+ *
+ * Only sent in multi-tenant deployments. In the HA addon single-user mode
+ * (`DEV_BYPASS_AUTH=true`) this returns no header, so the backend keeps using
+ * its shared token dir and existing addon tokens keep working — forwarding the
+ * fabricated `seed-user-001` there would switch the backend to a per-user dir
+ * and hide those tokens. When real auth is in effect, the session user id is
+ * forwarded so the backend isolates tokens and sync per user.
+ */
+export async function garminUserHeaders(): Promise<Record<string, string>> {
+  // eslint-disable-next-line no-restricted-properties
+  if (process.env.DEV_BYPASS_AUTH === "true") return {};
+  // Dynamic import keeps `server-only` (and better-auth) out of the module's
+  // top level, so unit tests importing getAuthServerBase don't pull it in.
+  const { getSession } = await import("~/auth/server");
+  const session = await getSession();
+  const userId = session?.user?.id;
+  return userId ? { [GARMIN_USER_HEADER]: userId } : {};
+}

--- a/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
+++ b/apps/nextjs/src/app/api/garmin/_lib/auth-server.ts
@@ -18,7 +18,7 @@ export function getAuthServerBase(): string {
   return configured ? configured : "http://127.0.0.1:8099";
 }
 
-/** Header the backend reads to scope tokens/sync per user (see request_user.py). */
+/** Header that the backend reads to scope tokens/sync per user (see request_user.py). */
 export const GARMIN_USER_HEADER = "X-PulseCoach-User";
 
 /**

--- a/apps/nextjs/src/app/api/garmin/auth/route.ts
+++ b/apps/nextjs/src/app/api/garmin/auth/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
-import { getAuthServerBase } from "../_lib/auth-server";
+import { garminUserHeaders, getAuthServerBase } from "../_lib/auth-server";
 
 const AUTH_SERVER = getAuthServerBase();
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
@@ -37,7 +37,10 @@ function mockMfa() {
 async function proxyPost(url: string, body: unknown) {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(await garminUserHeaders()),
+    },
     body: JSON.stringify(body),
   });
   const data: unknown = await res.json();
@@ -45,7 +48,7 @@ async function proxyPost(url: string, body: unknown) {
 }
 
 async function proxyGet(url: string) {
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: await garminUserHeaders() });
   const data: unknown = await res.json();
   return NextResponse.json(data, { status: res.status });
 }

--- a/apps/nextjs/src/app/api/garmin/auth/route.ts
+++ b/apps/nextjs/src/app/api/garmin/auth/route.ts
@@ -5,6 +5,8 @@ import { requireSession } from "~/auth/guard";
 import { garminUserHeaders, getAuthServerBase } from "../_lib/auth-server";
 
 const AUTH_SERVER = getAuthServerBase();
+// Per-user header is forwarded below, so never statically cache this route.
+export const dynamic = "force-dynamic";
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/sync/route.ts
+++ b/apps/nextjs/src/app/api/garmin/sync/route.ts
@@ -4,6 +4,8 @@ import { requireSession } from "~/auth/guard";
 import { garminUserHeaders, getAuthServerBase } from "../_lib/auth-server";
 
 const AUTH_SERVER = getAuthServerBase();
+// Per-user header is forwarded below, so never statically cache this route.
+export const dynamic = "force-dynamic";
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
 // eslint-disable-next-line no-restricted-properties
 const IS_ADDON = process.env.NODE_ENV === "production";

--- a/apps/nextjs/src/app/api/garmin/sync/route.ts
+++ b/apps/nextjs/src/app/api/garmin/sync/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireSession } from "~/auth/guard";
-import { getAuthServerBase } from "../_lib/auth-server";
+import { garminUserHeaders, getAuthServerBase } from "../_lib/auth-server";
 
 const AUTH_SERVER = getAuthServerBase();
 // Server-side route: `~/env` shim isn't available here; NODE_ENV is safe.
@@ -23,7 +23,9 @@ export async function GET() {
     });
   }
   try {
-    const res = await fetch(`${AUTH_SERVER}/auth/sync-status`);
+    const res = await fetch(`${AUTH_SERVER}/auth/sync-status`, {
+      headers: await garminUserHeaders(),
+    });
     const data: unknown = await res.json();
     return NextResponse.json(data);
   } catch {
@@ -50,7 +52,10 @@ export async function POST() {
   try {
     const res = await fetch(`${AUTH_SERVER}/auth/sync`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(await garminUserHeaders()),
+      },
     });
     const data: unknown = await res.json();
     return NextResponse.json(data, { status: res.status });


### PR DESCRIPTION
## Summary

App-side counterpart to addon PR #285 (per-user Garmin backend). The frontend
now forwards the authenticated user's id to the backend so it can isolate
tokens and sync **per user** — but only in a real multi-tenant deployment.

`garminUserHeaders()` sends the `X-PulseCoach-User` header (read by the backend
`request_user.resolve_user_id`) on the `auth` and `sync` proxy calls.

## The critical gate (why this is safe for the addon)

In the HA addon single-user mode (`DEV_BYPASS_AUTH=true`) the header is **not**
sent. The addon's session user is the fabricated `seed-user-001`; forwarding it
would switch the backend to a per-user token dir and hide the addon's existing
shared tokens. So the gate mirrors `requireSession`: no forwarding under
`DEV_BYPASS_AUTH`, forward the real session id otherwise.

## Scope

Wired into the credential + sync paths (`auth`, `sync`) that the backend
actually scopes today. `recompute` / `meeting-stress` / `gcal` remain
single-user on the backend (tracked follow-up), so forwarding there is deferred.

## Notes

- `getSession` is imported dynamically inside `garminUserHeaders` so the module
  doesn't pull `server-only` into unit tests.
- Adds a test asserting no header is sent under `DEV_BYPASS_AUTH`.

## Verification
- `typecheck`, `prettier`, `lint` (0 errors), jest (5/5) pass.