### PR TITLE
feat: first-run third-party consent notice on stress board

### DIFF
--- a/apps/nextjs/src/app/stress-board/page.tsx
+++ b/apps/nextjs/src/app/stress-board/page.tsx
@@ -15,6 +15,7 @@ import {
   fmtEnd,
   parseApiResponse,
 } from "./quick-add-lib";
+import { StressBoardConsent } from "./stress-board-consent";
 
 /* ─────────────── types (shape of meeting_stress.json) ─────────────── */
 
@@ -379,6 +380,7 @@ export default function StressBoardPage() {
   return (
     <main className="min-h-screen bg-zinc-950 pb-24 font-mono text-sm text-zinc-200">
       <div className="mx-auto max-w-3xl px-4 pt-6">
+        <StressBoardConsent />
         <div className="mb-4 flex items-center justify-between">
           <div>
             <h1 className="text-lg font-bold text-zinc-100">

--- a/apps/nextjs/src/app/stress-board/stress-board-consent.test.tsx
+++ b/apps/nextjs/src/app/stress-board/stress-board-consent.test.tsx
@@ -3,7 +3,13 @@
  */
 // SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import { StressBoardConsent } from "./stress-board-consent";
 
@@ -35,9 +41,11 @@ describe("StressBoardConsent", () => {
 
   it("does not show once already acknowledged", async () => {
     localStorage.setItem(ACK_KEY, "1");
-    const { container } = render(<StressBoardConsent />);
-    // Give the effect a tick; the notice must never appear.
-    await waitFor(() => expect(container).toBeInTheDocument());
+    render(<StressBoardConsent />);
+    // Flush the effect that reads localStorage; the notice must never appear.
+    await act(async () => {
+      await Promise.resolve();
+    });
     expect(
       screen.queryByRole("button", { name: /i understand/i }),
     ).not.toBeInTheDocument();

--- a/apps/nextjs/src/app/stress-board/stress-board-consent.test.tsx
+++ b/apps/nextjs/src/app/stress-board/stress-board-consent.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { StressBoardConsent } from "./stress-board-consent";
+
+const ACK_KEY = "pulsecoach.stressBoard.thirdPartyConsent.v1";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("StressBoardConsent", () => {
+  it("shows the notice when not yet acknowledged", async () => {
+    render(<StressBoardConsent />);
+    expect(
+      await screen.findByRole("button", { name: /i understand/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("persists acknowledgement and hides on click", async () => {
+    render(<StressBoardConsent />);
+    const btn = await screen.findByRole("button", { name: /i understand/i });
+    fireEvent.click(btn);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /i understand/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(localStorage.getItem(ACK_KEY)).toBe("1");
+  });
+
+  it("does not show once already acknowledged", async () => {
+    localStorage.setItem(ACK_KEY, "1");
+    const { container } = render(<StressBoardConsent />);
+    // Give the effect a tick; the notice must never appear.
+    await waitFor(() => expect(container).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: /i understand/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/nextjs/src/app/stress-board/stress-board-consent.tsx
+++ b/apps/nextjs/src/app/stress-board/stress-board-consent.tsx
@@ -41,8 +41,7 @@ export function StressBoardConsent() {
 
   return (
     <div
-      role="dialog"
-      aria-modal="false"
+      role="region"
       aria-label="Third-party data notice"
       className="mb-4 rounded border border-yellow-700 bg-yellow-950/40 p-3 text-xs text-yellow-100"
     >

--- a/apps/nextjs/src/app/stress-board/stress-board-consent.tsx
+++ b/apps/nextjs/src/app/stress-board/stress-board-consent.tsx
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Anil Belur <askb23@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect, useState } from "react";
+
+const ACK_KEY = "pulsecoach.stressBoard.thirdPartyConsent.v1";
+
+/**
+ * First-run disclosure for the Stress Board.
+ *
+ * The board scores *other people* by their effect on your heart rate — that is
+ * personal data about non-consenting third parties (privacy §3). Before the
+ * user works with it we disclose what it involves and their responsibility, and
+ * require an explicit acknowledgement (persisted locally). Names are masked by
+ * default regardless; this is the informed-use gate the privacy policy promises.
+ */
+export function StressBoardConsent() {
+  // null = not yet read from storage (avoids an SSR/first-paint flash).
+  const [ack, setAck] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    try {
+      setAck(localStorage.getItem(ACK_KEY) === "1");
+    } catch {
+      // Storage unavailable (private mode / TWA edge) — show the notice.
+      setAck(false);
+    }
+  }, []);
+
+  if (ack === null || ack) return null;
+
+  const acknowledge = () => {
+    try {
+      localStorage.setItem(ACK_KEY, "1");
+    } catch {
+      /* best-effort; still dismiss for this session */
+    }
+    setAck(true);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="Third-party data notice"
+      className="mb-4 rounded border border-yellow-700 bg-yellow-950/40 p-3 text-xs text-yellow-100"
+    >
+      <p className="font-bold">Before you use the Stress Board</p>
+      <ul className="mt-1 list-disc space-y-1 pl-4 text-yellow-200/90">
+        <li>
+          This board involves data about <strong>other people</strong>{" "}
+          (coworkers, family) — how they affect <em>your</em> heart rate.
+        </li>
+        <li>
+          Names are <strong>masked by default</strong>. Real names stay on your
+          own instance and never appear in shared or exported views unless you
+          reveal them.
+        </li>
+        <li>
+          You are responsible for collecting and using other people&apos;s data
+          lawfully and respectfully.
+        </li>
+      </ul>
+      <button
+        onClick={acknowledge}
+        className="mt-2 rounded border border-yellow-600 px-3 py-1.5 font-bold text-yellow-100 hover:bg-yellow-900/50"
+      >
+        I understand
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the first-run third-party-data disclosure the privacy policy promises
(privacy §3). The Stress Board scores *other people* by their effect on your
heart rate; before working with it, the user now sees a one-time notice naming
the concern and their responsibility, and must acknowledge it.

- localStorage-gated (`pulsecoach.stressBoard.thirdPartyConsent.v1`), shown once.
- Client-side only, no backend — works in the self-hosted model.
- Names remain masked by default regardless; this is the informed-use gate.

## Verification
- 3 jest tests (shows when unacked, persists + hides on click, stays hidden once
  acked). typecheck + lint clean.